### PR TITLE
Adding input study descriptions as of 2025-12-9. These have 1 row per…

### DIFF
--- a/in/BIH_StudyDescriptions_Gen3.tsv
+++ b/in/BIH_StudyDescriptions_Gen3.tsv
@@ -1,5135 +1,5135 @@
-StudyDescription	Modality	project_id	platform	frequency
-XR Chest AP or PA	{'CR', 'PR', 'DX', 'XR', 'CT', 'MR', 'CR,DX', nan}	{'NIHCC-CXR8', 'TCIA-covid-19-ar', 'IDC-IDC_acrin_nsclc_fdg_pet', 'TCIA-cmb-lca', 'MIDRC-Open-R1', 'MIDRC-Open-A1_PETAL_BLUECORAL', 'IDC-IDC_cmb_crc', 'MIDRC-Open-A1_PETAL_REDCORAL', 'MIDRC-TCIA-COVID-19-AR', 'MIDRC-Open-A1_SCCM_VIRUS', 'TCIA-cmb-mml', 'TCIA-midrc-ricord-1c', 'MIDRC-TCIA-RICORD_1c', 'TCIA-cmb-crc', 'TCIA-cptac-ccrcc', 'IDC-IDC_midrc_ricord_1c', 'IDC-IDC_cmb_mml', 'IDC-IDC_cmb_lca', 'TCIA-pseudo-phi-dicom-data', 'IDC-IDC_cptac_ccrcc', 'MIDRC-Open-A1', 'TCIA-acrin-nsclc-fdg-pet', 'AIMI-CheXpertPlus', 'IDC-IDC_pseudo_phi_dicom_data', 'IDC-IDC_covid_19_ar'}	{'IDC', 'TCIA', 'AIMI', 'NIHCC', 'MIDRC'}	428198
-NLST-LSS	{'SR', 'CT', 'SEG'}	{'IDC-IDC_nlst'}	{'IDC'}	48544
-NLST-ACRIN	{'SR', 'CT', 'SEG'}	{'IDC-IDC_nlst'}	{'IDC'}	24569
-Histopathology	{'SR', 'ANN', 'SEG', 'SM'}	{'IDC-IDC_tcga_read', 'IDC-IDC_tcga_lusc', 'IDC-IDC_cptac_pda', 'IDC-IDC_tcga_thym', 'IDC-IDC_tcga_ov', 'IDC-IDC_cmb_mel', 'IDC-IDC_tcga_prad', 'IDC-IDC_tcga_gbm', 'IDC-IDC_cptac_coad', 'IDC-IDC_tcga_skcm', 'IDC-IDC_cptac_luad', 'IDC-IDC_tcga_dlbc', 'IDC-IDC_tcga_stad', 'IDC-IDC_tcga_blca', 'IDC-IDC_cptac_ucec', 'IDC-IDC_cptac_gbm', 'IDC-IDC_tcga_hnsc', 'IDC-IDC_tcga_meso', 'IDC-IDC_rms_mutation_prediction', 'IDC-IDC_tcga_paad', 'IDC-IDC_tcga_lgg', 'IDC-IDC_cmb_crc', 'IDC-IDC_icdc_glioma', 'IDC-IDC_tcga_esca', 'IDC-IDC_tcga_lihc', 'IDC-IDC_tcga_chol', 'IDC-IDC_cmb_brca', 'IDC-IDC_ccdi_mci', 'IDC-IDC_tcga_luad', 'IDC-IDC_tcga_cesc', 'IDC-IDC_tcga_kirc', 'IDC-IDC_cmb_aml', 'IDC-IDC_tcga_sarc', 'IDC-IDC_cmb_gec', 'IDC-IDC_tcga_pcpg', 'IDC-IDC_cptac_lscc', 'IDC-IDC_cptac_hnscc', 'IDC-IDC_nlst', 'IDC-IDC_tcga_kich', 'IDC-IDC_tcga_uvm', 'IDC-IDC_gtex', 'IDC-IDC_cmb_pca', 'IDC-IDC_tcga_kirp', 'IDC-IDC_cptac_sar', 'IDC-IDC_cmb_lca', 'IDC-IDC_cptac_aml', 'IDC-IDC_tcga_acc', 'IDC-IDC_tcga_coad', 'IDC-IDC_tcga_thca', 'IDC-IDC_cptac_cm', 'IDC-IDC_tcga_tgct', 'IDC-IDC_tcga_ucs', 'IDC-IDC_cptac_ccrcc', 'IDC-IDC_cptac_brca', 'IDC-IDC_cmb_ov', 'IDC-IDC_tcga_ucec', 'IDC-IDC_cmb_mml', 'IDC-IDC_tcga_brca', 'IDC-IDC_cptac_ov'}	{'IDC'}	17045
-CHEST AP PORT	{'CR', 'DX', nan}	{'MIDRC-TCIA-COVID-19-NY-SBU', 'IDC-IDC_covid_19_ny_sbu', 'TCIA-covid-19-ny-sbu'}	{'IDC', 'TCIA', 'MIDRC'}	12732
-CHEST PORT 1 VIEW (RAD)-CS	{'CR', 'CR,DX', 'DX'}	{'MIDRC-Open-A1'}	{'MIDRC'}	7341
-MAMMO screening digital bilateral	{'MG', nan}	{'TCIA-breast-cancer-screening-dbt', 'IDC-IDC_breast_cancer_screening_dbt'}	{'IDC', 'TCIA'}	6752
-CHEST AP VIEWONLY	{'CR', 'DX', nan}	{'MIDRC-TCIA-COVID-19-NY-SBU', 'IDC-IDC_covid_19_ny_sbu', 'TCIA-covid-19-ny-sbu'}	{'IDC', 'TCIA', 'MIDRC'}	5297
-3D Rendering	{'US', nan}	{'TCIA-prostate-mri-us-biopsy', 'IDC-IDC_prostate_mri_us_biopsy'}	{'IDC', 'TCIA'}	3416
-Simulated DBT Projection	{'MG'}	{'IDC-IDC_victre'}	{'IDC'}	2994
-Simulated Digital Mammography	{'MG'}	{'IDC-IDC_victre'}	{'IDC'}	2994
-DBT Reconstructed Volume	{'MG', nan}	{'IDC-IDC_pseudo_phi_dicom_data', 'TCIA-pseudo-phi-dicom-data', 'IDC-IDC_victre'}	{'IDC', 'TCIA'}	2765
-NCI PDMR Tumor Characterization	{'SR', 'MR', nan}	{'IDC-IDC_pdmr_997537_175_t', 'IDC-IDC_pdmr_833975_119_r', 'TCIA-pdmr-833975-119-r', 'TCIA-pdmr-292921-168-r', 'IDC-IDC_pdmr_521955_158_r4', 'TCIA-pdmr-425362-245-t', 'TCIA-pdmr-bl0293-f563', 'IDC-IDC_pdmr_texture_analysis', 'TCIA-pdmr-texture-analysis', 'IDC-IDC_pdmr_bl0293_f563', 'IDC-IDC_pdmr_292921_168_r', 'TCIA-pdmr-997537-175-t', 'TCIA-pdmr-521955-158-r4', 'IDC-IDC_pdmr_425362_245_t'}	{'IDC', 'TCIA'}	2554
-Chest	{'CR', 'DX', 'CT', nan}	{'MIDRC-Open-A1_PETAL_REDCORAL', 'IDC-IDC_acrin_nsclc_fdg_pet', 'MIDRC-Open-A1', 'TCIA-acrin-nsclc-fdg-pet', 'MIDRC-Open-R1', 'IDC-IDC_lung_pet_ct_dx', 'MIDRC-Open-A1_PETAL_BLUECORAL', 'TCIA-lung-pet-ct-dx'}	{'IDC', 'TCIA', 'MIDRC'}	2165
-BrainTumor	{'MR', 'SEG', nan}	{'IDC-IDC_upenn_gbm', 'TCIA-upenn-gbm'}	{'IDC', 'TCIA'}	2108
-MAMMO SCREENING DIGITAL BILATERAL	{'MG', nan}	{'TCIA-breast-cancer-screening-dbt', 'IDC-IDC_breast_cancer_screening_dbt'}	{'IDC', 'TCIA'}	1922
-BRAIN W/O CONTRAST (CT)-CS	{'CT'}	{'MIDRC-Open-A1'}	{'MIDRC'}	1640
-CHEST PA & LATERAL (RAD)-CS	{'CR', 'CR,DX', 'DX'}	{'MIDRC-Open-A1'}	{'MIDRC'}	1559
-CT CHEST WO CONTRAST	{'RTSTRUCT', 'CT', 'SEG', nan}	{'TCIA-cptac-pda', 'IDC-IDC_cptac_pda', 'IDC-IDC_tcga_kirc', 'TCIA-covid-19-ar', 'TCIA-tcga-luad', 'MIDRC-Open-A1_PETAL_REDCORAL', 'MIDRC-Open-A1', 'TCIA-tcga-kirc', 'TCIA-lidc-idri', 'IDC-IDC_lidc_idri', 'MIDRC-Open-R1', 'MIDRC-Open-A1_PETAL_BLUECORAL', 'MIDRC-TCIA-COVID-19-AR', 'IDC-IDC_tcga_luad', 'IDC-IDC_covid_19_ar'}	{'IDC', 'TCIA', 'MIDRC'}	1390
-CHEST 1 VIEW	{'CR', 'DX'}	{'MIDRC-Open-A1_SCCM_VIRUS', 'MIDRC-Open-A1_PETAL_BLUECORAL', 'MIDRC-Open-R1', 'MIDRC-Open-A1_PETAL_REDCORAL'}	{'MIDRC'}	1303
-MRI BREASTS - Delayed contrast	{'MR', 'SEG', nan}	{'TCIA-advanced-mri-breast-lesions', 'IDC-IDC_advanced_mri_breast_lesions'}	{'IDC', 'TCIA'}	1264
-Portable Chest	{'CR'}	{'MIDRC-Open-A1', 'MIDRC-Open-R1', 'MIDRC-Open-A1_PETAL_BLUECORAL'}	{'MIDRC'}	1239
-CT CHEST WITH CONTRAST	{'CT', 'SEG', nan}	{'IDC-IDC_midrc_ricord_1a', 'TCIA-midrc-ricord-1b', 'IDC-IDC_cptac_luad', 'TCIA-midrc-ricord-1a', 'TCIA-cptac-luad', 'MIDRC-TCIA-RICORD_1b', 'MIDRC-Open-A1_PETAL_REDCORAL', 'IDC-IDC_acrin_nsclc_fdg_pet', 'MIDRC-Open-A1', 'TCIA-qin-lung-ct', 'TCIA-acrin-nsclc-fdg-pet', 'MIDRC-Open-R1', 'MIDRC-Open-A1_PETAL_BLUECORAL', 'IDC-IDC_qin_lung_ct', 'MIDRC-Open-A1_SCCM_VIRUS', 'IDC-IDC_midrc_ricord_1b', 'MIDRC-TCIA-RICORD_1a'}	{'IDC', 'TCIA', 'MIDRC'}	1235
-CT CHEST W CONTRAST	{'CT', 'SEG', nan}	{'TCIA-anti-pd-1_lung', 'IDC-IDC_anti_pd_1_lung', 'TCIA-covid-19-ar', 'IDC-IDC_nsclc_radiogenomics', 'MIDRC-Open-A1_PETAL_REDCORAL', 'TCIA-nsclc-radiogenomics', 'MIDRC-Open-A1', 'IDC-IDC_acrin_nsclc_fdg_pet', 'TCIA-acrin-nsclc-fdg-pet', 'TCIA-cptac-ucec', 'MIDRC-Open-R1', 'IDC-IDC_tcga_ucec', 'MIDRC-Open-A1_PETAL_BLUECORAL', 'MIDRC-TCIA-COVID-19-AR', 'IDC-IDC_cptac_ucec', 'IDC-IDC_covid_19_ar', 'TCIA-tcga-ucec'}	{'IDC', 'TCIA', 'MIDRC'}	1216
-CT Coronary Angio with Contrast	{'CT'}	{'AIMI-COCA'}	{'AIMI'}	1207
-p4	{'CT', nan}	{'IDC-IDC_4d_lung', 'TCIA-4d-lung'}	{'IDC', 'TCIA'}	1174
-MR PROSTATE WO+W CONTRAST	{'SEG', nan}	{'TCIA-prostate-mri-us-biopsy', 'IDC-IDC_prostate_mri_us_biopsy'}	{'IDC', 'TCIA'}	1082
-CTA CHEST (PE STUDY) W CONTRAST	{'CT'}	{'MIDRC-Open-A1', 'MIDRC-Open-A1_PETAL_BLUECORAL', 'MIDRC-Open-A1_PETAL_REDCORAL'}	{'MIDRC'}	1018
-CT CHEST PULMONARY EMBOLISM (CTPE)	{'CT', nan}	{'IDC-IDC_midrc_ricord_1a', 'TCIA-midrc-ricord-1b', 'TCIA-midrc-ricord-1a', 'MIDRC-TCIA-RICORD_1b', 'MIDRC-Open-R1', 'IDC-IDC_midrc_ricord_1b', 'MIDRC-TCIA-RICORD_1a'}	{'IDC', 'TCIA', 'MIDRC'}	1011
-BRAIN^ROUTINE	{'MR', 'SEG', nan}	{'IDC-IDC_upenn_gbm', 'TCIA-upenn-gbm'}	{'IDC', 'TCIA'}	982
-MAMMO SCREEN BREAST TOMOSYNTHESIS BILATERAL	{'MG', nan}	{'TCIA-breast-cancer-screening-dbt', 'IDC-IDC_breast_cancer_screening_dbt'}	{'IDC', 'TCIA'}	970
-CT CHEST WITHOUT CONTRAST	{'CT', nan}	{'IDC-IDC_midrc_ricord_1a', 'TCIA-midrc-ricord-1b', 'IDC-IDC_cptac_luad', 'TCIA-midrc-ricord-1a', 'TCIA-cptac-luad', 'MIDRC-TCIA-RICORD_1b', 'MIDRC-Open-A1_PETAL_REDCORAL', 'MIDRC-Open-A1', 'MIDRC-Open-R1', 'MIDRC-Open-A1_PETAL_BLUECORAL', 'MIDRC-Open-A1_SCCM_VIRUS', 'IDC-IDC_midrc_ricord_1b', 'MIDRC-TCIA-RICORD_1a'}	{'IDC', 'TCIA', 'MIDRC'}	925
-MRI BREAST BILATERAL W/WO	{'MR', 'SEG', nan}	{'TCIA-duke-breast-cancer-mri', 'IDC-IDC_duke_breast_cancer_mri'}	{'IDC', 'TCIA'}	882
-MAMMO diagnostic digital bilateral	{'MG', nan}	{'TCIA-breast-cancer-screening-dbt', 'IDC-IDC_breast_cancer_screening_dbt'}	{'IDC', 'TCIA'}	872
-Standard Screening - TomoHD	{'MG', nan}	{'TCIA-breast-cancer-screening-dbt', 'ACRdart-EA1141Restricted', 'IDC-IDC_breast_cancer_screening_dbt', 'IDC-IDC_ea1141'}	{'IDC', 'TCIA', 'ACRdart'}	800
-ACRIN-6698_ISPY2_MRI_T0	{'MR', 'SEG', nan}	{'IDC-IDC_acrin_6698', 'TCIA-acrin-6698'}	{'IDC', 'TCIA'}	770
-CT	{'RTSTRUCT', 'CT', nan}	{'IDC-IDC_nsclc_radiomics_interobserver1', 'TCIA-pediatric-ct-seg', 'TCIA-cptac-ccrcc', 'IDC-IDC_cptac_ccrcc', 'TCIA-nsclc-radiomics-interobserver1', 'IDC-IDC_pediatric_ct_seg'}	{'IDC', 'TCIA'}	764
-MRI PROSTATE W WO CONTRAST	{'MR', 'SEG', nan}	{'TCIA-prostate-mri-us-biopsy', 'IDC-IDC_pseudo_phi_dicom_data', 'TCIA-pseudo-phi-dicom-data', 'IDC-IDC_prostate_mri_us_biopsy'}	{'IDC', 'TCIA'}	762
-CT CHEST ANGIOGRAM AND PULMONARY ARTERIES WITH IV CONTRAST	{'CT'}	{'MIDRC-Open-A1_SCCM_VIRUS'}	{'MIDRC'}	739
-CT HEAD WO CONTRAST	{'CT'}	{'MIDRC-Open-A1'}	{'MIDRC'}	717
-ISPY2_MRI_T0	{'MR', 'SEG'}	{'IDC-IDC_ispy2'}	{'IDC'}	717
-PET-CT STUDY	{'CT', 'PT', nan}	{'TCIA-acrin-flt-breast', 'IDC-IDC_pseudo_phi_dicom_data', 'IDC-IDC_acrin_flt_breast', 'TCIA-pseudo-phi-dicom-data'}	{'IDC', 'TCIA'}	716
-CHEST-SINGLE VIEW (RAD)-CS	{'CR', 'DX'}	{'MIDRC-Open-A1'}	{'MIDRC'}	707
-ISPY2_MRI_T1	{'MR', 'SEG'}	{'IDC-IDC_ispy2'}	{'IDC'}	690
-CHEST AP PORT CENTRAL LINE PL	{'CR', 'DX', nan}	{'MIDRC-TCIA-COVID-19-NY-SBU', 'IDC-IDC_covid_19_ny_sbu', 'TCIA-covid-19-ny-sbu'}	{'IDC', 'TCIA', 'MIDRC'}	654
-ISPY2_MRI_T2	{'MR', 'SEG'}	{'IDC-IDC_ispy2'}	{'IDC'}	647
-ISPY2_MRI_T3	{'MR', 'SEG'}	{'IDC-IDC_ispy2'}	{'IDC'}	634
-BRAIN^SPECTROSCOPY	{'MR', 'SEG', nan}	{'IDC-IDC_upenn_gbm', 'TCIA-upenn-gbm'}	{'IDC', 'TCIA'}	598
-Chest 2V	{'CR'}	{'MIDRC-Open-A1', 'MIDRC-Open-A1_SCCM_VIRUS'}	{'MIDRC'}	593
-CT CHEST WO IV CONT	{'CT', nan}	{'MIDRC-TCIA-COVID-19-NY-SBU', 'IDC-IDC_covid_19_ny_sbu', 'TCIA-covid-19-ny-sbu'}	{'IDC', 'TCIA', 'MIDRC'}	554
-CT CHEST WO	{'CT'}	{'MIDRC-Open-A1', 'MIDRC-Open-R1'}	{'MIDRC'}	527
-ACRIN-6698_ISPY2_MRI_T1	{'MR', 'SEG', nan}	{'IDC-IDC_acrin_6698', 'TCIA-acrin-6698'}	{'IDC', 'TCIA'}	516
-CHEST W/O CONTRAST (CT)-CS	{'CT'}	{'MIDRC-Open-A1'}	{'MIDRC'}	513
-Chest Portable	{'CR', 'DX'}	{'MIDRC-Open-A1_PETAL_BLUECORAL', 'MIDRC-Open-A1_PETAL_REDCORAL'}	{'MIDRC'}	494
-X-RAY CHEST SINGLE VIEW	{'CR', 'DX'}	{'MIDRC-Open-A1', 'MIDRC-Open-R1'}	{'MIDRC'}	486
-ACRIN-6698_ISPY2_MRI_T2	{'MR', 'SEG', nan}	{'IDC-IDC_acrin_6698', 'TCIA-acrin-6698'}	{'IDC', 'TCIA'}	486
-Thorax^CTD_01_TH_ROUTINE_NEU (Adult)	{'CT', 'SEG', nan}	{'IDC-IDC_ct_phantom4radiomics', 'TCIA-ct-phantom4radiomics'}	{'IDC', 'TCIA'}	476
-BRAIN^BRAIN	{'MR', 'SEG', nan}	{'MIDRC-Open-A1', 'IDC-IDC_upenn_gbm', 'TCIA-upenn-gbm'}	{'IDC', 'TCIA', 'MIDRC'}	475
-ACRIN-6698_ISPY2_MRI_T3	{'MR', 'SEG', nan}	{'IDC-IDC_acrin_6698', 'TCIA-acrin-6698'}	{'IDC', 'TCIA'}	474
-CHEST AP PORTABLE	{'CR', nan}	{'MIDRC-TCIA-COVID-19-NY-SBU', 'IDC-IDC_covid_19_ny_sbu', 'TCIA-covid-19-ny-sbu'}	{'IDC', 'TCIA', 'MIDRC'}	465
-FLAT PLATE OF ABDOMEN PORTABLE	{'CR', 'DX', nan}	{'MIDRC-TCIA-COVID-19-NY-SBU', 'IDC-IDC_covid_19_ny_sbu', 'TCIA-covid-19-ny-sbu'}	{'IDC', 'TCIA', 'MIDRC'}	461
-BRAIN^BRAIN TUMOR	{'MR', 'SEG', nan}	{'IDC-IDC_upenn_gbm', 'TCIA-upenn-gbm'}	{'IDC', 'TCIA'}	456
-XR ABDOMEN 1 VIEW	{'CR', 'DX'}	{'MIDRC-Open-A1', 'MIDRC-Open-A1_PETAL_REDCORAL'}	{'MIDRC'}	446
-Vascular^PE_STUDY (Adult)	{'CT'}	{'MIDRC-Open-A1'}	{'MIDRC'}	432
-CT CHEST ABDOMEN PELVIS W CONTRAST (ROUTINE)	{'CT'}	{'MIDRC-Open-A1', 'MIDRC-Open-A1_PETAL_BLUECORAL'}	{'MIDRC'}	406
-CT CORONARY ANGIOGRAPHY W AND WO IV CONTRAST	{'CT'}	{'AIMI-COCA'}	{'AIMI'}	398
-MRI BREAST BILATERAL W + W/O	{'MR', 'SEG', nan}	{'TCIA-duke-breast-cancer-mri', 'IDC-IDC_duke_breast_cancer_mri'}	{'IDC', 'TCIA'}	384
-BREAST PRONE	{'MR', 'SEG', nan}	{'IDC-IDC_qin_breast', 'TCIA-qin-breast'}	{'IDC', 'TCIA'}	382
-CT CHEST PULMONARY ANGIO WITH IV CON	{'CT', nan}	{'MIDRC-TCIA-COVID-19-NY-SBU', 'IDC-IDC_covid_19_ny_sbu', 'TCIA-covid-19-ny-sbu'}	{'IDC', 'TCIA', 'MIDRC'}	366
-Head^HEAD (Adult)	{'CT'}	{'MIDRC-Open-A1'}	{'MIDRC'}	358
-CT ABD AND PELVIS WITH IV CONT	{'CT', nan}	{'MIDRC-TCIA-COVID-19-NY-SBU', 'IDC-IDC_covid_19_ny_sbu', 'TCIA-covid-19-ny-sbu'}	{'IDC', 'TCIA', 'MIDRC'}	358
-MR HEAD W AND WO IV CONTRAST	{'MR', 'SEG', nan}	{'IDC-IDC_upenn_gbm', 'TCIA-upenn-gbm'}	{'IDC', 'TCIA'}	350
-MR prostaat kanker detectie WDS_mc MCAPRODETW	{'MR', 'SEG', nan}	{'TCIA-prostatex', 'IDC-IDC_prostate_3t', 'TCIA-prostate-3t', 'IDC-IDC_prostatex'}	{'IDC', 'TCIA'}	346
-CT CHEST ABDOMEN PELVIS W	{'CT', nan}	{'TCIA-covid-19-ar', 'MIDRC-Open-A1', 'MIDRC-Open-R1', 'MIDRC-TCIA-COVID-19-AR', 'IDC-IDC_tcga_blca', 'IDC-IDC_covid_19_ar', 'TCIA-tcga-blca'}	{'IDC', 'TCIA', 'MIDRC'}	345
-MR HEAD W AND WO IV CONTRAST TUMOR NEW	{'MR', 'SEG', nan}	{'IDC-IDC_upenn_gbm', 'TCIA-upenn-gbm'}	{'IDC', 'TCIA'}	342
-Chest Single View Adult Portable	{'CR', 'DX'}	{'MIDRC-Open-A1_PETAL_BLUECORAL', 'MIDRC-Open-A1_PETAL_REDCORAL'}	{'MIDRC'}	314
-Avanto RoutineImage Guidance	{'RTDOSE', 'RTSTRUCT', 'RTPLAN', 'MR', nan}	{'TCIA-vestibular-schwannoma-seg', 'IDC-IDC_vestibular_schwannoma_seg'}	{'IDC', 'TCIA'}	304
-MR BREAS, UNIT	{'MR', 'SEG', nan}	{'TCIA-breast-mri-nact-pilot', 'IDC-IDC_ispy1', 'IDC-IDC_breast_mri_nact_pilot'}	{'IDC', 'TCIA'}	289
-CT CHEST PULMONARY EMBOLISM W CONTRAST	{'CT', 'SEG', nan}	{'TCIA-anti-pd-1_lung', 'IDC-IDC_anti_pd_1_lung', 'MIDRC-Open-A1_PETAL_REDCORAL', 'MIDRC-Open-R1', 'MIDRC-Open-A1_PETAL_BLUECORAL', 'MIDRC-Open-A1_SCCM_VIRUS'}	{'IDC', 'TCIA', 'MIDRC'}	284
-Breast^Screen	{'MR'}	{'ACRdart-EA1141Restricted', 'IDC-IDC_ea1141'}	{'ACRdart', 'IDC'}	279
-CT ABDOMEN PELVIS W CONTRAST (ROUTINE)	{'CT'}	{'MIDRC-Open-A1'}	{'MIDRC'}	278
-MR BREASTUNI UE	{'MR', 'SEG', nan}	{'TCIA-acrin-contralateral-breast-mr', 'TCIA-breast-mri-nact-pilot', 'IDC-IDC_acrin_contralateral_breast_mr', 'IDC-IDC_ispy1', 'IDC-IDC_breast_mri_nact_pilot'}	{'IDC', 'TCIA'}	273
-CT ABD AND PELVIS WO IV CONT	{'CT', nan}	{'MIDRC-TCIA-COVID-19-NY-SBU', 'IDC-IDC_covid_19_ny_sbu', 'TCIA-covid-19-ny-sbu'}	{'IDC', 'TCIA', 'MIDRC'}	271
-CT LUNG SCREEN	{'CT', 'SEG', nan}	{'TCIA-lidc-idri', 'IDC-IDC_lidc_idri'}	{'IDC', 'TCIA'}	270
-Preinvasive mammary neoplasia	{'MR', nan}	{'IDC-IDC_mouse_mammary', 'TCIA-mouse-mammary'}	{'IDC', 'TCIA'}	264
-RX SIMULATION	{'RTSTRUCT', 'CT', nan}	{'IDC-IDC_prostate_anatomical_edge_cases', 'TCIA-prostate-anatomical-edge-cases'}	{'IDC', 'TCIA'}	262
-CT CHEST W	{'CT', 'SEG', nan}	{'IDC-IDC_nsclc_radiogenomics', 'TCIA-nsclc-radiogenomics', 'IDC-IDC_acrin_nsclc_fdg_pet', 'MIDRC-Open-A1', 'TCIA-varepop-apollo', 'TCIA-acrin-nsclc-fdg-pet', 'MIDRC-Open-R1', 'IDC-IDC_tcga_ucec', 'TCIA-tcga-ucec'}	{'IDC', 'TCIA', 'MIDRC'}	259
-CHEST, PA & LATERAL	{'DX', nan}	{'IDC-IDC_acrin_nsclc_fdg_pet', 'TCIA-rider-pilot', 'TCIA-lidc-idri', 'TCIA-acrin-nsclc-fdg-pet', 'IDC-IDC_lidc_idri', 'TCIA-tcga-blca', 'IDC-IDC_tcga_blca', 'IDC-IDC_rider_pilot'}	{'IDC', 'TCIA'}	256
-CT_CAP	{'CT', nan}	{'TCIA-cmb-crc', 'IDC-IDC_cmb_gec', 'TCIA-cmb-mml', 'IDC-IDC_cmb_crc', 'IDC-IDC_cmb_mel', 'TCIA-cmb-brca', 'TCIA-cmb-mel', 'TCIA-cmb-lca', 'IDC-IDC_cmb_pca', 'IDC-IDC_cmb_mml', 'TCIA-cmb-gec', 'IDC-IDC_cmb_lca', 'TCIA-cmb-pca'}	{'IDC', 'TCIA'}	254
-MRI BREAST ABBREVIATED - RESEARCH	{'MR'}	{'ACRdart-EA1141Restricted', 'IDC-IDC_ea1141'}	{'ACRdart', 'IDC'}	254
-MR prostaat kanker detectie_mc MCAPRODET	{'MR', 'SEG', nan}	{'TCIA-prostatex', 'IDC-IDC_prostate_3t', 'TCIA-prostate-3t', 'IDC-IDC_prostatex'}	{'IDC', 'TCIA'}	254
-MAM MAMMOGRAPHY SCREENING WITH TOMOSYNTHESIS	{'MG'}	{'ACRdart-EA1141Restricted', 'IDC-IDC_ea1141'}	{'ACRdart', 'IDC'}	251
-Thorax^CT_PE (Adult)	{'CT'}	{'MIDRC-Open-A1'}	{'MIDRC'}	242
-Breast	{'US'}	{'ACRdart-ACRIN_6666'}	{'ACRdart'}	241
-MRI BREAST BILAT WO/W CONTRAST	{'MR'}	{'ACRdart-EA1141Restricted', 'IDC-IDC_ea1141'}	{'ACRdart', 'IDC'}	239
-CHEST PORTABLE AP	{'CR', 'DX'}	{'MIDRC-Open-A1_PETAL_BLUECORAL', 'MIDRC-Open-A1_PETAL_REDCORAL'}	{'MIDRC'}	238
-CT THORAX W/CONTRAST	{'CT', 'SEG', nan}	{'IDC-IDC_hcc_tace_seg', 'IDC-IDC_adrenal_acc_ki67_seg', 'IDC-IDC_tcga_ov', 'TCIA-hcc-tace-seg', 'IDC-IDC_acrin_nsclc_fdg_pet', 'TCIA-rider-pilot', 'TCIA-tcga-kirc', 'TCIA-tcga-ov', 'TCIA-lidc-idri', 'IDC-IDC_lidc_idri', 'TCIA-acrin-nsclc-fdg-pet', 'IDC-IDC_rider_pilot', 'TCIA-adrenal-acc-ki67-seg', 'IDC-IDC_tcga_blca', 'IDC-IDC_tcga_kirc', 'TCIA-tcga-blca'}	{'IDC', 'TCIA'}	236
-CT CHEST HIGH RESOLUTION	{'CT', nan}	{'TCIA-midrc-ricord-1b', 'MIDRC-TCIA-RICORD_1b', 'MIDRC-Open-A1', 'MIDRC-Open-R1', 'IDC-IDC_midrc_ricord_1b'}	{'IDC', 'TCIA', 'MIDRC'}	232
-CHEST 1V	{'CR', nan}	{'MIDRC-TCIA-RICORD_1c', 'IDC-IDC_midrc_ricord_1c', 'TCIA-midrc-ricord-1c', 'MIDRC-Open-A1_PETAL_REDCORAL'}	{'IDC', 'TCIA', 'MIDRC'}	229
-Pelvic Cavity CT Routine+Enhanced	{'CT', nan}	{'IDC-IDC_stageii_colorectal_ct', 'TCIA-stageii-colorectal-ct'}	{'IDC', 'TCIA'}	210
-CT CHEST PULMONARY EMB	{'CT'}	{'MIDRC-Open-R1'}	{'MIDRC'}	209
-CT CHEST WITHOUT IV CONTRAST	{'CT', nan}	{'MIDRC-TCIA-COVID-19-NY-SBU', 'MIDRC-Open-A1_SCCM_VIRUS', 'TCIA-covid-19-ny-sbu', 'IDC-IDC_covid_19_ny_sbu'}	{'IDC', 'TCIA', 'MIDRC'}	209
-CHEST 2 VIEWS	{'CR', 'DX'}	{'MIDRC-Open-A1_SCCM_VIRUS', 'MIDRC-Open-A1_PETAL_BLUECORAL', 'MIDRC-Open-R1', 'MIDRC-Open-A1_PETAL_REDCORAL'}	{'MIDRC'}	209
-X-RAY CHEST FRONTAL AND LATERAL	{'CR', 'DX'}	{'MIDRC-Open-A1'}	{'MIDRC'}	203
-MRI BREAST BILATERAL W WO CONTRAST	{'MR'}	{'ACRdart-EA1141Restricted', 'IDC-IDC_ea1141'}	{'ACRdart', 'IDC'}	202
-Abdomen^24ACRIN_Colo_IRB2415-04 (Adult)	{'CT', nan}	{'TCIA-ct-colonography', 'IDC-IDC_ct_colonography'}	{'IDC', 'TCIA'}	202
-CHEST AP VIEW ONLY	{'CR', nan}	{'MIDRC-TCIA-COVID-19-NY-SBU', 'IDC-IDC_covid_19_ny_sbu', 'TCIA-covid-19-ny-sbu'}	{'IDC', 'TCIA', 'MIDRC'}	199
-MRI BRAIN W/INJ/MHDI	{'MR', 'SEG', nan}	{'IDC-IDC_upenn_gbm', 'TCIA-upenn-gbm'}	{'IDC', 'TCIA'}	198
-CR DIAG-PORTABLE CHEST	{'CR'}	{'MIDRC-Open-A1_PETAL_BLUECORAL', 'MIDRC-Open-A1_PETAL_REDCORAL'}	{'MIDRC'}	195
-Abdomen CT Routine+Enhanced	{'CT', nan}	{'IDC-IDC_stageii_colorectal_ct', 'TCIA-stageii-colorectal-ct'}	{'IDC', 'TCIA'}	194
-CT CHEST ABDOMEN PELVIS W CONTRAST	{'CT', 'SEG', nan}	{'TCIA-anti-pd-1_lung', 'IDC-IDC_anti_pd_1_lung', 'MIDRC-Open-R1', 'MIDRC-Open-A1_PETAL_BLUECORAL', 'MIDRC-Open-A1_SCCM_VIRUS'}	{'IDC', 'TCIA', 'MIDRC'}	189
-Thorax^CHEST_WO (Adult)	{'CT', nan}	{'MIDRC-Open-A1_PETAL_REDCORAL', 'IDC-IDC_acrin_nsclc_fdg_pet', 'MIDRC-Open-A1', 'TCIA-acrin-nsclc-fdg-pet', 'TCIA-varepop-apollo'}	{'IDC', 'TCIA', 'MIDRC'}	188
-MAMMO 3D SCREEN BILAT	{'MG'}	{'ACRdart-EA1141Restricted', 'IDC-IDC_ea1141'}	{'ACRdart', 'IDC'}	188
-CHEST	{'CR', 'DX', 'CT', 'SEG', nan}	{'IDC-IDC_tcga_lusc', 'TCIA-lung-pet-ct-dx', 'TCIA-tcga-luad', 'MIDRC-Open-A1_PETAL_REDCORAL', 'IDC-IDC_acrin_nsclc_fdg_pet', 'MIDRC-Open-A1', 'TCIA-tcga-lusc', 'TCIA-lidc-idri', 'TCIA-acrin-nsclc-fdg-pet', 'IDC-IDC_lidc_idri', 'MIDRC-Open-R1', 'IDC-IDC_lung_pet_ct_dx', 'IDC-IDC_tcga_blca', 'IDC-IDC_tcga_luad', 'TCIA-tcga-blca'}	{'IDC', 'TCIA', 'MIDRC'}	188
-MR BREAST RESEARCH EXAM	{'MR'}	{'ACRdart-EA1141Restricted', 'IDC-IDC_ea1141'}	{'ACRdart', 'IDC'}	187
-Thorax^PE (Adult)	{'CT'}	{'MIDRC-Open-A1', 'MIDRC-Open-A1_PETAL_BLUECORAL'}	{'MIDRC'}	186
-CT CAP	{'RTSTRUCT', 'CT', 'SEG', nan}	{'IDC-IDC_tcga_ov', 'IDC-IDC_cmb_mel', 'TCIA-hcc-tace-seg', 'TCIA-cmb-mel', 'TCIA-tcga-ov', 'TCIA-cmb-lca', 'IDC-IDC_lidc_idri', 'IDC-IDC_tcga_blca', 'IDC-IDC_cptac_ucec', 'IDC-IDC_cmb_crc', 'TCIA-cptac-ucec', 'IDC-IDC_tcga_kirc', 'TCIA-tcga-blca', 'IDC-IDC_hcc_tace_seg', 'TCIA-cmb-crc', 'IDC-IDC_cmb_gec', 'TCIA-lidc-idri', 'IDC-IDC_cmb_pca', 'TCIA-cmb-gec', 'IDC-IDC_cmb_lca', 'IDC-IDC_rider_pilot', 'TCIA-rider-pilot', 'TCIA-tcga-kirc', 'TCIA-cmb-pca'}	{'IDC', 'TCIA'}	182
-mediastinal_lymph_nodes	{'SEG', nan}	{'IDC-IDC_ct_lymph_nodes', 'TCIA-ct-lymph-nodes'}	{'IDC', 'TCIA'}	180
-CT THORAX	{'CT', 'SEG', nan}	{'AIMI-COCA', 'IDC-IDC_nsclc_radiogenomics', 'TCIA-nsclc-radiogenomics'}	{'IDC', 'TCIA', 'AIMI'}	179
-CHEST W/CONTRAST (CT)-CS	{'CT'}	{'MIDRC-Open-A1'}	{'MIDRC'}	179
-abdominal_lymph_nodes	{'SEG', nan}	{'IDC-IDC_ct_lymph_nodes', 'TCIA-ct-lymph-nodes'}	{'IDC', 'TCIA'}	172
-Avanto RoutineHead	{'RTDOSE', 'RTSTRUCT', 'RTPLAN', 'MR', nan}	{'TCIA-vestibular-schwannoma-seg', 'IDC-IDC_vestibular_schwannoma_seg'}	{'IDC', 'TCIA'}	168
-MRI PROSTATE WITH AND WITHOUT CONTRAST	{'MR', nan}	{'IDC-IDC_prostate_diagnosis', 'TCIA-prostate-diagnosis'}	{'IDC', 'TCIA'}	168
-MAMMO SCREENING DIGITAL BIALTERAL	{'MG', nan}	{'TCIA-breast-cancer-screening-dbt', 'IDC-IDC_breast_cancer_screening_dbt'}	{'IDC', 'TCIA'}	164
-CT CHEST ABDOMEN PELVIS WO CONTRAST (ROUTINE)	{'CT'}	{'MIDRC-Open-A1'}	{'MIDRC'}	163
-MRI BREAST BI W/WO CONTRAST	{'MR'}	{'ACRdart-EA1141Restricted', 'IDC-IDC_ea1141'}	{'ACRdart', 'IDC'}	162
-CT CHEST ABDOMEN PELVI	{'RTSTRUCT', 'CT', 'SEG', nan}	{'TCIA-anti-pd-1_lung', 'IDC-IDC_anti_pd_1_lung', 'MIDRC-Open-A1', 'MIDRC-Open-R1', 'TCIA-cptac-ucec', 'IDC-IDC_tcga_ucec', 'IDC-IDC_cptac_ucec', 'TCIA-tcga-ucec'}	{'IDC', 'TCIA', 'MIDRC'}	162
-CT CH/ABD/PEL W/ CONTRAST	{'CT', 'SEG', nan}	{'IDC-IDC_tcga_ov', 'TCIA-colorectal-liver-metastases', 'TCIA-tcga-kirc', 'TCIA-tcga-ov', 'IDC-IDC_colorectal_liver_metastases', 'IDC-IDC_tcga_kirc'}	{'IDC', 'TCIA'}	160
-Pancreas	{'SEG', nan}	{'TCIA-pancreas-ct', 'IDC-IDC_pancreas_ct'}	{'IDC', 'TCIA'}	160
-MC prostaat kliniek detectie-mc MCPROSKL30	{'MR', 'SEG', nan}	{'TCIA-prostatex', 'IDC-IDC_prostate_3t', 'TCIA-prostate-3t', 'IDC-IDC_prostatex'}	{'IDC', 'TCIA'}	158
-MAMMO SCREENING BREAST TOMOSYNTHESIS	{'MG', nan}	{'TCIA-breast-cancer-screening-dbt', 'IDC-IDC_breast_cancer_screening_dbt'}	{'IDC', 'TCIA'}	156
-BRST BILAT SCREENING MAMMO W/ TOMO	{'MG'}	{'ACRdart-EA1141Restricted', 'IDC-IDC_ea1141'}	{'ACRdart', 'IDC'}	155
-MAMMO TOMOGRAPHY SCREENING BILATERAL	{'MG'}	{'ACRdart-EA1141Restricted', 'IDC-IDC_ea1141'}	{'ACRdart', 'IDC'}	150
-HUP5 PROTOCOLS^BREAST	{'MR', 'SEG', nan}	{'IDC-IDC_acrin_contralateral_breast_mr', 'IDC-IDC_ispy1', 'TCIA-acrin-contralateral-breast-mr'}	{'IDC', 'TCIA'}	144
-Abdomen^ACRIN_COLON_USE (Adult)	{'CT', nan}	{'TCIA-ct-colonography', 'IDC-IDC_ct_colonography'}	{'IDC', 'TCIA'}	142
-MRI BREAST UNI 1ST EXA	{'MR', nan}	{'IDC-IDC_acrin_contralateral_breast_mr', 'TCIA-acrin-contralateral-breast-mr'}	{'IDC', 'TCIA'}	142
-Head^DE_HEAD_WITHOUT_Customized (Adult)	{'CT'}	{'MIDRC-Open-A1'}	{'MIDRC'}	141
-MR HEAD W AND WO IV CONTRAST TUMOR HIGH GRADE	{'MR', 'SEG', nan}	{'IDC-IDC_upenn_gbm', 'TCIA-upenn-gbm'}	{'IDC', 'TCIA'}	140
-CT CHEST ABDOMEN PELVIS W CONTRAST (TRAUMA)	{'CT'}	{'MIDRC-Open-A1'}	{'MIDRC'}	140
-MRI BREAST SCREENING AB BILATERAL WITH AND WITHOUT CONTRAST	{'MR'}	{'ACRdart-EA1141Restricted', 'IDC-IDC_ea1141'}	{'ACRdart', 'IDC'}	140
-MAMMOGRAM SCREENING BILATERAL W/TOMOSYNTHESIS	{'MG'}	{'ACRdart-EA1141Restricted', 'IDC-IDC_ea1141'}	{'ACRdart', 'IDC'}	138
-Abdomen^ABD_PEL_WITH (Adult)	{'RTSTRUCT', 'CT', nan}	{'MIDRC-Open-A1', 'TCIA-tcga-kirc', 'TCIA-cptac-ucec', 'IDC-IDC_tcga_blca', 'IDC-IDC_cptac_ucec', 'IDC-IDC_tcga_kirc', 'TCIA-tcga-blca'}	{'IDC', 'TCIA', 'MIDRC'}	138
-CTA PE CHEST W	{'CT'}	{'MIDRC-Open-A1', 'MIDRC-Open-R1'}	{'MIDRC'}	137
-MAMMO SCREENING TOMOSYNTHESIS - BILATERAL	{'MG'}	{'ACRdart-EA1141Restricted', 'IDC-IDC_ea1141'}	{'ACRdart', 'IDC'}	137
-MRM	{'MR', nan}	{'IDC-IDC_acrin_contralateral_breast_mr', 'TCIA-acrin-contralateral-breast-mr'}	{'IDC', 'TCIA'}	136
-CHEST INSPIR/EXPIR (RAD)-CS	{'CR', 'DX'}	{'MIDRC-Open-A1'}	{'MIDRC'}	135
-MRM 6667	{'MR', nan}	{'IDC-IDC_acrin_contralateral_breast_mr', 'TCIA-acrin-contralateral-breast-mr'}	{'IDC', 'TCIA'}	134
-MAMMO TOMOSYNTHESIS SCREENING WITH 2D MAMMOGRAM BILATERAL	{'MG'}	{'ACRdart-EA1141Restricted', 'IDC-IDC_ea1141'}	{'ACRdart', 'IDC'}	133
-3-D Tomo Mammogram	{'MG'}	{'ACRdart-EA1141Restricted', 'IDC-IDC_ea1141'}	{'ACRdart', 'IDC'}	133
-MRI Breast Bilateral with and without Contrast	{'MR', nan}	{'TCIA-breast-diagnosis', 'IDC-IDC_breast_diagnosis'}	{'IDC', 'TCIA'}	132
-Thorax^CHEST_WITHOUT (Adult)	{'CT'}	{'MIDRC-Open-A1'}	{'MIDRC'}	127
-MR BREAST BIL SCREENING WO W CONTRAST	{'MR'}	{'ACRdart-EA1141Restricted', 'IDC-IDC_ea1141'}	{'ACRdart', 'IDC'}	125
-BREAST^AB-MRI STUDY	{'MR'}	{'ACRdart-EA1141Restricted', 'IDC-IDC_ea1141'}	{'ACRdart', 'IDC'}	124
-MR HEAD W AND WO IV CONTRAST TUMOR FOLLOWUP WITH PERFUSION PERME	{'MR', 'SEG', nan}	{'IDC-IDC_upenn_gbm', 'TCIA-upenn-gbm'}	{'IDC', 'TCIA'}	124
-Diagnostic Pre-Surgery Contrast Enhanced CT	{'CT', nan}	{'IDC-IDC_lungct_diagnosis', 'TCIA-lungct-diagnosis'}	{'IDC', 'TCIA'}	122
-MAMMOGRAM/ULTRASOUND EXAM	{'US'}	{'ACRdart-ACRIN_6666'}	{'ACRdart'}	120
-breast^standard	{'MR', nan}	{'IDC-IDC_acrin_contralateral_breast_mr', 'TCIA-acrin-contralateral-breast-mr'}	{'IDC', 'TCIA'}	120
-CT ABDOMEN w & PELVIS w	{'CT', 'SEG', nan}	{'IDC-IDC_tcga_ov', 'TCIA-tcga-lihc', 'TCIA-tcga-kirc', 'TCIA-tcga-ov', 'IDC-IDC_tcga_lihc', 'IDC-IDC_tcga_ucec', 'IDC-IDC_tcga_kirc', 'TCIA-tcga-ucec'}	{'IDC', 'TCIA'}	120
-CHEST 1 VIEW PA/AP PORTABLE	{'CR'}	{'MIDRC-Open-A1_PETAL_BLUECORAL'}	{'MIDRC'}	119
-Head^ROUTINE_DE_HEAD (Adult)	{'CT'}	{'MIDRC-Open-A1'}	{'MIDRC'}	119
-BREAST^ROUTINE DYNAMICS	{'MR', 'SEG', nan}	{'TCIA-duke-breast-cancer-mri', 'IDC-IDC_duke_breast_cancer_mri'}	{'IDC', 'TCIA'}	118
-Abdomen^02_0_AP_Routine (Adult)	{'CT', nan}	{'IDC-IDC_tcga_ov', 'TCIA-tcga-lihc', 'TCIA-tcga-kirc', 'TCIA-tcga-ov', 'IDC-IDC_tcga_lihc', 'IDC-IDC_tcga_ucec', 'IDC-IDC_tcga_kirc', 'TCIA-tcga-ucec'}	{'IDC', 'TCIA'}	118
-MR BREAST BILAT W OR WO	{'MR', nan}	{'IDC-IDC_acrin_contralateral_breast_mr', 'TCIA-acrin-contralateral-breast-mr'}	{'IDC', 'TCIA'}	118
-MAMMO DIAGNOSTIC DIGITAL BILATERAL	{'MG', nan}	{'TCIA-breast-cancer-screening-dbt', 'IDC-IDC_breast_cancer_screening_dbt'}	{'IDC', 'TCIA'}	116
-Thorax^FLASH_CHEST_WO (Adult)	{'CT'}	{'MIDRC-Open-A1'}	{'MIDRC'}	115
-Preop	{'MR', 'SEG'}	{'IDC-IDC_remind'}	{'IDC'}	114
-Intraop	{'US', 'MR', 'SEG'}	{'IDC-IDC_remind'}	{'IDC'}	114
-Radiomics Phantom	{nan}	{'TCIA-cc-radiomics-phantom-3'}	{'TCIA'}	113
-BRAIN W/O STROKE PROTOCOL-CS	{'CT'}	{'MIDRC-Open-A1'}	{'MIDRC'}	112
-MRI CLINICAL SPECTROSCOPY	{'MR', 'SEG', nan}	{'IDC-IDC_upenn_gbm', 'TCIA-upenn-gbm'}	{'IDC', 'TCIA'}	112
-Thorax^DE_CHEST_PE_Customized (Adult)	{'CT'}	{'MIDRC-Open-A1', 'MIDRC-Open-A1_PETAL_BLUECORAL'}	{'MIDRC'}	110
-BREAST  W/O followed by W CONTRAST, BILATERAL	{'MR', 'SEG', nan}	{'IDC-IDC_acrin_contralateral_breast_mr', 'IDC-IDC_ispy1', 'TCIA-acrin-contralateral-breast-mr'}	{'IDC', 'TCIA'}	109
-FDG 5AFOV TORSO	{'CT', 'SEG', 'PT', nan}	{'IDC-IDC_rider_lung_pet_ct', 'TCIA-rider-lung-pet-ct'}	{'IDC', 'TCIA'}	109
-CT INFUSED CHEST	{'SEG', nan}	{'IDC-IDC_spie_aapm_lung_ct_challenge', 'TCIA-spie-aapm-lung-ct-challenge'}	{'IDC', 'TCIA'}	108
-Unspecified CT	{'CT', nan}	{'TCIA-cc-radiomics-phantom-2', 'IDC-IDC_rider_lung_pet_ct', 'TCIA-rider-lung-pet-ct'}	{'IDC', 'TCIA'}	108
-CT ANGIO CHEST W	{'CT'}	{'MIDRC-Open-A1', 'MIDRC-Open-R1'}	{'MIDRC'}	108
-CHEST PORTABLE	{'CR', 'DX'}	{'MIDRC-Open-A1_PETAL_BLUECORAL', 'MIDRC-Open-A1_PETAL_REDCORAL'}	{'MIDRC'}	108
-Head^CT_HEAD_WO (Adult)	{'CT'}	{'MIDRC-Open-A1'}	{'MIDRC'}	107
-CTA CHEST-CS	{'CT'}	{'MIDRC-Open-A1'}	{'MIDRC'}	107
-MR BREASTS ABBREV WO W	{'MR'}	{'ACRdart-EA1141Restricted', 'IDC-IDC_ea1141'}	{'ACRdart', 'IDC'}	105
-DIG SCR TOMO MAM BIL	{'MG'}	{'ACRdart-EA1141Restricted', 'IDC-IDC_ea1141'}	{'ACRdart', 'IDC'}	105
-CT ANGIO ABD WITH CH AND PEL	{'SEG', nan}	{'TCIA-colorectal-liver-metastases', 'IDC-IDC_colorectal_liver_metastases'}	{'IDC', 'TCIA'}	104
-BREAST^ROUTINE	{'MR', 'SEG', nan}	{'ACRdart-EA1141Restricted', 'IDC-IDC_duke_breast_cancer_mri', 'IDC-IDC_ea1141', 'TCIA-duke-breast-cancer-mri'}	{'IDC', 'TCIA', 'ACRdart'}	104
-THORAX PE	{'CT', nan}	{'IDC-IDC_midrc_ricord_1a', 'TCIA-midrc-ricord-1b', 'TCIA-midrc-ricord-1a', 'MIDRC-TCIA-RICORD_1b', 'IDC-IDC_midrc_ricord_1b', 'MIDRC-TCIA-RICORD_1a'}	{'IDC', 'TCIA', 'MIDRC'}	100
-MAMMO DIGITAL TOMOSYNTHESIS SCREENING BILATERAL	{'MG'}	{'ACRdart-EA1141Restricted', 'IDC-IDC_ea1141'}	{'ACRdart', 'IDC'}	100
-Abdomen^1 ACRIN PRONE COLONOGRAPHY	{'CT', nan}	{'TCIA-ct-colonography', 'IDC-IDC_ct_colonography'}	{'IDC', 'TCIA'}	100
-MAMMO+3D SCREEN	{'MG'}	{'ACRdart-EA1141Restricted', 'IDC-IDC_ea1141'}	{'ACRdart', 'IDC'}	100
-CT_Chest	{'CT', nan}	{'TCIA-cmb-crc', 'IDC-IDC_cmb_gec', 'TCIA-cmb-mml', 'IDC-IDC_cmb_crc', 'IDC-IDC_cmb_mel', 'TCIA-cmb-pca', 'TCIA-cmb-mel', 'TCIA-cmb-lca', 'IDC-IDC_cmb_pca', 'TCIA-cmb-gec', 'TCIA-cmb-aml', 'IDC-IDC_cmb_lca', 'IDC-IDC_cmb_aml'}	{'IDC', 'TCIA'}	99
-01_PM_Thorax_Plain(Adult)	{'CT'}	{'MIDRC-Open-A1_SCCM_VIRUS'}	{'MIDRC'}	98
-Thorax^AThoraxRoutine (Adult)	{'CT', nan}	{'IDC-IDC_lung_pet_ct_dx', 'TCIA-lung-pet-ct-dx'}	{'IDC', 'TCIA'}	98
-PET^03_Wholebody_First_Head (Adult)	{'CT', 'SEG', 'PT', nan}	{'IDC-IDC_lung_pet_ct_dx', 'TCIA-lung-pet-ct-dx'}	{'IDC', 'TCIA'}	96
-CTA CHEST PULMONARY ANGIOGRAPHY W CONTRAST	{'CT'}	{'MIDRC-Open-R1'}	{'MIDRC'}	96
-CT ABDOMEN PELVIS WO CONTRAST (ROUTINE)	{'CT'}	{'MIDRC-Open-A1'}	{'MIDRC'}	96
-MAMMOGRAPHY-SCREENING-TOMO-BILAT	{'MG'}	{'ACRdart-EA1141Restricted', 'IDC-IDC_ea1141'}	{'ACRdart', 'IDC'}	95
-Standard Screening - Combo	{'MG', 'MR'}	{'ACRdart-EA1141Restricted', 'IDC-IDC_ea1141'}	{'ACRdart', 'IDC'}	95
-MR BREAST BILAT W OR WO CA	{'MR', nan}	{'IDC-IDC_acrin_contralateral_breast_mr', 'TCIA-acrin-contralateral-breast-mr'}	{'IDC', 'TCIA'}	94
-CTC	{'CT', nan}	{'TCIA-ct-colonography', 'IDC-IDC_ct_colonography'}	{'IDC', 'TCIA'}	94
-HEAD^ROUTINE	{'MR', 'SEG', nan}	{'IDC-IDC_upenn_gbm', 'TCIA-upenn-gbm'}	{'IDC', 'TCIA'}	94
-Abdomen^CT_AP_WITH (Adult)	{'CT'}	{'MIDRC-Open-A1'}	{'MIDRC'}	92
-BREAST^ACRIN STUDY	{'MR', nan}	{'IDC-IDC_acrin_contralateral_breast_mr', 'TCIA-acrin-contralateral-breast-mr'}	{'IDC', 'TCIA'}	92
-CT ANGIOGRAM CHEST	{'CT', nan}	{'IDC-IDC_midrc_ricord_1a', 'TCIA-midrc-ricord-1b', 'TCIA-midrc-ricord-1a', 'MIDRC-TCIA-RICORD_1b', 'MIDRC-Open-R1', 'IDC-IDC_midrc_ricord_1b', 'MIDRC-TCIA-RICORD_1a'}	{'IDC', 'TCIA', 'MIDRC'}	90
-three_phase__abdomen	{'SEG', nan}	{'TCIA-c4kc-kits', 'IDC-IDC_c4kc_kits'}	{'IDC', 'TCIA'}	90
-CT ANGIO CHEST WWO	{'CT'}	{'MIDRC-Open-A1', 'MIDRC-Open-R1'}	{'MIDRC'}	90
-CHEST 1 VIEW ICU	{'DX'}	{'MIDRC-Open-R1'}	{'MIDRC'}	89
-MR BREAST BILAT W AND W/O CONT-DR	{'MR', 'SEG', nan}	{'TCIA-duke-breast-cancer-mri', 'IDC-IDC_duke_breast_cancer_mri'}	{'IDC', 'TCIA'}	88
-PET CT with registered MR	{'RTSTRUCT', 'CT', 'PT', 'MR', nan}	{'TCIA-pseudo-phi-dicom-data', 'IDC-IDC_pseudo_phi_dicom_data', 'IDC-IDC_soft_tissue_sarcoma', 'TCIA-soft-tissue-sarcoma'}	{'IDC', 'TCIA'}	88
-MRI BREAST BILATERAL ABBREVIATED STUDY	{'MR'}	{'ACRdart-EA1141Restricted', 'IDC-IDC_ea1141'}	{'ACRdart', 'IDC'}	87
-BREAST W/O followed by W CONTRAST, UNILAT	{'MR', 'SEG', nan}	{'IDC-IDC_acrin_contralateral_breast_mr', 'IDC-IDC_ispy1', 'TCIA-acrin-contralateral-breast-mr'}	{'IDC', 'TCIA'}	86
-MRI RESEARCH AB BREAST BILAT LIMITED W AND WO CONT ECH	{'MR'}	{'ACRdart-EA1141Restricted', 'IDC-IDC_ea1141'}	{'ACRdart', 'IDC'}	86
-BREAST MRI	{'MR', nan}	{'IDC-IDC_tcga_brca', 'TCIA-tcga-brca'}	{'IDC', 'TCIA'}	86
-*CT ABDOMEN & PELVIS	{'CT', nan}	{'IDC-IDC_tcga_ov', 'TCIA-tcga-lihc', 'TCIA-tcga-kirc', 'TCIA-tcga-ov', 'IDC-IDC_tcga_lihc', 'IDC-IDC_tcga_ucec', 'IDC-IDC_tcga_kirc', 'TCIA-tcga-ucec'}	{'IDC', 'TCIA'}	86
-CT ABDOMEN w + PELVIS w	{'CT', 'SEG', nan}	{'TCIA-tcga-lihc', 'TCIA-tcga-kirc', 'IDC-IDC_tcga_lihc', 'IDC-IDC_tcga_ucec', 'IDC-IDC_tcga_kirc', 'TCIA-tcga-ucec'}	{'IDC', 'TCIA'}	86
-MAMSCTOMO	{'MG'}	{'ACRdart-EA1141Restricted', 'IDC-IDC_ea1141'}	{'ACRdart', 'IDC'}	85
-BREAST^7 CHANNEL WHITE COIL ROUTINE FOV 320	{'MR'}	{'ACRdart-EA1141Restricted', 'IDC-IDC_ea1141'}	{'ACRdart', 'IDC'}	84
-Abdomen^3_COLONOGRAPHY	{'CT', nan}	{'TCIA-ct-colonography', 'IDC-IDC_ct_colonography'}	{'IDC', 'TCIA'}	84
-MAMMO TOMO SCREEN BILAT	{'MG'}	{'ACRdart-EA1141Restricted', 'IDC-IDC_ea1141'}	{'ACRdart', 'IDC'}	84
-CT CHEST W/O CONTRAST	{'CT', 'SEG', nan}	{'IDC-IDC_tcga_lusc', 'IDC-IDC_nsclc_radiogenomics', 'TCIA-nsclc-radiogenomics', 'IDC-IDC_acrin_nsclc_fdg_pet', 'MIDRC-Open-A1', 'TCIA-tcga-lusc', 'TCIA-acrin-nsclc-fdg-pet', 'IDC-IDC_tcga_blca', 'TCIA-tcga-blca'}	{'IDC', 'TCIA', 'MIDRC'}	84
-PET F-18 NaF Bone Scan	{'CT', 'PT', nan}	{'IDC-IDC_naf_prostate', 'TCIA-naf-prostate'}	{'IDC', 'TCIA'}	82
-CT ANGIOGRAPHY NECK AND HEAD	{'CT'}	{'MIDRC-Open-A1'}	{'MIDRC'}	82
-CT ABD W/CONT  RECONSTRUCTION	{'CT', nan}	{'TCIA-ct-colonography', 'IDC-IDC_ct_colonography'}	{'IDC', 'TCIA'}	82
-0	{'CR', 'DX', 'MG', 'MR'}	{'IDC-IDC_ea1141', 'MIDRC-Open-R1'}	{'IDC', 'MIDRC'}	81
-MAM Dig Breast Screen Tomosynthesis	{'MG'}	{'ACRdart-EA1141Restricted', 'IDC-IDC_ea1141'}	{'ACRdart', 'IDC'}	81
-DG CHEST 2V	{'CR', 'DX'}	{'MIDRC-Open-A1', 'MIDRC-Open-A1_SCCM_VIRUS'}	{'MIDRC'}	80
-CHEST 2 VIEW	{'DX', nan}	{'TCIA-rider-pilot', 'TCIA-lidc-idri', 'IDC-IDC_lidc_idri', 'TCIA-tcga-blca', 'IDC-IDC_tcga_blca', 'IDC-IDC_rider_pilot'}	{'IDC', 'TCIA'}	78
-CT CHEST WO IV CONTRAST	{'CT'}	{'MIDRC-Open-A1', 'AIMI-COCA', 'MIDRC-Open-A1_PETAL_REDCORAL'}	{'MIDRC', 'AIMI'}	78
-XR KUB, FLAT PLATE, ABDOMEN 1 VIEW	{'CR', 'DX'}	{'MIDRC-Open-R1'}	{'MIDRC'}	78
-MR BREAST BILAT W+WO	{'MR'}	{'ACRdart-EA1141Restricted'}	{'ACRdart'}	78
-MRI BREAST RESEARCH	{'MR'}	{'ACRdart-EA1141Restricted', 'IDC-IDC_ea1141'}	{'ACRdart', 'IDC'}	77
-BODY^BREAST	{'MR', nan}	{'ACRdart-EA1141Restricted', 'IDC-IDC_tcga_brca', 'TCIA-tcga-brca', 'IDC-IDC_ea1141'}	{'ACRdart', 'TCIA', 'IDC'}	74
-abdomen_pelvis__w	{'SEG', nan}	{'TCIA-c4kc-kits', 'IDC-IDC_c4kc_kits'}	{'IDC', 'TCIA'}	74
-RESSONANCIA MAGNETICA DE ABDOME INFERIOR	{'MR', nan}	{'IDC-IDC_tcga_blca', 'IDC-IDC_tcga_cesc', 'TCIA-tcga-cesc', 'TCIA-tcga-blca'}	{'IDC', 'TCIA'}	74
-MRI BREAST ABBREVIATED BILATERAL W/WO CONTRAST	{'MR'}	{'ACRdart-EA1141Restricted', 'IDC-IDC_ea1141'}	{'ACRdart', 'IDC'}	74
-BREAST^LESION  DETECTION	{'MR'}	{'ACRdart-EA1141Restricted', 'IDC-IDC_ea1141'}	{'ACRdart', 'IDC'}	74
-Unspecified CT CHEST	{'CT', nan}	{'TCIA-cc-radiomics-phantom-2', 'MIDRC-Open-R1'}	{'TCIA', 'MIDRC'}	74
-Abdomen^14_SUPINE_COLON (Adult)	{'CT', nan}	{'TCIA-ct-colonography', 'IDC-IDC_ct_colonography'}	{'IDC', 'TCIA'}	74
-CTA CHEST ABDOMEN PELVIS WWO	{'CT'}	{'MIDRC-Open-A1', 'MIDRC-Open-A1_PETAL_REDCORAL'}	{'MIDRC'}	73
-CT ABDOMEN/PELVIS WITH CONTRAST	{'CT'}	{'MIDRC-Open-R1', 'MIDRC-Open-A1_PETAL_REDCORAL'}	{'MIDRC'}	73
-abdomen__w	{'SEG', nan}	{'TCIA-c4kc-kits', 'IDC-IDC_c4kc_kits'}	{'IDC', 'TCIA'}	72
-Infinity-1 Treat:Tx Plan	{'CT', nan}	{'IDC-IDC_pelvic_reference_data', 'TCIA-pelvic-reference-data'}	{'IDC', 'TCIA'}	72
-CT ABDOMEN PELVIS W CONT	{'CT', nan}	{'IDC-IDC_tcga_read', 'IDC-IDC_tcga_lusc', 'TCIA-tcga-coad', 'IDC-IDC_tcga_coad', 'IDC-IDC_tcga_ov', 'TCIA-tcga-lihc', 'TCIA-tcga-kirc', 'TCIA-tcga-ov', 'TCIA-tcga-read', 'TCIA-tcga-kirp', 'TCIA-tcga-lusc', 'IDC-IDC_tcga_lihc', 'IDC-IDC_tcga_kirp', 'IDC-IDC_tcga_blca', 'IDC-IDC_tcga_kirc', 'TCIA-tcga-blca'}	{'IDC', 'TCIA'}	72
-Thorax^04_0_CAP_Routine (Adult)	{'CT', 'SEG', nan}	{'IDC-IDC_tcga_ov', 'TCIA-tcga-lihc', 'TCIA-tcga-kirc', 'TCIA-tcga-ov', 'IDC-IDC_tcga_lihc', 'IDC-IDC_tcga_ucec', 'IDC-IDC_tcga_kirc', 'TCIA-tcga-ucec'}	{'IDC', 'TCIA'}	72
-CT CHEST WITH IV CONTRAST	{'CT'}	{'MIDRC-Open-A1_SCCM_VIRUS'}	{'MIDRC'}	71
-CT CHEST AND UPPER ABD W	{'CT'}	{'MIDRC-Open-A1', 'MIDRC-Open-R1'}	{'MIDRC'}	70
-LUNG	{'CT', 'SEG', 'PT', nan}	{'IDC-IDC_acrin_nsclc_fdg_pet', 'TCIA-acrin-nsclc-fdg-pet', 'IDC-IDC_lung_pet_ct_dx', 'TCIA-lung-pet-ct-dx'}	{'IDC', 'TCIA'}	68
-CT CHEST ABDOMEN PELVIS WO CONTRAST	{'CT'}	{'MIDRC-Open-R1', 'MIDRC-Open-A1_PETAL_REDCORAL'}	{'MIDRC'}	68
-PET^01_PThead_lung (Adult)	{'CT', nan}	{'IDC-IDC_lung_pet_ct_dx', 'TCIA-lung-pet-ct-dx'}	{'IDC', 'TCIA'}	68
-Chest children	{'DX'}	{'MIDRC-Open-A1'}	{'MIDRC'}	67
-PET/CT Lung Cancer	{'CT', 'SEG', nan}	{'IDC-IDC_nsclc_radiogenomics', 'TCIA-nsclc-radiogenomics'}	{'IDC', 'TCIA'}	66
-MR ACRN STUDY	{'MR', nan}	{'IDC-IDC_acrin_contralateral_breast_mr', 'TCIA-acrin-contralateral-breast-mr'}	{'IDC', 'TCIA'}	66
-SCREENING CT COLONOGRA	{'CT', nan}	{'TCIA-ct-colonography', 'IDC-IDC_ct_colonography'}	{'IDC', 'TCIA'}	66
-MR Breast Research Gra	{'MR', 'SEG'}	{'IDC-IDC_ispy1'}	{'IDC'}	66
-Thorax^CT_CAP_WITH (Adult)	{'CT'}	{'MIDRC-Open-A1'}	{'MIDRC'}	65
-CT ABDOMEN	{'CT', 'SEG', nan}	{'IDC-IDC_adrenal_acc_ki67_seg', 'IDC-IDC_tcga_kirc', 'MIDRC-Open-A1_PETAL_REDCORAL', 'TCIA-tcga-kirc', 'TCIA-adrenal-acc-ki67-seg', 'TCIA-ct-colonography', 'IDC-IDC_tcga_ucec', 'IDC-IDC_tcga_blca', 'IDC-IDC_ct_colonography', 'TCIA-tcga-ucec', 'TCIA-tcga-blca'}	{'IDC', 'TCIA', 'MIDRC'}	65
-PR CHEST 1 VIEW	{'CR'}	{'MIDRC-Open-A1_PETAL_BLUECORAL', 'MIDRC-Open-A1_PETAL_REDCORAL'}	{'MIDRC'}	65
-CT CHEST O CONTR	{'CT', 'SEG', nan}	{'TCIA-lidc-idri', 'IDC-IDC_lidc_idri'}	{'IDC', 'TCIA'}	64
-CT CARDIAC CTA CORONARY	{'CT', nan}	{'IDC-IDC_rider_lung_pet_ct', 'TCIA-rider-lung-pet-ct'}	{'IDC', 'TCIA'}	64
-PET^1PETCT_WholeBody (Adult)	{'CT', 'SEG', nan}	{'TCIA-acrin-nsclc-fdg-pet', 'IDC-IDC_acrin_nsclc_fdg_pet'}	{'IDC', 'TCIA'}	64
-Thorax^ThoraxPETCT1	{'CT', 'SEG', 'PT', nan}	{'IDC-IDC_tcga_lusc', 'TCIA-tcga-luad', 'IDC-IDC_acrin_nsclc_fdg_pet', 'TCIA-tcga-lusc', 'TCIA-acrin-nsclc-fdg-pet', 'IDC-IDC_tcga_luad'}	{'IDC', 'TCIA'}	64
-CHEST ROUTINE PA AP AND LATERAL	{'CR', nan}	{'MIDRC-TCIA-COVID-19-NY-SBU', 'IDC-IDC_covid_19_ny_sbu', 'TCIA-covid-19-ny-sbu'}	{'IDC', 'TCIA', 'MIDRC'}	64
-MRMAM	{'MR'}	{'ACRdart-EA1141Restricted', 'IDC-IDC_ea1141'}	{'ACRdart', 'IDC'}	64
-Standard Screening - ComboHD	{'MG'}	{'ACRdart-EA1141Restricted', 'IDC-IDC_ea1141'}	{'ACRdart', 'IDC'}	64
-Tomo HD BDS	{'MG', 'CT'}	{'ACRdart-EA1141Restricted', 'IDC-IDC_ea1141'}	{'ACRdart', 'IDC'}	63
-Thorax^CHEST_WO_GR (Adult)	{'CT'}	{'MIDRC-Open-A1'}	{'MIDRC'}	62
-CHEST ROUTINE	{'CR', 'DX'}	{'MIDRC-Open-R1'}	{'MIDRC'}	62
-BREAST^ROUTINE DYNAMIC	{'MR', 'SEG', nan}	{'TCIA-duke-breast-cancer-mri', 'IDC-IDC_duke_breast_cancer_mri'}	{'IDC', 'TCIA'}	62
-MR PELVIS IMAGE IMPORT	{'MR', nan}	{'TCIA-prostate-mri-us-biopsy', 'IDC-IDC_prostate_mri_us_biopsy'}	{'IDC', 'TCIA'}	62
-MRI BREAST W/ + W/O CONTRAST BILATERAL	{'MR'}	{'ACRdart-EA1141Restricted', 'IDC-IDC_ea1141'}	{'ACRdart', 'IDC'}	62
-Thorax^CHEST_WITH (Adult)	{'CT'}	{'MIDRC-Open-A1'}	{'MIDRC'}	61
-Abdomen^ABDOMEN_PELVIS_W_ROUTINE (Adult)	{'CT'}	{'MIDRC-Open-A1'}	{'MIDRC'}	61
-three_phase__abdomen_pelvis	{'SEG', nan}	{'TCIA-c4kc-kits', 'IDC-IDC_c4kc_kits'}	{'IDC', 'TCIA'}	60
-Research 1^breast	{'MR', nan}	{'IDC-IDC_acrin_contralateral_breast_mr', 'TCIA-acrin-contralateral-breast-mr'}	{'IDC', 'TCIA'}	60
-JCCI CT CHEST	{'CT'}	{'MIDRC-Open-R1'}	{'MIDRC'}	60
-MR1	{'REG', 'RTSTRUCT', 'MR', nan}	{'IDC-IDC_cc_tumor_heterogeneity', 'TCIA-cc-tumor-heterogeneity'}	{'IDC', 'TCIA'}	60
-CHEST WO(Adult)	{'CT'}	{'MIDRC-Open-A1', 'MIDRC-Open-R1'}	{'MIDRC'}	59
-ULTRASOUND	{'US'}	{'ACRdart-ACRIN_6666'}	{'ACRdart'}	59
-Bladder CT	{'CT', nan}	{'IDC-IDC_tcga_blca', 'TCIA-tcga-blca'}	{'IDC', 'TCIA'}	58
-CT CHEST W/O IV CON	{'CT'}	{'MIDRC-Open-R1'}	{'MIDRC'}	58
-CT ANGIO CHEST PULM EMBOLISM	{'CT'}	{'MIDRC-Open-R1', 'MIDRC-Open-A1_PETAL_BLUECORAL'}	{'MIDRC'}	57
-CT THORAX PE EXAM	{'CT'}	{'MIDRC-Open-R1'}	{'MIDRC'}	57
-MRI Breast Bilateral wo then w Contrast	{'MR'}	{'ACRdart-EA1141Restricted', 'IDC-IDC_ea1141'}	{'ACRdart', 'IDC'}	57
-MR2	{'RTSTRUCT', 'REG', 'MR', nan}	{'IDC-IDC_cc_tumor_heterogeneity', 'TCIA-cc-tumor-heterogeneity'}	{'IDC', 'TCIA'}	56
-GBM_intracranial	{'MR', nan}	{'TCIA-mouse-astrocytoma', 'IDC-IDC_mouse_astrocytoma'}	{'IDC', 'TCIA'}	56
-PELVIS^PROSTATE	{'MR', nan}	{'TCIA-prostate-fused-mri-pathology', 'IDC-IDC_prostate_fused_mri_pathology'}	{'IDC', 'TCIA'}	56
-BRAIN BRAIN TUMOR	{'MR', 'SEG', nan}	{'IDC-IDC_upenn_gbm', 'TCIA-upenn-gbm'}	{'IDC', 'TCIA'}	56
-Thorax^XL_PE_Customized (Adult)	{'CT'}	{'MIDRC-Open-A1', 'MIDRC-Open-A1_PETAL_BLUECORAL'}	{'MIDRC'}	55
-EC BREAST SCREENING-BILATERAL WITH CAD	{'MG'}	{'ACRdart-EA1141Restricted', 'IDC-IDC_ea1141'}	{'ACRdart', 'IDC'}	55
-MRI BREAST, BILATERAL WITH T WITHOUT CONTRAST	{'MR', nan}	{'TCIA-breast-diagnosis', 'IDC-IDC_breast_diagnosis'}	{'IDC', 'TCIA'}	55
-MR Breast Research Gr?	{'MR', 'SEG'}	{'IDC-IDC_ispy1'}	{'IDC'}	55
-MRI Breast w w o Contrast bilat (Birad)	{'MR'}	{'ACRdart-EA1141Restricted', 'IDC-IDC_ea1141'}	{'ACRdart', 'IDC'}	55
-CT ABDOMEN AND PELVIS WITH CONTRAST	{'RTSTRUCT', 'CT', nan}	{'TCIA-cptac-ccrcc', 'IDC-IDC_cptac_ccrcc', 'MIDRC-Open-A1', 'TCIA-cptac-ucec', 'IDC-IDC_cptac_ucec'}	{'IDC', 'TCIA', 'MIDRC'}	55
-Abdomen^STONE_STUDY_FULL (Adult)	{'CT'}	{'MIDRC-Open-A1'}	{'MIDRC'}	55
-BREAST^MASS PROTOCAL	{'MR', nan}	{'IDC-IDC_acrin_contralateral_breast_mr', 'TCIA-acrin-contralateral-breast-mr'}	{'IDC', 'TCIA'}	54
-MR3	{'RTSTRUCT', 'REG', 'MR', nan}	{'IDC-IDC_cc_tumor_heterogeneity', 'TCIA-cc-tumor-heterogeneity'}	{'IDC', 'TCIA'}	54
-Abdomen^17_Supine_and_Prone_Colon (Adult)	{'CT', nan}	{'TCIA-ct-colonography', 'IDC-IDC_ct_colonography'}	{'IDC', 'TCIA'}	54
-PANCREAS	{'RTSTRUCT', 'CT', nan}	{'IDC-IDC_pancreatic_ct_cbct_seg', 'TCIA-pancreatic-ct-cbct-seg'}	{'IDC', 'TCIA'}	54
-Thorax^ROUTINE_CHEST_WITHOUT (Adult)	{'CT'}	{'MIDRC-Open-A1'}	{'MIDRC'}	54
-HEAD^BRAIN TUMOR	{'MR', 'SEG', nan}	{'IDC-IDC_upenn_gbm', 'TCIA-upenn-gbm'}	{'IDC', 'TCIA'}	54
-CT ANGIO LIVER WITH CH/PEL	{'SEG', nan}	{'TCIA-colorectal-liver-metastases', 'IDC-IDC_colorectal_liver_metastases'}	{'IDC', 'TCIA'}	54
-Thorax^GH_ThoraxRoutine (Adult)	{'CT'}	{'MIDRC-Open-A1_SCCM_VIRUS'}	{'MIDRC'}	53
-MIEDNICA	{'RTSTRUCT', 'MR', nan}	{'IDC-IDC_cptac_ucec', 'TCIA-cptac-ucec'}	{'IDC', 'TCIA'}	52
-CT AbdPelvis	{'CT', nan}	{'TCIA-cmb-crc', 'IDC-IDC_cmb_gec', 'TCIA-cmb-mml', 'IDC-IDC_cmb_crc', 'IDC-IDC_cmb_mel', 'TCIA-cmb-mel', 'TCIA-cmb-lca', 'IDC-IDC_cmb_pca', 'IDC-IDC_cmb_mml', 'TCIA-cmb-gec', 'IDC-IDC_cmb_lca', 'TCIA-cmb-pca'}	{'IDC', 'TCIA'}	52
-Abdomen^1_ACRIN_COLON (Adult)	{'CT', nan}	{'TCIA-ct-colonography', 'IDC-IDC_ct_colonography'}	{'IDC', 'TCIA'}	52
-CT, COLONOGRAPHY SCREE	{'CT', nan}	{'TCIA-ct-colonography', 'IDC-IDC_ct_colonography'}	{'IDC', 'TCIA'}	52
-Abdomen^02_0_Abdomen_Routine (Adult)	{'CT', nan}	{'IDC-IDC_tcga_ov', 'TCIA-tcga-kirc', 'TCIA-tcga-ov', 'IDC-IDC_tcga_ucec', 'IDC-IDC_tcga_kirc', 'TCIA-tcga-ucec'}	{'IDC', 'TCIA'}	52
-CT Chest	{'CT', 'SEG', nan}	{'TCIA-cmb-crc', 'IDC-IDC_adrenal_acc_ki67_seg', 'IDC-IDC_cmb_crc', 'IDC-IDC_cmb_mel', 'IDC-IDC_acrin_nsclc_fdg_pet', 'TCIA-cmb-mel', 'TCIA-cmb-lca', 'TCIA-acrin-nsclc-fdg-pet', 'TCIA-adrenal-acc-ki67-seg', 'IDC-IDC_cmb_mml', 'TCIA-cmb-mml', 'IDC-IDC_cmb_lca'}	{'IDC', 'TCIA'}	52
-Thorax^CHEST_ABD_PEL_WITH (Adult)	{'CT'}	{'MIDRC-Open-A1'}	{'MIDRC'}	52
-CT PE CHEST	{'CT', nan}	{'MIDRC-TCIA-COVID-19-AR', 'TCIA-covid-19-ar', 'IDC-IDC_covid_19_ar'}	{'IDC', 'TCIA', 'MIDRC'}	51
-DIGITAL MAMM SCREENING W/ TOMO	{'MG'}	{'ACRdart-EA1141Restricted', 'IDC-IDC_ea1141'}	{'ACRdart', 'IDC'}	51
-Thorax^FLASH_PE (Adult)	{'CT'}	{'MIDRC-Open-A1'}	{'MIDRC'}	51
-CT CHEST ABDOMEN PELVIS WO	{'CT'}	{'MIDRC-Open-A1', 'MIDRC-Open-R1'}	{'MIDRC'}	50
-66671F	{'MR', nan}	{'IDC-IDC_acrin_contralateral_breast_mr', 'TCIA-acrin-contralateral-breast-mr'}	{'IDC', 'TCIA'}	50
-CT CH/AB/PEL KIDNEY PROTOCOL	{'CT', 'SEG', nan}	{'TCIA-tcga-kirc', 'IDC-IDC_tcga_kirc'}	{'IDC', 'TCIA'}	50
-Thorax^CT_CHEST_WITHOUT (Adult)	{'CT'}	{'MIDRC-Open-A1'}	{'MIDRC'}	50
-MR BREAST FAST BILATERAL	{'MR'}	{'ACRdart-EA1141Restricted', 'IDC-IDC_ea1141'}	{'ACRdart', 'IDC'}	50
-BRAIN^STEALTH	{'MR', 'SEG', nan}	{'IDC-IDC_upenn_gbm', 'TCIA-upenn-gbm'}	{'IDC', 'TCIA'}	50
-lung+c	{'CT', 'SEG', nan}	{'IDC-IDC_lung_pet_ct_dx', 'TCIA-lung-pet-ct-dx'}	{'IDC', 'TCIA'}	50
-MR HEAD FUNCTIONAL MOTOR LANGUAGE	{'MR', 'SEG', nan}	{'IDC-IDC_upenn_gbm', 'TCIA-upenn-gbm'}	{'IDC', 'TCIA'}	50
-Abdomen^22 COLON SUPINE	{'CT', nan}	{'TCIA-ct-colonography', 'IDC-IDC_ct_colonography'}	{'IDC', 'TCIA'}	50
-Abdomen^Brzuch_3fazy_Adult (Adult)	{'RTSTRUCT', 'CT', nan}	{'IDC-IDC_cptac_ucec', 'TCIA-cptac-ucec'}	{'IDC', 'TCIA'}	50
-MRI Prostate ERC	{'MR', nan}	{'IDC-IDC_prostate_mri', 'TCIA-prostate-mri'}	{'IDC', 'TCIA'}	50
-MR BREAST BILATERAL WITH/WITHOUT CONTRAST	{'MR'}	{'ACRdart-EA1141Restricted', 'IDC-IDC_ea1141'}	{'ACRdart', 'IDC'}	49
-Thorax^ROUTINE_CHEST_ABD_PEL_WITH (Adult)	{'CT'}	{'MIDRC-Open-A1'}	{'MIDRC'}	48
-LUNG+C	{'CT', 'SEG', nan}	{'IDC-IDC_lung_pet_ct_dx', 'TCIA-lung-pet-ct-dx'}	{'IDC', 'TCIA'}	48
-CT THORAX W/O DYE	{'SEG', nan}	{'TCIA-varepop-apollo', 'IDC-IDC_nsclc_radiogenomics', 'TCIA-nsclc-radiogenomics'}	{'IDC', 'TCIA'}	48
-ACRIN6667-RESEARCH	{'MR', nan}	{'IDC-IDC_acrin_contralateral_breast_mr', 'TCIA-acrin-contralateral-breast-mr'}	{'IDC', 'TCIA'}	48
-MRI Abd wo&w	{'MR', nan}	{'TCIA-tcga-lihc', 'TCIA-tcga-kirc', 'IDC-IDC_tcga_kirc', 'IDC-IDC_tcga_lihc'}	{'IDC', 'TCIA'}	48
-ABDOMEN SUPINE KUB	{'CR', 'DX', nan}	{'MIDRC-TCIA-COVID-19-NY-SBU', 'IDC-IDC_covid_19_ny_sbu', 'TCIA-covid-19-ny-sbu'}	{'IDC', 'TCIA', 'MIDRC'}	48
-CT_AbdPel	{'CT', nan}	{'TCIA-cmb-crc', 'IDC-IDC_cmb_gec', 'TCIA-cmb-mml', 'IDC-IDC_cmb_crc', 'IDC-IDC_cmb_mel', 'TCIA-cmb-mel', 'TCIA-cmb-lca', 'IDC-IDC_cmb_pca', 'IDC-IDC_cmb_mml', 'TCIA-cmb-gec', 'IDC-IDC_cmb_lca', 'TCIA-cmb-pca'}	{'IDC', 'TCIA'}	48
-CT CHEST W CONT	{'CT', nan}	{'IDC-IDC_acrin_nsclc_fdg_pet', 'TCIA-acrin-nsclc-fdg-pet', 'MIDRC-Open-A1_SCCM_VIRUS', 'IDC-IDC_rider_lung_pet_ct', 'TCIA-rider-lung-pet-ct'}	{'IDC', 'TCIA', 'MIDRC'}	48
-MAMM TOMO SCREEN DIGITAL BILAT	{'MG'}	{'ACRdart-EA1141Restricted', 'IDC-IDC_ea1141'}	{'ACRdart', 'IDC'}	47
-PET CT MID BODY	{'CT', 'SEG', 'PT', nan}	{'IDC-IDC_rider_lung_pet_ct', 'IDC-IDC_cc_tumor_heterogeneity', 'TCIA-cc-tumor-heterogeneity', 'TCIA-rider-lung-pet-ct'}	{'IDC', 'TCIA'}	47
-Thorax^XL_PE (Adult)	{'CT'}	{'MIDRC-Open-A1'}	{'MIDRC'}	47
-Head^DE_HEAD_WITHOUT (Adult)	{'CT'}	{'MIDRC-Open-A1'}	{'MIDRC'}	47
-BREAST^LESION	{'MR', nan}	{'ACRdart-EA1141Restricted', 'IDC-IDC_acrin_contralateral_breast_mr', 'IDC-IDC_ea1141', 'TCIA-acrin-contralateral-breast-mr'}	{'ACRdart', 'TCIA', 'IDC'}	47
-H DIGITAL SCREEN/TOMO, CVIEW & CAD	{'MG'}	{'ACRdart-EA1141Restricted', 'IDC-IDC_ea1141'}	{'ACRdart', 'IDC'}	46
-Abdomen^1_ROUTINE_CAP (Adult)	{'CT'}	{'MIDRC-Open-A1'}	{'MIDRC'}	46
-CT CODE STROKE (BRAIN WO, CTA, PERFUSION)	{'CT'}	{'MIDRC-Open-A1'}	{'MIDRC'}	46
-IMR BREAST W/O & W/BILATERAL	{'MR', nan}	{'IDC-IDC_acrin_contralateral_breast_mr', 'TCIA-acrin-contralateral-breast-mr'}	{'IDC', 'TCIA'}	46
-MR PELVIS, OUTSIDE IMAGING	{'SEG', nan}	{'TCIA-prostate-mri-us-biopsy', 'IDC-IDC_prostate_mri_us_biopsy'}	{'IDC', 'TCIA'}	46
-TRANSTHORACIC ECHO	{'US'}	{'MIDRC-Open-R1'}	{'MIDRC'}	46
-CT_AbdPelvis	{'CT', nan}	{'TCIA-cmb-crc', 'IDC-IDC_cmb_crc', 'IDC-IDC_cmb_mel', 'TCIA-cmb-mel', 'TCIA-cmb-lca', 'IDC-IDC_cmb_mml', 'TCIA-cmb-mml', 'TCIA-cmb-aml', 'IDC-IDC_cmb_lca', 'IDC-IDC_cmb_aml'}	{'IDC', 'TCIA'}	46
-CT FACE SINUSES WO CONTRAST	{'CT'}	{'MIDRC-Open-A1'}	{'MIDRC'}	45
-CT CHEST W IV CONTRAST	{'RTSTRUCT', 'CT', nan}	{'TCIA-cptac-pda', 'IDC-IDC_cptac_pda', 'IDC-IDC_cptac_lscc', 'IDC-IDC_cptac_luad', 'TCIA-cptac-ccrcc', 'TCIA-cptac-luad', 'IDC-IDC_cptac_ccrcc', 'TCIA-cptac-lscc', 'MIDRC-Open-A1'}	{'IDC', 'TCIA', 'MIDRC'}	44
-Abdomen^01ACRINColonographySupine	{'CT', nan}	{'TCIA-ct-colonography', 'IDC-IDC_ct_colonography'}	{'IDC', 'TCIA'}	44
-CT GUIDED LUNG B	{'CT', 'SEG', nan}	{'TCIA-lidc-idri', 'IDC-IDC_lidc_idri'}	{'IDC', 'TCIA'}	44
-CT RENAL Mass	{'CT', 'SEG', nan}	{'IDC-IDC_tcga_kirp', 'TCIA-tcga-kirc', 'TCIA-tcga-kirp', 'IDC-IDC_tcga_kirc'}	{'IDC', 'TCIA'}	44
-Abdomen^1_COLONOGRAPHY (Adult)	{'CT', nan}	{'TCIA-ct-colonography', 'IDC-IDC_ct_colonography'}	{'IDC', 'TCIA'}	44
-LUNG CA	{'CT', 'SEG', 'PT', nan}	{'TCIA-acrin-nsclc-fdg-pet', 'IDC-IDC_acrin_nsclc_fdg_pet'}	{'IDC', 'TCIA'}	44
-CT Thorax	{'CT', 'SEG', nan}	{'IDC-IDC_nsclc_radiogenomics', 'TCIA-nsclc-radiogenomics'}	{'IDC', 'TCIA'}	44
-MRI BREAST ABBREVIATED	{'MR'}	{'ACRdart-EA1141Restricted', 'IDC-IDC_ea1141'}	{'ACRdart', 'IDC'}	44
-Unknown	{'US'}	{'ACRdart-ACRIN_6666'}	{'ACRdart'}	43
-MR BREAST, BILATERAL W/WO CONT	{'MR'}	{'ACRdart-EA1141Restricted', 'IDC-IDC_tcga_brca', 'IDC-IDC_ea1141'}	{'ACRdart', 'IDC'}	43
-RT^RT_RespLowBreathRateRNS (Adult)	{'RWV', 'CT', 'PT', nan}	{'TCIA-ct-vs-pet-ventilation-imaging', 'IDC-IDC_ct_vs_pet_ventilation_imaging'}	{'IDC', 'TCIA'}	42
-MR BREAST	{'MR', 'SEG', nan}	{'TCIA-breast-mri-nact-pilot', 'IDC-IDC_breast_mri_nact_pilot'}	{'IDC', 'TCIA'}	42
-THORAX/ABDOMEN/PELVIS + CONT	{'CT', nan}	{'IDC-IDC_midrc_ricord_1a', 'TCIA-midrc-ricord-1b', 'TCIA-midrc-ricord-1a', 'MIDRC-TCIA-RICORD_1b', 'IDC-IDC_midrc_ricord_1b', 'MIDRC-TCIA-RICORD_1a'}	{'IDC', 'TCIA', 'MIDRC'}	42
-lung	{'CT', 'SEG', 'PT', nan}	{'IDC-IDC_nsclc_radiogenomics', 'TCIA-nsclc-radiogenomics', 'IDC-IDC_acrin_nsclc_fdg_pet', 'TCIA-acrin-nsclc-fdg-pet', 'IDC-IDC_lung_pet_ct_dx', 'TCIA-lung-pet-ct-dx'}	{'IDC', 'TCIA'}	42
-MR BREAST BILAT W AND W-O CONT -DR	{'MR', 'SEG', nan}	{'TCIA-duke-breast-cancer-mri', 'IDC-IDC_duke_breast_cancer_mri'}	{'IDC', 'TCIA'}	42
-MRI BRAIN WITH INJ - MHDI	{'MR', 'SEG', nan}	{'IDC-IDC_upenn_gbm', 'TCIA-upenn-gbm'}	{'IDC', 'TCIA'}	42
-CHEST 2 VIEWS (ROUTINE)	{'CR'}	{'MIDRC-Open-R1'}	{'MIDRC'}	42
-CCR Phantom	{nan}	{'TCIA-cc-radiomics-phantom-2'}	{'TCIA'}	41
-Thorax^CHEST_ABD_PEL_WO (Adult)	{'CT'}	{'MIDRC-Open-A1'}	{'MIDRC'}	41
-XR P PORT ABDOMEN AP 1 VIEW	{'CR'}	{'MIDRC-Open-A1', 'MIDRC-Open-R1'}	{'MIDRC'}	41
-Thorax^XL_CHEST_WO (Adult)	{'CT'}	{'MIDRC-Open-A1'}	{'MIDRC'}	41
-Breast CE	{'MR', nan}	{'IDC-IDC_qin_breast_dce_mri', 'TCIA-qin-breast-dce-mri'}	{'IDC', 'TCIA'}	40
-HEAD^FUNCTIONAL	{'MR', 'SEG', nan}	{'IDC-IDC_upenn_gbm', 'TCIA-upenn-gbm'}	{'IDC', 'TCIA'}	40
-Spine^SPINE_BONE_SBRT (Adult)	{'CT', 'SEG', nan}	{'TCIA-spine-mets-ct-seg', 'IDC-IDC_spine_mets_ct_seg'}	{'IDC', 'TCIA'}	40
-CT AB/PEL KIDNEY PROTOCOL	{'CT', 'SEG', nan}	{'TCIA-tcga-kirc', 'IDC-IDC_tcga_kirc'}	{'IDC', 'TCIA'}	40
-MR Breast Bi w/wo contrast	{'MR'}	{'ACRdart-EA1141Restricted', 'IDC-IDC_ea1141'}	{'ACRdart', 'IDC'}	40
-Abdomen^12_0_Liver_BiPhase (Adult)	{'CT', 'SEG', nan}	{'TCIA-tcga-lihc', 'TCIA-tcga-ov', 'IDC-IDC_tcga_lihc', 'IDC-IDC_tcga_ov'}	{'IDC', 'TCIA'}	40
-CT THORAX WITH CONTRAST	{'RTSTRUCT', 'CT', 'SEG', nan}	{'IDC-IDC_nsclc_radiogenomics', 'TCIA-nsclc-radiogenomics', 'MIDRC-Open-A1_PETAL_REDCORAL', 'IDC-IDC_acrin_nsclc_fdg_pet', 'TCIA-varepop-apollo', 'TCIA-acrin-nsclc-fdg-pet', 'TCIA-cptac-ucec', 'IDC-IDC_cptac_ucec'}	{'IDC', 'TCIA', 'MIDRC'}	40
-PET/CT	{'CT', 'SEG', 'PT', nan}	{'IDC-IDC_nsclc_radiogenomics', 'TCIA-nsclc-radiogenomics', 'IDC-IDC_acrin_nsclc_fdg_pet', 'TCIA-acrin-nsclc-fdg-pet', 'TCIA-naf-prostate', 'IDC-IDC_naf_prostate'}	{'IDC', 'TCIA'}	40
-PET CT LUNG CANCER	{'SEG', nan}	{'IDC-IDC_nsclc_radiogenomics', 'TCIA-nsclc-radiogenomics'}	{'IDC', 'TCIA'}	40
-_t1of3  External Images for PACS	{'MR', nan}	{'IDC-IDC_vestibular_schwannoma_mc_rc', 'TCIA-vestibular-schwannoma-mc-rc'}	{'IDC', 'TCIA'}	40
-PET1	{'CT', 'PT', nan}	{'IDC-IDC_cc_tumor_heterogeneity', 'TCIA-cc-tumor-heterogeneity'}	{'IDC', 'TCIA'}	40
-PET2	{'CT', 'PT', nan}	{'IDC-IDC_cc_tumor_heterogeneity', 'TCIA-cc-tumor-heterogeneity'}	{'IDC', 'TCIA'}	40
-MAM Tomo Screening	{'MG'}	{'ACRdart-EA1141Restricted', 'IDC-IDC_ea1141'}	{'ACRdart', 'IDC'}	40
-PET^03_CBM_Wholebody_First_Head (Adult)	{'CT', 'SEG', 'PT', nan}	{'IDC-IDC_lung_pet_ct_dx', 'TCIA-lung-pet-ct-dx'}	{'IDC', 'TCIA'}	40
-CT Thorax W/ Contrast	{'CT'}	{'MIDRC-Open-A1_PETAL_BLUECORAL', 'MIDRC-Open-A1_PETAL_REDCORAL'}	{'MIDRC'}	39
-BREAST^16 Channel Coil	{'MR'}	{'ACRdart-EA1141Restricted', 'IDC-IDC_ea1141'}	{'ACRdart', 'IDC'}	39
-CTA CORONARY	{'CT'}	{'MIDRC-Open-A1', 'MIDRC-Open-R1'}	{'MIDRC'}	39
-BREAST^EA1141 - AB MRI ECOG-ACRIN	{'MR'}	{'ACRdart-EA1141Restricted', 'IDC-IDC_ea1141'}	{'ACRdart', 'IDC'}	39
-MA MAMMOGRAM SCREENING BILATERAL W/TOMO	{'MG'}	{'ACRdart-EA1141Restricted'}	{'ACRdart'}	39
-CT DIAGN VIRT COLONOSCOPY	{'CT', nan}	{'TCIA-ct-colonography', 'IDC-IDC_ct_colonography'}	{'IDC', 'TCIA'}	38
-CT COLONOGRAPHY SCREEN	{'CT', nan}	{'TCIA-ct-colonography', 'IDC-IDC_ct_colonography'}	{'IDC', 'TCIA'}	38
-MR SCREENING BREAST WANDW/O CONTRAST	{'MR'}	{'ACRdart-EA1141Restricted', 'IDC-IDC_ea1141'}	{'ACRdart', 'IDC'}	38
-CTA PULMONARY EMBOLUS	{'CT'}	{'MIDRC-Open-A1'}	{'MIDRC'}	38
-PET3	{'CT', 'PT', nan}	{'IDC-IDC_cc_tumor_heterogeneity', 'TCIA-cc-tumor-heterogeneity'}	{'IDC', 'TCIA'}	38
-X-RAY LUMBOSACRAL SPINE 2 OR 3 VIEWS	{'CR', 'DX'}	{'MIDRC-Open-A1'}	{'MIDRC'}	38
-FORFILE CT ABD AND/OR PEL - CD	{'CT', 'SEG', nan}	{'TCIA-pseudo-phi-dicom-data', 'IDC-IDC_tcga_ov', 'IDC-IDC_tcga_blca', 'TCIA-colorectal-liver-metastases', 'TCIA-tcga-kirc', 'TCIA-tcga-ov', 'IDC-IDC_pseudo_phi_dicom_data', 'IDC-IDC_colorectal_liver_metastases', 'IDC-IDC_tcga_kirc', 'TCIA-tcga-blca'}	{'IDC', 'TCIA'}	38
-Abdomen^ABD_PEL_WO (Adult)	{'CT'}	{'MIDRC-Open-A1'}	{'MIDRC'}	38
-CT CHEST	{'CT', 'SEG', nan}	{'IDC-IDC_tcga_lusc', 'TCIA-tcga-luad', 'IDC-IDC_nsclc_radiogenomics', 'MIDRC-Open-A1_PETAL_REDCORAL', 'TCIA-nsclc-radiogenomics', 'TCIA-tcga-lusc', 'IDC-IDC_acrin_nsclc_fdg_pet', 'TCIA-lidc-idri', 'TCIA-acrin-nsclc-fdg-pet', 'IDC-IDC_lidc_idri', 'MIDRC-Open-R1', 'MIDRC-Open-A1_PETAL_BLUECORAL', 'MIDRC-Open-A1_SCCM_VIRUS', 'IDC-IDC_tcga_luad'}	{'IDC', 'TCIA', 'MIDRC'}	37
-MRI BREAST BILATERAL	{'MR', 'SEG', nan}	{'IDC-IDC_ea1141', 'IDC-IDC_duke_breast_cancer_mri', 'ACRdart-EA1141Restricted', 'TCIA-duke-breast-cancer-mri', 'TCIA-tcga-brca'}	{'IDC', 'TCIA', 'ACRdart'}	37
-CT ABDOMEN PELVIS WO CONTRAST (STONE)	{'CT'}	{'MIDRC-Open-A1'}	{'MIDRC'}	37
-CTA CHEST PULMONARY EMBOLISM	{'CT'}	{'MIDRC-Open-A1_PETAL_BLUECORAL'}	{'MIDRC'}	37
-Thorax^DE_PE (Adult)	{'CT'}	{'MIDRC-Open-A1'}	{'MIDRC'}	37
-MRI ABD W+WO CONT	{'MR', nan}	{'TCIA-tcga-lihc', 'TCIA-tcga-kirc', 'TCIA-tcga-kirp', 'IDC-IDC_tcga_lihc', 'IDC-IDC_tcga_kirp', 'IDC-IDC_tcga_kirc'}	{'IDC', 'TCIA'}	36
-PETCT SUBSEQUENT TREAT	{'SEG', nan}	{'IDC-IDC_anti_pd_1_lung', 'TCIA-anti-pd-1_lung'}	{'IDC', 'TCIA'}	36
-TX AS	{'CT', nan}	{'TCIA-tcga-esca', 'IDC-IDC_tcga_esca', 'TCIA-tcga-stad', 'IDC-IDC_tcga_stad', 'IDC-IDC_tcga_blca', 'TCIA-tcga-blca'}	{'IDC', 'TCIA'}	36
-MG. Mammo Digital Screening Bilateral	{'MG'}	{'ACRdart-EA1141Restricted', 'IDC-IDC_ea1141'}	{'ACRdart', 'IDC'}	36
-CT ABD PELVIS(WITH CHEST IMAGES) WO IV CON	{'CT', nan}	{'MIDRC-TCIA-COVID-19-NY-SBU', 'IDC-IDC_covid_19_ny_sbu', 'TCIA-covid-19-ny-sbu'}	{'IDC', 'TCIA', 'MIDRC'}	36
-PET IMAGE W/CT, SKULL-	{'SEG', 'PT', nan}	{'IDC-IDC_nsclc_radiogenomics', 'TCIA-nsclc-radiogenomics'}	{'IDC', 'TCIA'}	36
-CT THORAX WO IV CONTRA	{'CT', 'SEG', nan}	{'TCIA-lidc-idri', 'IDC-IDC_lidc_idri'}	{'IDC', 'TCIA'}	36
-FDG PET CT Clinical Wh	{'SEG', nan}	{'IDC-IDC_nsclc_radiogenomics', 'TCIA-nsclc-radiogenomics'}	{'IDC', 'TCIA'}	36
-WB PET/CT	{'CT', 'SEG', 'PT', nan}	{'TCIA-tcga-lusc', 'IDC-IDC_tcga_lusc', 'TCIA-acrin-nsclc-fdg-pet', 'IDC-IDC_acrin_nsclc_fdg_pet'}	{'IDC', 'TCIA'}	36
-CT ANGIO ABD AND PEL WWO IV CONT	{'CT', nan}	{'MIDRC-TCIA-COVID-19-NY-SBU', 'IDC-IDC_covid_19_ny_sbu', 'TCIA-covid-19-ny-sbu'}	{'IDC', 'TCIA', 'MIDRC'}	36
-Thorax^DE_CHEST_PE (Adult)	{'CT'}	{'MIDRC-Open-A1'}	{'MIDRC'}	36
-abdomen__w_and_wo	{'SEG', nan}	{'TCIA-c4kc-kits', 'IDC-IDC_c4kc_kits'}	{'IDC', 'TCIA'}	36
-TOMOSYNTHESIS MAMMO DIGITAL SCREENING BILATERAL	{'MG'}	{'ACRdart-EA1141Restricted', 'IDC-IDC_ea1141'}	{'ACRdart', 'IDC'}	36
-Abdomen^7MCV_VIRTUAL_COLONOSCOPY	{'CT', nan}	{'TCIA-ct-colonography', 'IDC-IDC_ct_colonography'}	{'IDC', 'TCIA'}	36
-PET/CT WHOLE BODY	{'CT', 'SEG', 'PT', nan}	{'IDC-IDC_cmb_mel', 'IDC-IDC_nsclc_radiogenomics', 'TCIA-nsclc-radiogenomics', 'TCIA-cmb-mel', 'IDC-IDC_acrin_nsclc_fdg_pet', 'TCIA-acrin-nsclc-fdg-pet'}	{'IDC', 'TCIA'}	36
-MR prostaat detectie PCMAPS_mc MCAPCMAPS	{'MR', 'SEG', nan}	{'TCIA-prostatex', 'IDC-IDC_prostate_3t', 'TCIA-prostate-3t', 'IDC-IDC_prostatex'}	{'IDC', 'TCIA'}	36
-MAM MAMMOGRAPHY SCREENING WITH TOMOSYNTHESIS BILATERAL	{'MG'}	{'ACRdart-EA1141Restricted', 'IDC-IDC_ea1141'}	{'ACRdart', 'IDC'}	35
-BREAST	{'US', 'MR', 'SEG', nan}	{'IDC-IDC_ea1141', 'IDC-IDC_duke_breast_cancer_mri', 'ACRdart-ACRIN_6666', 'TCIA-qin-breast', 'TCIA-duke-breast-cancer-mri', 'IDC-IDC_qin_breast'}	{'IDC', 'TCIA', 'ACRdart'}	35
-CT CHEST W/O	{'CT', 'SEG', nan}	{'IDC-IDC_nsclc_radiogenomics', 'IDC-IDC_acrin_nsclc_fdg_pet', 'TCIA-nsclc-radiogenomics', 'TCIA-acrin-nsclc-fdg-pet', 'MIDRC-Open-R1'}	{'IDC', 'TCIA', 'MIDRC'}	35
-CT, ABDOMEN W&W/O CONT	{'CT', 'SEG', nan}	{'IDC-IDC_hcc_tace_seg', 'TCIA-hcc-tace-seg', 'IDC-IDC_acrin_nsclc_fdg_pet', 'TCIA-tcga-kirc', 'TCIA-acrin-nsclc-fdg-pet', 'IDC-IDC_tcga_blca', 'IDC-IDC_tcga_kirc', 'TCIA-tcga-blca'}	{'IDC', 'TCIA'}	34
-BREAST^EA1141 RESEARCH STUDY	{'MR'}	{'ACRdart-EA1141Restricted', 'IDC-IDC_ea1141'}	{'ACRdart', 'IDC'}	34
-Thorax^CT_CHEST_WITH (Adult)	{'CT'}	{'MIDRC-Open-A1'}	{'MIDRC'}	34
-CT ABDOMEN AND PELVIS	{'RTSTRUCT', 'CT', 'SEG', nan}	{'TCIA-cptac-pda', 'IDC-IDC_cptac_pda', 'IDC-IDC_adrenal_acc_ki67_seg', 'TCIA-cptac-ccrcc', 'IDC-IDC_cptac_ccrcc', 'MIDRC-Open-A1_PETAL_REDCORAL', 'TCIA-adrenal-acc-ki67-seg', 'TCIA-cptac-ucec', 'MIDRC-Open-A1_PETAL_BLUECORAL', 'IDC-IDC_cptac_ucec'}	{'IDC', 'TCIA', 'MIDRC'}	34
-MRM/6667	{'MR', nan}	{'IDC-IDC_acrin_contralateral_breast_mr', 'TCIA-acrin-contralateral-breast-mr'}	{'IDC', 'TCIA'}	34
-CT ABDOMEN & PELVIS ENHANCED=AB	{'RTSTRUCT', 'CT', nan}	{'TCIA-cptac-pda', 'IDC-IDC_cptac_pda'}	{'IDC', 'TCIA'}	34
-X-RAY ABDOMEN SINGLE VIEW	{'CR', 'DX'}	{'MIDRC-Open-A1'}	{'MIDRC'}	34
-CT LEVEL CHEST ABDOMEN PELVIS W ED	{'CT'}	{'MIDRC-Open-A1'}	{'MIDRC'}	34
-CT AB/PEL W/ CONTRAST	{'CT', 'SEG', nan}	{'IDC-IDC_tcga_ov', 'IDC-IDC_tcga_blca', 'TCIA-colorectal-liver-metastases', 'TCIA-tcga-kirc', 'TCIA-tcga-ov', 'IDC-IDC_colorectal_liver_metastases', 'IDC-IDC_tcga_kirc', 'TCIA-tcga-blca'}	{'IDC', 'TCIA'}	34
-CT ABD PELVIS(WITH CHEST IMAGES) W IV CON	{'CT', nan}	{'MIDRC-TCIA-COVID-19-NY-SBU', 'IDC-IDC_covid_19_ny_sbu', 'TCIA-covid-19-ny-sbu'}	{'IDC', 'TCIA', 'MIDRC'}	33
-Vascular^CTA_HEAD_NECK (Adult)	{'CT'}	{'MIDRC-Open-A1'}	{'MIDRC'}	33
-MR BREAST BILATERAL W/WO CONT	{nan}	{'TCIA-tcga-brca'}	{'TCIA'}	33
-CT Angio Pulmonary	{'CT'}	{'MIDRC-Open-A1_PETAL_BLUECORAL', 'MIDRC-Open-A1_PETAL_REDCORAL'}	{'MIDRC'}	33
-ABD SERIES FLAT AND ERECT PORTABLE	{'CR', 'DX', nan}	{'MIDRC-TCIA-COVID-19-NY-SBU', 'IDC-IDC_covid_19_ny_sbu', 'TCIA-covid-19-ny-sbu'}	{'IDC', 'TCIA', 'MIDRC'}	33
-CHEST AP CENTRAL LINE PL PORTABLE	{'CR', nan}	{'MIDRC-TCIA-COVID-19-NY-SBU', 'IDC-IDC_covid_19_ny_sbu', 'TCIA-covid-19-ny-sbu'}	{'IDC', 'TCIA', 'MIDRC'}	33
-Thorax^ROUTINE_CHEST_WO (Adult)	{'CT'}	{'MIDRC-Open-A1'}	{'MIDRC'}	33
-XR LEFT FOOT 3+ VIEWS	{'CR', 'DX'}	{'MIDRC-Open-A1'}	{'MIDRC'}	32
-PET^02_CBM_Wholebody_Only (Adult)	{'CT', 'SEG', 'PT', nan}	{'IDC-IDC_lung_pet_ct_dx', 'TCIA-lung-pet-ct-dx'}	{'IDC', 'TCIA'}	32
-CT Thorax w/Contrast	{'SEG', nan}	{'IDC-IDC_qin_lung_ct', 'TCIA-qin-lung-ct'}	{'IDC', 'TCIA'}	32
-PET^08_Wholebody_Only (Adult)	{'CT', 'SEG', 'PT', nan}	{'IDC-IDC_lung_pet_ct_dx', 'TCIA-lung-pet-ct-dx'}	{'IDC', 'TCIA'}	32
-XR CERVICAL SPINE 2-3 VIEWS	{'CR', 'DX'}	{'MIDRC-Open-A1'}	{'MIDRC'}	32
-PET^CCF_WholeBody_PETCT (Adult)	{'CT', 'SEG', 'PT', nan}	{'TCIA-acrin-nsclc-fdg-pet', 'IDC-IDC_acrin_nsclc_fdg_pet'}	{'IDC', 'TCIA'}	32
-Outside Read or Comparison BODY CT	{'CT', 'SEG', nan}	{'IDC-IDC_tcga_lusc', 'IDC-IDC_tcga_kirc', 'IDC-IDC_tcga_ov', 'TCIA-tcga-luad', 'TCIA-tcga-lihc', 'TCIA-tcga-kirc', 'TCIA-tcga-ov', 'TCIA-tcga-lusc', 'IDC-IDC_tcga_lihc', 'IDC-IDC_tcga_blca', 'IDC-IDC_tcga_luad', 'TCIA-tcga-blca'}	{'IDC', 'TCIA'}	32
-CT C	{'CT', nan}	{'TCIA-ct-colonography', 'IDC-IDC_ct_colonography'}	{'IDC', 'TCIA'}	32
-PCAMPMRI	{'SEG', nan}	{'IDC-IDC_qin_prostate_repeatability', 'TCIA-qin-prostate-repeatability'}	{'IDC', 'TCIA'}	32
-MAMMO SCREENING TOMOSYNTHESIS - BILATERAL TOMO CC	{'MG'}	{'ACRdart-EA1141Restricted', 'IDC-IDC_ea1141'}	{'ACRdart', 'IDC'}	31
-Screening Mammogram Bilateral W Tomo	{'MG'}	{'ACRdart-EA1141Restricted', 'IDC-IDC_ea1141'}	{'ACRdart', 'IDC'}	31
-MRI LUMBAR SPINE W/O CONTRAST	{'MR'}	{'MIDRC-Open-A1'}	{'MIDRC'}	31
-<NONE>	{'CR', 'DX', 'MR'}	{'MIDRC-Open-A1'}	{'MIDRC'}	31
-BR DBT Screening Mammography-Digital	{'MG'}	{'ACRdart-EA1141Restricted', 'IDC-IDC_ea1141'}	{'ACRdart', 'IDC'}	31
-PET/CT NSCLC RESTAGING	{'SEG', nan}	{'TCIA-acrin-nsclc-fdg-pet', 'IDC-IDC_acrin_nsclc_fdg_pet'}	{'IDC', 'TCIA'}	30
-CT Chest with	{'CT', nan}	{'IDC-IDC_tcga_ov', 'IDC-IDC_acrin_nsclc_fdg_pet', 'TCIA-tcga-ov', 'TCIA-acrin-nsclc-fdg-pet', 'IDC-IDC_tcga_ucec', 'TCIA-tcga-ucec'}	{'IDC', 'TCIA'}	30
-BR MRI BREAST, BILATERAL W/O-W CONTRAST	{'MR'}	{'ACRdart-EA1141Restricted', 'IDC-IDC_ea1141'}	{'ACRdart', 'IDC'}	30
-CT ANGIO CHEST W&W/O C	{'CT', 'SEG', nan}	{'TCIA-lidc-idri', 'TCIA-rider-pilot', 'IDC-IDC_lidc_idri', 'IDC-IDC_rider_pilot'}	{'IDC', 'TCIA'}	30
-K9 BRAIN	{'MR', nan}	{'IDC-IDC_icdc_glioma', 'TCIA-icdc-glioma'}	{'IDC', 'TCIA'}	30
-BREAST^ROUTINE_DYNAMICS	{'MR', 'SEG', nan}	{'TCIA-duke-breast-cancer-mri', 'IDC-IDC_duke_breast_cancer_mri'}	{'IDC', 'TCIA'}	30
-CT ABDOMEN/PELVIS WITHOUT CONTRAST	{'CT'}	{'MIDRC-Open-A1_PETAL_BLUECORAL', 'MIDRC-Open-R1', 'MIDRC-Open-A1_PETAL_REDCORAL'}	{'MIDRC'}	30
-HEAD^SMALL ANIMAL	{'MR', nan}	{'IDC-IDC_icdc_glioma', 'TCIA-icdc-glioma'}	{'IDC', 'TCIA'}	30
-BILAT/ATTN LEFT	{'MR', nan}	{'IDC-IDC_acrin_contralateral_breast_mr', 'TCIA-acrin-contralateral-breast-mr'}	{'IDC', 'TCIA'}	30
-MRI Abdomen	{'MR', nan}	{'TCIA-cmb-crc', 'IDC-IDC_cmb_crc', 'TCIA-tcga-kirc', 'TCIA-cmb-lca', 'IDC-IDC_tcga_kich', 'TCIA-tcga-kirp', 'IDC-IDC_tcga_kirp', 'TCIA-tcga-kich', 'IDC-IDC_tcga_kirc', 'IDC-IDC_cmb_lca'}	{'IDC', 'TCIA'}	30
-MR BREAST WO/W CONT	{'MR', 'SEG', nan}	{'IDC-IDC_acrin_contralateral_breast_mr', 'IDC-IDC_ispy1', 'TCIA-acrin-contralateral-breast-mr'}	{'IDC', 'TCIA'}	30
-F-18 FDG PETWhole Bod	{'SEG', 'PT', nan}	{'TCIA-acrin-nsclc-fdg-pet', 'IDC-IDC_acrin_nsclc_fdg_pet'}	{'IDC', 'TCIA'}	30
-PT CT WHOLE BODY-BODY	{'SEG', 'PT', nan}	{'TCIA-acrin-nsclc-fdg-pet', 'IDC-IDC_acrin_nsclc_fdg_pet'}	{'IDC', 'TCIA'}	30
-*MRI - ABDOMEN	{'MR', nan}	{'TCIA-tcga-lihc', 'TCIA-tcga-kirc', 'IDC-IDC_tcga_kirc', 'IDC-IDC_tcga_lihc'}	{'IDC', 'TCIA'}	30
-F-18 FDG PET(Whole Bod	{'CT', 'SEG', 'PT', nan}	{'TCIA-acrin-nsclc-fdg-pet', 'IDC-IDC_acrin_nsclc_fdg_pet'}	{'IDC', 'TCIA'}	30
-Lung	{'SEG', 'PT', nan}	{'TCIA-acrin-nsclc-fdg-pet', 'IDC-IDC_acrin_nsclc_fdg_pet'}	{'IDC', 'TCIA'}	30
-Abdomen^1WBPETCT	{'SEG', 'PT', nan}	{'IDC-IDC_tcga_prad', 'TCIA-tcga-prad', 'TCIA-acrin-nsclc-fdg-pet', 'IDC-IDC_acrin_nsclc_fdg_pet'}	{'IDC', 'TCIA'}	30
-CONTRABREAST (RIGHT)	{'MR', nan}	{'IDC-IDC_acrin_contralateral_breast_mr', 'TCIA-acrin-contralateral-breast-mr'}	{'IDC', 'TCIA'}	30
-^BRAIN RESEARCH	{'MR', 'SEG', nan}	{'IDC-IDC_upenn_gbm', 'TCIA-upenn-gbm'}	{'IDC', 'TCIA'}	30
-DPCXR	{'DX'}	{'MIDRC-Open-A1_PETAL_BLUECORAL', 'MIDRC-Open-A1_PETAL_REDCORAL'}	{'MIDRC'}	29
-XR RIGHT FOOT 3+ VIEWS	{'CR', 'DX'}	{'MIDRC-Open-A1'}	{'MIDRC'}	29
-AS AI	{'CT', nan}	{'TCIA-tcga-stad', 'IDC-IDC_tcga_blca', 'IDC-IDC_tcga_stad', 'TCIA-tcga-blca'}	{'IDC', 'TCIA'}	29
-BREAST^LESION EVALUATION	{'MR'}	{'ACRdart-EA1141Restricted', 'IDC-IDC_ea1141'}	{'ACRdart', 'IDC'}	29
-Thorax^CHEST_WITH_GR (Adult)	{'CT'}	{'MIDRC-Open-A1'}	{'MIDRC'}	29
-CT THORAX W/DYE	{'SEG', nan}	{'TCIA-varepop-apollo', 'IDC-IDC_nsclc_radiogenomics', 'TCIA-nsclc-radiogenomics'}	{'IDC', 'TCIA'}	29
-ECOG-ACRIN^ECOG-ACRIN	{'MR'}	{'ACRdart-EA1141Restricted', 'IDC-IDC_ea1141'}	{'ACRdart', 'IDC'}	29
-BR MRI BREAST BILATERAL WITH CONTRAST FULL PROTOCOL	{'MR'}	{'ACRdart-EA1141Restricted', 'IDC-IDC_ea1141'}	{'ACRdart', 'IDC'}	29
-PET/CT Sk-Th	{'CT', 'SEG', nan}	{'IDC-IDC_acrin_nsclc_fdg_pet', 'TCIA-acrin-nsclc-fdg-pet', 'TCIA-tcga-ucec', 'IDC-IDC_tcga_ucec'}	{'IDC', 'TCIA'}	28
-MR ABDOMEN W/WO CONTRAST	{'MR', 'SEG', nan}	{'TCIA-tcga-lihc', 'TCIA-tcga-kirc', 'TCIA-tcga-kirp', 'IDC-IDC_tcga_lihc', 'IDC-IDC_tcga_kirp', 'IDC-IDC_tcga_kirc'}	{'IDC', 'TCIA'}	28
-*CT Chest,Abdomen,Pelv	{'CT', nan}	{'IDC-IDC_tcga_ov', 'TCIA-tcga-lihc', 'TCIA-tcga-kirc', 'TCIA-tcga-ov', 'IDC-IDC_tcga_lihc', 'IDC-IDC_tcga_ucec', 'IDC-IDC_tcga_kirc', 'TCIA-tcga-ucec'}	{'IDC', 'TCIA'}	28
-BRAIN BRAIN	{'MR', 'SEG', nan}	{'IDC-IDC_upenn_gbm', 'TCIA-upenn-gbm'}	{'IDC', 'TCIA'}	28
-BRAIN	{'MR', nan}	{'IDC-IDC_icdc_glioma', 'TCIA-icdc-glioma'}	{'IDC', 'TCIA'}	28
-BREAST^GENERAL	{'MR', 'SEG', nan}	{'TCIA-duke-breast-cancer-mri', 'IDC-IDC_duke_breast_cancer_mri'}	{'IDC', 'TCIA'}	28
-CT CHEST W/O CONT-DESC	{'SEG', nan}	{'IDC-IDC_nsclc_radiogenomics', 'TCIA-nsclc-radiogenomics'}	{'IDC', 'TCIA'}	28
-CT Chest Reference Only	{'CT', 'SEG', nan}	{'IDC-IDC_nsclc_radiogenomics', 'TCIA-nsclc-radiogenomics'}	{'IDC', 'TCIA'}	28
-RM CHEST 1 VIEW PORTABLE	{'DX'}	{'MIDRC-Open-A1_PETAL_BLUECORAL', 'MIDRC-Open-A1_PETAL_REDCORAL'}	{'MIDRC'}	28
-CT NON-INFUSED CHEST	{'SEG', nan}	{'IDC-IDC_spie_aapm_lung_ct_challenge', 'TCIA-spie-aapm-lung-ct-challenge'}	{'IDC', 'TCIA'}	28
-CT ABDOMEN NONENH & ENHANCED=AB	{'RTSTRUCT', nan}	{'TCIA-cptac-pda', 'IDC-IDC_cptac_pda'}	{'IDC', 'TCIA'}	28
-PET/CT SKULL BASE TO M	{'CT', 'SEG', 'PT', nan}	{'TCIA-acrin-nsclc-fdg-pet', 'IDC-IDC_acrin_nsclc_fdg_pet'}	{'IDC', 'TCIA'}	28
-Abdomen^01_WB_PETCT	{'SEG', nan}	{'TCIA-acrin-nsclc-fdg-pet', 'IDC-IDC_acrin_nsclc_fdg_pet'}	{'IDC', 'TCIA'}	28
-BREAST W/WO	{'MR', nan}	{'IDC-IDC_acrin_contralateral_breast_mr', 'TCIA-acrin-contralateral-breast-mr'}	{'IDC', 'TCIA'}	28
-XR LUMBAR SPINE 2-3 VIEWS	{'CR', 'DX'}	{'MIDRC-Open-A1', 'MIDRC-Open-R1'}	{'MIDRC'}	28
-Abdomen^1 AP ROUTINE	{'CT', nan}	{'IDC-IDC_tcga_ov', 'TCIA-tcga-kirc', 'TCIA-tcga-ov', 'IDC-IDC_tcga_ucec', 'IDC-IDC_tcga_kirc', 'TCIA-tcga-ucec'}	{'IDC', 'TCIA'}	28
-_t3of3  MRI IAMS	{'MR', nan}	{'IDC-IDC_vestibular_schwannoma_mc_rc', 'TCIA-vestibular-schwannoma-mc-rc'}	{'IDC', 'TCIA'}	28
-CT ANGIOGRAPHY NECK	{'CT'}	{'MIDRC-Open-A1'}	{'MIDRC'}	27
-CT Angio Chest	{'CT'}	{'MIDRC-Open-A1_PETAL_BLUECORAL', 'MIDRC-Open-R1', 'MIDRC-Open-A1_PETAL_REDCORAL'}	{'MIDRC'}	27
-Head^HEAD_ROUTINE (Adult)	{'CT'}	{'MIDRC-Open-A1'}	{'MIDRC'}	27
-MAMMO 3D TOMO SCREENING BILATERAL	{'MG'}	{'ACRdart-EA1141Restricted', 'IDC-IDC_ea1141'}	{'ACRdart', 'IDC'}	27
-Abdomen^1_ROUTINE_CAP_WO (Adult)	{'CT'}	{'MIDRC-Open-A1'}	{'MIDRC'}	27
-MAMMO SCREENING BILATERAL TOMOSYNTHESIS	{'MG'}	{'ACRdart-EA1141Restricted', 'IDC-IDC_ea1141'}	{'ACRdart', 'IDC'}	27
-HIGH RES CHEST(Adult)	{'CT'}	{'MIDRC-Open-A1'}	{'MIDRC'}	27
-Vascular^CTA_PE_GR (Adult)	{'CT'}	{'MIDRC-Open-A1'}	{'MIDRC'}	27
-Study De-Identified for Patient Confidentiality	{'US', 'CT', nan}	{'ACRdart-ACRIN_6666', 'TCIA-acrin-nsclc-fdg-pet', 'IDC-IDC_acrin_nsclc_fdg_pet'}	{'ACRdart', 'TCIA', 'IDC'}	27
-XR LEFT SHOULDER 2+ VIEWS	{'CR', 'DX'}	{'MIDRC-Open-A1'}	{'MIDRC'}	27
-MAMMO SCREEN BILAT/TOMO/CAD	{'MG'}	{'ACRdart-EA1141Restricted', 'IDC-IDC_ea1141'}	{'ACRdart', 'IDC'}	26
-abdomen_pelvis__w_and_wo	{'SEG', nan}	{'TCIA-c4kc-kits', 'IDC-IDC_c4kc_kits'}	{'IDC', 'TCIA'}	26
-CT THORAX W/O CONTRAST	{'CT', 'SEG', nan}	{'TCIA-tcga-kirc', 'TCIA-lidc-idri', 'IDC-IDC_lidc_idri', 'IDC-IDC_tcga_ucec', 'IDC-IDC_tcga_blca', 'IDC-IDC_tcga_kirc', 'TCIA-tcga-ucec', 'TCIA-tcga-blca'}	{'IDC', 'TCIA'}	26
-BRAIN^HEAD	{'MR', 'SEG', nan}	{'IDC-IDC_upenn_gbm', 'TCIA-upenn-gbm'}	{'IDC', 'TCIA'}	26
-MR HEAD W AND WO IV CONTRAST FOLLOWUP WITH PERFUSION PERMEABILIT	{'MR', 'SEG', nan}	{'IDC-IDC_upenn_gbm', 'TCIA-upenn-gbm'}	{'IDC', 'TCIA'}	26
-CT COLONOGRAPHY	{'CT', nan}	{'TCIA-ct-colonography', 'IDC-IDC_ct_colonography'}	{'IDC', 'TCIA'}	26
-CT BRAIN WITHOUT CONTRAST	{'CT'}	{'MIDRC-Open-R1'}	{'MIDRC'}	26
-CT SCREENING VIRT COLONOSCOPY	{'CT', nan}	{'TCIA-ct-colonography', 'IDC-IDC_ct_colonography'}	{'IDC', 'TCIA'}	26
-PET/CT LUNG CA	{'SEG', nan}	{'IDC-IDC_nsclc_radiogenomics', 'TCIA-nsclc-radiogenomics'}	{'IDC', 'TCIA'}	26
-MRI BREAST RESEARCH BILAT WO/W CONTRAST	{'MR'}	{'ACRdart-EA1141Restricted', 'IDC-IDC_ea1141'}	{'ACRdart', 'IDC'}	26
-PROSTATE	{'CT', 'MR', nan}	{'IDC-IDC_tcga_prad', 'TCIA-tcga-prad', 'IDC-IDC_pelvic_reference_data', 'TCIA-pelvic-reference-data'}	{'IDC', 'TCIA'}	26
-PET^NEW_03_CBM_Wholebody_First_Head (Adult)	{'CT', 'SEG', nan}	{'IDC-IDC_lung_pet_ct_dx', 'TCIA-lung-pet-ct-dx'}	{'IDC', 'TCIA'}	26
-CT Rad Onc Lmtd.	{'CT', nan}	{'TCIA-tcga-ucec', 'IDC-IDC_tcga_ucec'}	{'IDC', 'TCIA'}	26
-XRAY-MAMMOGRAM SCREENING TOMO	{'MG'}	{'ACRdart-EA1141Restricted', 'IDC-IDC_ea1141'}	{'ACRdart', 'IDC'}	25
-CT ANGIO CHEST (NON-CO	{'SEG', nan}	{'TCIA-lidc-idri', 'IDC-IDC_lidc_idri', 'TCIA-rider-pilot'}	{'IDC', 'TCIA'}	25
-XR RIGHT ANKLE 3+ VIEWS	{'CR', 'DX'}	{'MIDRC-Open-A1'}	{'MIDRC'}	25
-MRI RESEARCH GRANT	{'MR', 'SEG'}	{'IDC-IDC_ispy1'}	{'IDC'}	25
-MR prostaat kanker detectie ND_mc MCAPRODETN	{'MR', 'SEG', nan}	{'TCIA-prostatex', 'IDC-IDC_prostate_3t', 'TCIA-prostate-3t', 'IDC-IDC_prostatex'}	{'IDC', 'TCIA'}	24
-CTA CHEST PULMONARY AN	{'CT'}	{'MIDRC-Open-R1'}	{'MIDRC'}	24
-MRI^BREAST	{'MR'}	{'ACRdart-EA1141Restricted', 'IDC-IDC_ea1141'}	{'ACRdart', 'IDC'}	24
-CT ANGIO ABD WITH PEL	{'SEG', nan}	{'TCIA-colorectal-liver-metastases', 'IDC-IDC_colorectal_liver_metastases'}	{'IDC', 'TCIA'}	24
-Abdomen^01_AP_Routine (Adult)	{'CT', nan}	{'IDC-IDC_tcga_ov', 'TCIA-tcga-kirc', 'TCIA-tcga-ov', 'IDC-IDC_tcga_ucec', 'IDC-IDC_tcga_kirc', 'TCIA-tcga-ucec'}	{'IDC', 'TCIA'}	24
-CT CHEST CONTRAST	{'CT', nan}	{'TCIA-acrin-nsclc-fdg-pet', 'IDC-IDC_acrin_nsclc_fdg_pet'}	{'IDC', 'TCIA'}	24
-Thorax^02_CAP_Routine (Adult)	{'CT', nan}	{'TCIA-tcga-kirc', 'TCIA-tcga-ov', 'IDC-IDC_tcga_kirc', 'IDC-IDC_tcga_ov'}	{'IDC', 'TCIA'}	24
-CT ABDOMEN w	{'CT', 'SEG', nan}	{'TCIA-tcga-lihc', 'TCIA-tcga-kirc', 'IDC-IDC_tcga_kirc', 'IDC-IDC_tcga_lihc'}	{'IDC', 'TCIA'}	24
-PET^07_PThead_lung (Adult)	{'CT', nan}	{'IDC-IDC_lung_pet_ct_dx', 'TCIA-lung-pet-ct-dx'}	{'IDC', 'TCIA'}	24
-CTA CHEST PULMONARY EMBOLUS W/IVCON	{'CT'}	{'MIDRC-Open-A1_PETAL_BLUECORAL'}	{'MIDRC'}	24
-SCREENING MAMMOGRAM WITH TOMOSYNTHESIS	{'MG'}	{'ACRdart-EA1141Restricted', 'IDC-IDC_ea1141'}	{'ACRdart', 'IDC'}	24
-CHEST 1 VIEW (INCLUDING PORTABLE)	{'CR'}	{'MIDRC-Open-R1'}	{'MIDRC'}	24
-CT Chest with contrast	{'CT', nan}	{'TCIA-tcga-lusc', 'IDC-IDC_tcga_lusc', 'TCIA-acrin-nsclc-fdg-pet', 'IDC-IDC_acrin_nsclc_fdg_pet'}	{'IDC', 'TCIA'}	24
-Abdomen^DE_ROUTINE_AP_WITH_OVER_50_Customized (Adult)	{'CT'}	{'MIDRC-Open-A1'}	{'MIDRC'}	24
-MAMMOGRAM DIGITAL SCREENING BILATERAL W/TOMO	{'MG'}	{'ACRdart-EA1141Restricted', 'IDC-IDC_ea1141'}	{'ACRdart', 'IDC'}	24
-Chest CT routine	{'CT', nan}	{'TCIA-acrin-nsclc-fdg-pet', 'IDC-IDC_acrin_nsclc_fdg_pet'}	{'IDC', 'TCIA'}	24
-ABDOMEN	{'CT', 'MR', nan}	{'TCIA-cptac-pda', 'IDC-IDC_cptac_pda', 'IDC-IDC_pancreatic_ct_cbct_seg', 'TCIA-tcga-lihc', 'TCIA-tcga-kirc', 'TCIA-pancreatic-ct-cbct-seg', 'TCIA-cptac-sar', 'IDC-IDC_ctpred_sunitinib_pannet', 'IDC-IDC_tcga_lihc', 'TCIA-ctpred-sunitinib-pannet', 'IDC-IDC_cptac_sar', 'IDC-IDC_tcga_kirc'}	{'IDC', 'TCIA'}	24
-CT COLONOSCOPY	{'CT', nan}	{'TCIA-ct-colonography', 'IDC-IDC_ct_colonography'}	{'IDC', 'TCIA'}	24
-Thorax^ROUTINE_CHEST_ABD_PELVIS_W (Adult)	{'CT'}	{'MIDRC-Open-A1'}	{'MIDRC'}	24
-CT CHEST W/ CONT	{'CT', 'SEG', nan}	{'IDC-IDC_acrin_nsclc_fdg_pet', 'TCIA-rider-pilot', 'TCIA-lidc-idri', 'TCIA-acrin-nsclc-fdg-pet', 'IDC-IDC_lidc_idri', 'IDC-IDC_rider_pilot'}	{'IDC', 'TCIA'}	24
-BREAST^ROUTINE CA	{'MR', 'SEG', nan}	{'TCIA-duke-breast-cancer-mri', 'IDC-IDC_duke_breast_cancer_mri'}	{'IDC', 'TCIA'}	24
-MAMMO DIAGNOSTIC BREAST TOMOSYNTHESIS BILATERAL	{'MG', nan}	{'TCIA-breast-cancer-screening-dbt', 'IDC-IDC_breast_cancer_screening_dbt'}	{'IDC', 'TCIA'}	24
-Thorax^C_A_P_WITH_GR (Adult)	{'CT'}	{'MIDRC-Open-A1'}	{'MIDRC'}	23
-Thorax^FLASH_CHEST_WITH_ (Adult)	{'CT'}	{'MIDRC-Open-A1'}	{'MIDRC'}	23
-Abdomen^ABD_WITH_GR (Adult)	{'CT'}	{'MIDRC-Open-A1'}	{'MIDRC'}	23
-MRI BREAST BILAT CAD WWO	{'MR', nan}	{'ACRdart-EA1141Restricted', 'TCIA-tcga-brca', 'IDC-IDC_tcga_brca'}	{'ACRdart', 'TCIA', 'IDC'}	23
-LEFT BREAST	{'MR', 'SEG', nan}	{'IDC-IDC_acrin_contralateral_breast_mr', 'IDC-IDC_ispy1', 'TCIA-acrin-contralateral-breast-mr'}	{'IDC', 'TCIA'}	23
-Thorax^CHEST_ABD_PELVIS_W (Adult)	{'CT'}	{'MIDRC-Open-A1'}	{'MIDRC'}	23
-CT CHEST PE WITH CONTRAST	{'CT'}	{'MIDRC-Open-A1_PETAL_BLUECORAL', 'MIDRC-Open-A1_PETAL_REDCORAL'}	{'MIDRC'}	23
-DX CXR 1 View-Post Procedure	{'CR', 'DX'}	{'MIDRC-Open-A1_PETAL_REDCORAL'}	{'MIDRC'}	23
-MRI Breast w/ + w/o Contrast Bil Abbrev	{'MR'}	{'ACRdart-EA1141Restricted', 'IDC-IDC_ea1141'}	{'ACRdart', 'IDC'}	23
-PELVIS	{'RTSTRUCT', 'CT', nan}	{'TCIA-pelvic-reference-data', 'IDC-IDC_tcga_ov', 'TCIA-pancreatic-ct-cbct-seg', 'TCIA-tcga-ov', 'IDC-IDC_pancreatic_ct_cbct_seg', 'IDC-IDC_pelvic_reference_data'}	{'IDC', 'TCIA'}	22
-CHEST PA - LAT	{'CR', 'DX', nan}	{'TCIA-lidc-idri', 'IDC-IDC_lidc_idri'}	{'IDC', 'TCIA'}	22
-Chest 1V	{'CR'}	{'MIDRC-Open-A1'}	{'MIDRC'}	22
-CHEST PE(Adult)	{'CT'}	{'MIDRC-Open-A1'}	{'MIDRC'}	22
-BREAST^ECOG-ACRIN	{'MR'}	{'ACRdart-EA1141Restricted', 'IDC-IDC_ea1141'}	{'ACRdart', 'IDC'}	22
-Abdomen^2_ROUTINE_AP (Adult)	{'CT'}	{'MIDRC-Open-A1'}	{'MIDRC'}	22
-ABDOMEN 1 VIEW	{'CR', 'DX'}	{'MIDRC-Open-R1', 'MIDRC-Open-A1_PETAL_REDCORAL'}	{'MIDRC'}	22
-CH+C	{'SEG', nan}	{'IDC-IDC_lung_pet_ct_dx', 'TCIA-lung-pet-ct-dx'}	{'IDC', 'TCIA'}	22
-WI-MR BREAST BILAT W+WO	{'MR'}	{'IDC-IDC_ea1141'}	{'IDC'}	22
-MR BRAIN WITH AND WITHOUT CONTRAST	{'MR'}	{'MIDRC-Open-R1'}	{'MIDRC'}	22
-CONTRABREAST (LEFT)	{'MR', nan}	{'IDC-IDC_acrin_contralateral_breast_mr', 'TCIA-acrin-contralateral-breast-mr'}	{'IDC', 'TCIA'}	22
-Vascular^DISSECTION_CTA_CAP (Adult)	{'CT'}	{'MIDRC-Open-A1'}	{'MIDRC'}	22
-XR LEFT HAND 3+ VIEWS	{'CR', 'DX'}	{'MIDRC-Open-A1'}	{'MIDRC'}	22
-CT ABD PELV EN	{'CT', nan}	{'TCIA-tcga-ov', 'IDC-IDC_tcga_ov'}	{'IDC', 'TCIA'}	22
-BILAT/ATTN RIGHT	{'MR', nan}	{'IDC-IDC_acrin_contralateral_breast_mr', 'TCIA-acrin-contralateral-breast-mr'}	{'IDC', 'TCIA'}	22
-MR SPINE LUMBAR WO CONTRAST	{'MR'}	{'MIDRC-Open-A1'}	{'MIDRC'}	22
-CT CHEST ABD PELVIS W/ CONTR	{'CT', nan}	{'IDC-IDC_tcga_sarc', 'IDC-IDC_tcga_lusc', 'TCIA-tcga-coad', 'IDC-IDC_tcga_coad', 'TCIA-tcga-sarc', 'TCIA-tcga-lusc', 'TCIA-tcga-kirc', 'IDC-IDC_tcga_kirc'}	{'IDC', 'TCIA'}	22
-PROTOCOLS^BREAST	{'MR', nan}	{'IDC-IDC_acrin_contralateral_breast_mr', 'TCIA-acrin-contralateral-breast-mr'}	{'IDC', 'TCIA'}	22
-Outside Read or Comparison MRI	{'MR', nan}	{'TCIA-tcga-lihc', 'TCIA-tcga-kirc', 'TCIA-tcga-kirp', 'IDC-IDC_tcga_lihc', 'IDC-IDC_tcga_kirp', 'IDC-IDC_tcga_kirc'}	{'IDC', 'TCIA'}	22
-CT ABDOMEN WITH CONTRA	{'CT', 'SEG', nan}	{'IDC-IDC_tcga_ov', 'TCIA-cptac-ccrcc', 'IDC-IDC_cptac_ccrcc', 'TCIA-tcga-kirc', 'TCIA-tcga-ov', 'IDC-IDC_tcga_kirc'}	{'IDC', 'TCIA'}	22
-Abdomen^CT_UROGRAM_STONE_STUDY (Adult)	{'CT'}	{'MIDRC-Open-A1'}	{'MIDRC'}	22
-CT UROGRAM	{'CT', nan}	{'TCIA-pseudo-phi-dicom-data', 'TCIA-tcga-kirc', 'IDC-IDC_pseudo_phi_dicom_data', 'MIDRC-Open-R1', 'IDC-IDC_tcga_blca', 'IDC-IDC_tcga_kirc', 'TCIA-tcga-blca'}	{'IDC', 'TCIA', 'MIDRC'}	22
-PET CT SKULL BASE TO MID-THIGH	{'CT', 'PT', nan}	{'TCIA-tcga-lusc', 'IDC-IDC_tcga_kirp', 'IDC-IDC_tcga_lusc', 'TCIA-tcga-kirp'}	{'IDC', 'TCIA'}	22
-CT ABDOMEN/PELVIS W IV CONTRAST	{'RTSTRUCT', 'CT', nan}	{'MIDRC-Open-A1', 'TCIA-cptac-pda', 'IDC-IDC_cptac_pda'}	{'IDC', 'TCIA', 'MIDRC'}	22
-LUNG DELAYS	{'SEG', nan}	{'TCIA-acrin-nsclc-fdg-pet', 'IDC-IDC_acrin_nsclc_fdg_pet'}	{'IDC', 'TCIA'}	22
-TX AS AI	{'CT', nan}	{'TCIA-tcga-esca', 'IDC-IDC_tcga_esca', 'TCIA-tcga-stad', 'IDC-IDC_tcga_stad', 'IDC-IDC_tcga_blca', 'TCIA-tcga-blca'}	{'IDC', 'TCIA'}	22
-MRI CLINICAL SPECTROSCOPY - MRSPC	{'MR', 'SEG', nan}	{'IDC-IDC_upenn_gbm', 'TCIA-upenn-gbm'}	{'IDC', 'TCIA'}	22
-CAP_WITH(Adult)	{'CT'}	{'MIDRC-Open-A1'}	{'MIDRC'}	22
-PETCT_WholeBody	{'CT', 'PT', nan}	{'IDC-IDC_cmb_mel', 'IDC-IDC_cmb_mml', 'TCIA-cmb-mml', 'TCIA-cmb-mel'}	{'IDC', 'TCIA'}	22
-SL2 Treatment:Tx Plan	{'CT', nan}	{'IDC-IDC_pelvic_reference_data', 'TCIA-pelvic-reference-data'}	{'IDC', 'TCIA'}	22
-_t2of3  MRI IAMS	{'MR', nan}	{'IDC-IDC_vestibular_schwannoma_mc_rc', 'TCIA-vestibular-schwannoma-mc-rc'}	{'IDC', 'TCIA'}	22
-XR RIGHT SHOULDER 2+ VIEWS	{'CR', 'DX'}	{'MIDRC-Open-A1'}	{'MIDRC'}	21
-X-RAY SHOULDER COMPLETE MIN 2 VIEWS - RIGHT	{'DX'}	{'MIDRC-Open-A1'}	{'MIDRC'}	21
-XR RIGHT KNEE 3 VIEWS (PAIN/ARTHRITIS)	{'CR', 'CR,DX', 'DX'}	{'MIDRC-Open-A1'}	{'MIDRC'}	21
-CT ABDOMEN AND PELVIS W/O CONTRAST	{'CT'}	{'MIDRC-Open-A1'}	{'MIDRC'}	21
-MAMMO SCREEN BILAT+TOMO	{'MG'}	{'ACRdart-EA1141Restricted', 'IDC-IDC_ea1141'}	{'ACRdart', 'IDC'}	21
-XR LEFT KNEE 3 VIEWS (PAIN/ARTHRITIS)	{'CR', 'DX'}	{'MIDRC-Open-A1'}	{'MIDRC'}	21
-X-RAY KNEE 3 VIEWS - RIGHT	{'DX'}	{'MIDRC-Open-A1'}	{'MIDRC'}	21
-CAP	{'CT', 'SEG', nan}	{'IDC-IDC_hcc_tace_seg', 'IDC-IDC_tcga_ov', 'TCIA-hcc-tace-seg', 'TCIA-tcga-ov', 'TCIA-lidc-idri', 'IDC-IDC_lidc_idri', 'MIDRC-Open-R1', 'IDC-IDC_tcga_ucec', 'TCIA-tcga-ucec'}	{'IDC', 'TCIA', 'MIDRC'}	21
-Abdomen^2_ROUTINE_AP_WO (Adult)	{'CT'}	{'MIDRC-Open-A1'}	{'MIDRC'}	21
-CT CHEST REFERENCE ONLY	{'CT', nan}	{'AIMI-COCA', 'IDC-IDC_nsclc_radiogenomics', 'TCIA-nsclc-radiogenomics'}	{'IDC', 'TCIA', 'AIMI'}	21
-NMPET/CT trunk	{'CT', 'PT', nan}	{'TCIA-tcga-ucec', 'IDC-IDC_tcga_ucec'}	{'IDC', 'TCIA'}	20
-Abd	{'US', nan}	{'TCIA-b-mode-and-ceus-liver', 'IDC-IDC_b_mode_and_ceus_liver'}	{'IDC', 'TCIA'}	20
-CT CHEST   W/CONTRAST	{'CT', nan}	{'IDC-IDC_tcga_lusc', 'IDC-IDC_tcga_kirc', 'IDC-IDC_tcga_ov', 'TCIA-tcga-luad', 'TCIA-tcga-lihc', 'TCIA-tcga-kirc', 'TCIA-tcga-ov', 'TCIA-tcga-lusc', 'IDC-IDC_tcga_lihc', 'IDC-IDC_tcga_luad'}	{'IDC', 'TCIA'}	20
-Abdomen^ABDOMEN (Adult)	{'CT', 'SEG', nan}	{'TCIA-spine-mets-ct-seg', 'IDC-IDC_spine_mets_ct_seg'}	{'IDC', 'TCIA'}	20
-BRAIN^FUNCTIONAL	{'MR', 'SEG', nan}	{'IDC-IDC_upenn_gbm', 'TCIA-upenn-gbm'}	{'IDC', 'TCIA'}	20
-CT CHEST W IV CON	{'CT'}	{'MIDRC-Open-R1'}	{'MIDRC'}	20
-CT C-SPINE W/O CONTRAST	{'CT'}	{'MIDRC-Open-A1'}	{'MIDRC'}	20
-CT Dynamic Chest Routi	{'CT', nan}	{'TCIA-acrin-nsclc-fdg-pet', 'IDC-IDC_acrin_nsclc_fdg_pet'}	{'IDC', 'TCIA'}	20
-CT PULMONARY W/CONTRAST	{'CT'}	{'MIDRC-Open-A1_PETAL_BLUECORAL', 'MIDRC-Open-A1_PETAL_REDCORAL'}	{'MIDRC'}	20
-XR RIGHT KNEE 1-2 VIEWS	{'CR', 'DX'}	{'MIDRC-Open-A1'}	{'MIDRC'}	20
-CT chest upper low abdomen and pelvic+c	{'CT', nan}	{'IDC-IDC_ctpred_sunitinib_pannet', 'TCIA-ctpred-sunitinib-pannet'}	{'IDC', 'TCIA'}	20
-XR LEFT WRIST 3+ VIEWS	{'CR', 'DX'}	{'MIDRC-Open-A1'}	{'MIDRC'}	20
-PETCT SKULL-THIGH	{'SEG', 'PT', nan}	{'TCIA-acrin-nsclc-fdg-pet', 'IDC-IDC_acrin_nsclc_fdg_pet'}	{'IDC', 'TCIA'}	20
-DG CHEST 1V PORT	{'CR'}	{'MIDRC-Open-A1_SCCM_VIRUS'}	{'MIDRC'}	20
-TomoHD Screening	{'MG'}	{'ACRdart-EA1141Restricted', 'IDC-IDC_ea1141'}	{'ACRdart', 'IDC'}	20
-LT BREAST	{'MR', nan}	{'IDC-IDC_acrin_contralateral_breast_mr', 'TCIA-acrin-contralateral-breast-mr'}	{'IDC', 'TCIA'}	20
-MM Mammogram Screening Digital DDI	{'MG'}	{'ACRdart-EA1141Restricted', 'IDC-IDC_ea1141'}	{'ACRdart', 'IDC'}	20
-BREAST^ACRIN RESEARCH	{'MR'}	{'ACRdart-EA1141Restricted', 'IDC-IDC_ea1141'}	{'ACRdart', 'IDC'}	20
-BREAST ROUTINE	{'MR', 'SEG', nan}	{'TCIA-duke-breast-cancer-mri', 'IDC-IDC_duke_breast_cancer_mri'}	{'IDC', 'TCIA'}	20
-CT ABD PELVIS W/ CONTRAST	{'OT', 'CT', nan}	{'IDC-IDC_tcga_kirp', 'TCIA-tcga-kirp', 'TCIA-tcga-coad', 'IDC-IDC_tcga_coad'}	{'IDC', 'TCIA'}	20
-PET^02_Wholebody_Only (Adult)	{'CT', 'SEG', 'PT', nan}	{'IDC-IDC_lung_pet_ct_dx', 'TCIA-lung-pet-ct-dx'}	{'IDC', 'TCIA'}	20
-MR BREAST UNI U	{'MR', 'SEG', nan}	{'TCIA-breast-mri-nact-pilot', 'IDC-IDC_ispy1', 'IDC-IDC_breast_mri_nact_pilot'}	{'IDC', 'TCIA'}	20
-Abdomen^ROUTINE_ABD_PEL_WITH (Adult)	{'CT'}	{'MIDRC-Open-A1'}	{'MIDRC'}	20
-RT BREAST	{'MR', nan}	{'IDC-IDC_acrin_contralateral_breast_mr', 'TCIA-acrin-contralateral-breast-mr'}	{'IDC', 'TCIA'}	20
-MR PELVIS WO+W CONTRAST	{nan}	{'TCIA-prostate-mri-us-biopsy'}	{'TCIA'}	20
-PETCT Skull-MidThigh	{'CT', 'PT', nan}	{'TCIA-cmb-crc', 'IDC-IDC_cmb_gec', 'IDC-IDC_cmb_crc', 'TCIA-cmb-lca', 'IDC-IDC_cmb_pca', 'TCIA-cmb-gec', 'IDC-IDC_cmb_lca', 'TCIA-cmb-pca'}	{'IDC', 'TCIA'}	20
-MR HEAD W AND WO IV CONTRAST TUMOR NAVIGATION	{'MR', 'SEG', nan}	{'IDC-IDC_upenn_gbm', 'TCIA-upenn-gbm'}	{'IDC', 'TCIA'}	20
-RESSONANCIA MAGNETICA DE PELVE	{'MR', nan}	{'IDC-IDC_tcga_blca', 'IDC-IDC_tcga_cesc', 'TCIA-tcga-cesc', 'TCIA-tcga-blca'}	{'IDC', 'TCIA'}	20
-Thorax^FLASH_CAP_WITH (Adult)	{'CT'}	{'MIDRC-Open-A1'}	{'MIDRC'}	19
-CT CHEST PULMONARY ANGIOGRAM (ACUTE)	{'CT'}	{'MIDRC-Open-A1_PETAL_BLUECORAL', 'MIDRC-Open-A1_PETAL_REDCORAL'}	{'MIDRC'}	19
-CT P CHEST ABDOMEN PELVIS W	{'CT'}	{'MIDRC-Open-A1', 'MIDRC-Open-R1'}	{'MIDRC'}	19
-CT CHEST WO CONTRAST (LOW DOSE FOR NODULE FOLLOW UP)	{'CT'}	{'MIDRC-Open-A1'}	{'MIDRC'}	19
-CT CHEST WITHOUT CONTR	{'RTSTRUCT', 'CT', 'SEG', nan}	{'TCIA-cptac-pda', 'IDC-IDC_cptac_pda', 'IDC-IDC_tcga_lusc', 'IDC-IDC_cptac_luad', 'TCIA-cptac-luad', 'TCIA-tcga-luad', 'MIDRC-Open-A1_PETAL_REDCORAL', 'IDC-IDC_acrin_nsclc_fdg_pet', 'TCIA-tcga-lusc', 'TCIA-acrin-nsclc-fdg-pet', 'IDC-IDC_tcga_luad'}	{'IDC', 'TCIA', 'MIDRC'}	19
-breast^general	{'MR', nan}	{'ACRdart-EA1141Restricted', 'IDC-IDC_acrin_contralateral_breast_mr', 'IDC-IDC_ea1141', 'TCIA-acrin-contralateral-breast-mr'}	{'ACRdart', 'TCIA', 'IDC'}	19
-Abdomen^ROUTINE_AP_WO_Customized (Adult)	{'CT'}	{'MIDRC-Open-A1'}	{'MIDRC'}	19
-CTA CHEST FOR PE	{'CT'}	{'MIDRC-Open-A1_PETAL_BLUECORAL', 'MIDRC-Open-A1_PETAL_REDCORAL'}	{'MIDRC'}	19
-RIGHT BREAST	{'MR', nan}	{'IDC-IDC_acrin_contralateral_breast_mr', 'IDC-IDC_ispy1', 'TCIA-acrin-contralateral-breast-mr'}	{'IDC', 'TCIA'}	19
-NM_WholeBody	{'NM', nan}	{'TCIA-cmb-crc', 'IDC-IDC_cmb_crc', 'TCIA-cmb-lca', 'IDC-IDC_cmb_pca', 'TCIA-cmb-pca'}	{'IDC', 'TCIA'}	19
-PET LYMPHOMA NON HODGKINS (W/LOW DOSE CT)	{'PT,CT'}	{'MIDRC-Open-A1'}	{'MIDRC'}	19
-Thorax^ROUTINE_CHEST_WITH (Adult)	{'CT'}	{'MIDRC-Open-A1'}	{'MIDRC'}	19
-Thorax^PE_STUDY (Adult)	{'CT'}	{'MIDRC-Open-A1'}	{'MIDRC'}	19
-CT CT-Thorax for Pulmonary Embolism W/Cont	{'CT'}	{'MIDRC-Open-A1_PETAL_BLUECORAL', 'MIDRC-Open-A1_PETAL_REDCORAL'}	{'MIDRC'}	19
-CT COLONOGRAP C	{'CT', nan}	{'TCIA-ct-colonography', 'IDC-IDC_ct_colonography'}	{'IDC', 'TCIA'}	18
-NPETSB	{'CT', 'SEG', nan}	{'TCIA-acrin-nsclc-fdg-pet', 'IDC-IDC_acrin_nsclc_fdg_pet'}	{'IDC', 'TCIA'}	18
-CT CHEST LUNG CANCER SCREENING WITHOUT CONTRAST ANNUAL	{'CT'}	{'MIDRC-Open-R1'}	{'MIDRC'}	18
-CT CHEST BIOPSY	{'CT'}	{'MIDRC-Open-R1'}	{'MIDRC'}	18
-Abdomen^14_Supine_and_Prone_Colon (Adult)	{'CT', nan}	{'TCIA-ct-colonography', 'IDC-IDC_ct_colonography'}	{'IDC', 'TCIA'}	18
-CT CHEST ABDOMEN W CONTRAST (ROUTINE)	{'CT'}	{'MIDRC-Open-A1'}	{'MIDRC'}	18
-CT CHEST ABDOMEN PELVIS W WO CONTRAST	{'CT', 'SEG', nan}	{'MIDRC-Open-R1', 'TCIA-adrenal-acc-ki67-seg', 'IDC-IDC_adrenal_acc_ki67_seg'}	{'IDC', 'TCIA', 'MIDRC'}	18
-CT CHEST w	{'CT', nan}	{'TCIA-tcga-lihc', 'TCIA-tcga-ov', 'IDC-IDC_tcga_lihc', 'IDC-IDC_tcga_ov'}	{'IDC', 'TCIA'}	18
-CT CH/AB/PEL WITH LIVER TRIPHASIC	{'SEG', nan}	{'TCIA-colorectal-liver-metastases', 'IDC-IDC_colorectal_liver_metastases'}	{'IDC', 'TCIA'}	18
-BR-Breast US BI	{'US'}	{'ACRdart-ACRIN_6666'}	{'ACRdart'}	18
-CT HIP W/O CONTRAST,BILAT	{'CT', nan}	{'IDC-IDC_tcga_blca', 'IDC-IDC_pseudo_phi_dicom_data', 'TCIA-pseudo-phi-dicom-data', 'TCIA-tcga-blca'}	{'IDC', 'TCIA'}	18
-CT ABDOMEN W/O CONT	{'CT', nan}	{'TCIA-ct-colonography', 'IDC-IDC_ct_colonography'}	{'IDC', 'TCIA'}	18
-CT PET with registered MR	{'RTSTRUCT', 'CT', 'PT', 'MR', nan}	{'IDC-IDC_soft_tissue_sarcoma', 'TCIA-soft-tissue-sarcoma'}	{'IDC', 'TCIA'}	18
-MRI PELVIS W WO CONTRAST	{'SEG'}	{'IDC-IDC_prostate_mri_us_biopsy'}	{'IDC'}	18
-CT THORAX ENHANCED	{'CT', nan}	{'TCIA-acrin-nsclc-fdg-pet', 'IDC-IDC_acrin_nsclc_fdg_pet'}	{'IDC', 'TCIA'}	18
-MRI_Abdomen	{'MR', nan}	{'TCIA-cmb-lca', 'TCIA-cmb-crc', 'IDC-IDC_cmb_lca', 'IDC-IDC_cmb_crc'}	{'IDC', 'TCIA'}	18
-CTA CHEST W CONTRAST	{'CT'}	{'MIDRC-Open-A1_PETAL_BLUECORAL'}	{'MIDRC'}	18
-CHEST_WITH(Adult)	{'CT'}	{'MIDRC-Open-A1'}	{'MIDRC'}	18
-CHEST/ABD/PELVIS	{'CT', 'SEG', nan}	{'IDC-IDC_hcc_tace_seg', 'TCIA-hcc-tace-seg', 'IDC-IDC_acrin_nsclc_fdg_pet', 'TCIA-tcga-kirc', 'TCIA-lidc-idri', 'TCIA-acrin-nsclc-fdg-pet', 'IDC-IDC_lidc_idri', 'IDC-IDC_tcga_kirc'}	{'IDC', 'TCIA'}	18
-Abdomen CT Enhanced	{'CT', nan}	{'IDC-IDC_ctpred_sunitinib_pannet', 'IDC-IDC_stageii_colorectal_ct', 'TCIA-ctpred-sunitinib-pannet', 'TCIA-stageii-colorectal-ct'}	{'IDC', 'TCIA'}	18
-FOREIGN CD CT AB/PEL	{'CT', nan}	{'TCIA-tcga-ov', 'IDC-IDC_tcga_ov'}	{'IDC', 'TCIA'}	18
-CHEST CT	{'CT', nan}	{'TCIA-acrin-nsclc-fdg-pet', 'IDC-IDC_acrin_nsclc_fdg_pet'}	{'IDC', 'TCIA'}	18
-MR Breast Bilateral	{'MR'}	{'ACRdart-EA1141Restricted', 'IDC-IDC_ea1141'}	{'ACRdart', 'IDC'}	18
-MR BREAST LT W/WO	{'MR', nan}	{'IDC-IDC_acrin_contralateral_breast_mr', 'TCIA-acrin-contralateral-breast-mr'}	{'IDC', 'TCIA'}	18
-CT THORAX  WITHOUT CON	{'CT', 'SEG', nan}	{'IDC-IDC_tcga_lusc', 'TCIA-tcga-luad', 'TCIA-tcga-lusc', 'TCIA-cptac-sar', 'IDC-IDC_cptac_sar', 'IDC-IDC_tcga_luad'}	{'IDC', 'TCIA'}	18
-with DCE	{'MR', nan}	{'IDC-IDC_mouse_mammary', 'TCIA-mouse-mammary'}	{'IDC', 'TCIA'}	18
-Spontaneous Brain Tumor Model	{'MR', nan}	{'TCIA-mouse-astrocytoma', 'IDC-IDC_mouse_astrocytoma'}	{'IDC', 'TCIA'}	18
-*MRI - BREAST	{'MR', nan}	{'IDC-IDC_tcga_brca', 'TCIA-tcga-brca'}	{'IDC', 'TCIA'}	18
-Pancreas CT Enhanced	{'CT', nan}	{'IDC-IDC_ctpred_sunitinib_pannet', 'TCIA-ctpred-sunitinib-pannet'}	{'IDC', 'TCIA'}	18
-PET IMAGE W/CT SKULL-T	{'SEG', nan}	{'IDC-IDC_nsclc_radiogenomics', 'TCIA-nsclc-radiogenomics'}	{'IDC', 'TCIA'}	18
-Pio Xll001^Pelve	{'MR', nan}	{'IDC-IDC_tcga_cesc', 'TCIA-tcga-cesc'}	{'IDC', 'TCIA'}	18
-PET CT SKULL BASE TO MID THIGH	{'CT', 'SEG', nan}	{'IDC-IDC_tcga_blca', 'TCIA-tcga-luad', 'IDC-IDC_tcga_luad', 'TCIA-tcga-blca'}	{'IDC', 'TCIA'}	18
-PET CT Clinical Body Reference Only	{'CT', 'SEG', 'PT', nan}	{'IDC-IDC_nsclc_radiogenomics', 'TCIA-nsclc-radiogenomics'}	{'IDC', 'TCIA'}	18
-Standard Screening -  COMBO HD	{'MG'}	{'ACRdart-EA1141Restricted', 'IDC-IDC_ea1141'}	{'ACRdart', 'IDC'}	17
-MRI BREAST BILATERAL WITH T WITHOUT CONTRAST	{nan}	{'TCIA-breast-diagnosis'}	{'TCIA'}	17
-IR CT CHEST TUBE	{'CT'}	{'MIDRC-Open-R1'}	{'MIDRC'}	17
-XR RIGHT WRIST 3+ VIEWS	{'CR', 'DX'}	{'MIDRC-Open-A1'}	{'MIDRC'}	17
-Head^head_wo_GR (Adult)	{'CT'}	{'MIDRC-Open-A1'}	{'MIDRC'}	17
-Head^HEAD_WO (Adult)	{'CT'}	{'MIDRC-Open-A1'}	{'MIDRC'}	17
-MR BREAST BILAT W OR WO SCCA	{'MR', 'SEG'}	{'IDC-IDC_ispy1'}	{'IDC'}	17
-CTA CHEST AND ABDOMEN (THORACOABDOMNAL DISSECTION) WWO CONTRAST	{'CT'}	{'MIDRC-Open-A1'}	{'MIDRC'}	17
-MR BRST BI BIRAD W WO CNTRST	{'MR'}	{'ACRdart-EA1141Restricted', 'IDC-IDC_ea1141'}	{'ACRdart', 'IDC'}	17
-CT C/A/P	{'CT', 'SEG', nan}	{'IDC-IDC_hcc_tace_seg', 'IDC-IDC_tcga_ov', 'TCIA-hcc-tace-seg', 'TCIA-rider-pilot', 'TCIA-tcga-kirc', 'TCIA-tcga-ov', 'TCIA-lidc-idri', 'IDC-IDC_lidc_idri', 'IDC-IDC_tcga_kirc', 'IDC-IDC_rider_pilot'}	{'IDC', 'TCIA'}	16
-Abdomen^DUO_TX_AS_VOL (Adult)	{'CT', nan}	{'IDC-IDC_tcga_esca', 'TCIA-tcga-stad', 'IDC-IDC_tcga_stad', 'TCIA-tcga-esca'}	{'IDC', 'TCIA'}	16
-KUB (RAD)-CS	{'CR', 'DX'}	{'MIDRC-Open-A1'}	{'MIDRC'}	16
-CT ANGIO ABDOMEN W & W/O CONT	{'SEG', nan}	{'TCIA-colorectal-liver-metastases', 'IDC-IDC_colorectal_liver_metastases'}	{'IDC', 'TCIA'}	16
-MR SPECTROSCOPY	{'MR', 'SEG', nan}	{'IDC-IDC_upenn_gbm', 'MIDRC-Open-R1', 'TCIA-upenn-gbm'}	{'IDC', 'TCIA', 'MIDRC'}	16
-CT Chest, Abdomen + Pelvis	{'CT', 'SEG', nan}	{'TCIA-tcga-kirc', 'IDC-IDC_tcga_kich', 'TCIA-tcga-kirp', 'IDC-IDC_tcga_kirp', 'IDC-IDC_tcga_kirc', 'TCIA-tcga-kich'}	{'IDC', 'TCIA'}	16
-Ribs L	{'CR'}	{'MIDRC-Open-A1'}	{'MIDRC'}	16
-CT Chest Pre OP (Post Contrast)	{'CT', nan}	{'TCIA-acrin-nsclc-fdg-pet', 'IDC-IDC_acrin_nsclc_fdg_pet'}	{'IDC', 'TCIA'}	16
-MRI_LSpine	{'MR', nan}	{'IDC-IDC_cmb_pca', 'IDC-IDC_cmb_mml', 'TCIA-cmb-mml', 'TCIA-cmb-pca'}	{'IDC', 'TCIA'}	16
-XR LEFT ANKLE 3+ VIEWS	{'CR', 'DX'}	{'MIDRC-Open-A1'}	{'MIDRC'}	16
-CT ANGIOGRAM PULMONARY W CONTRAST	{'CT'}	{'MIDRC-Open-A1_PETAL_BLUECORAL', 'MIDRC-Open-A1_PETAL_REDCORAL'}	{'MIDRC'}	16
-CTA CHEST (THORACIC DISSECTION) WWO CONTRAST	{'CT'}	{'MIDRC-Open-A1'}	{'MIDRC'}	16
-Abdomen^CT_AP_WO (Adult)	{'CT'}	{'MIDRC-Open-A1'}	{'MIDRC'}	16
-PET^NEW_02_CBM_Wholebody_Only (Adult)	{'CT', 'SEG', 'PT', nan}	{'IDC-IDC_lung_pet_ct_dx', 'TCIA-lung-pet-ct-dx'}	{'IDC', 'TCIA'}	16
-MRI BREAST BILATERAL WITH AND WITHOUT CONTRAST	{'MR', 'SEG', nan}	{'TCIA-duke-breast-cancer-mri', 'IDC-IDC_duke_breast_cancer_mri'}	{'IDC', 'TCIA'}	16
-MRI BREAST BILATERAL WO THEN W CONTRAST	{'MR'}	{'ACRdart-EA1141Restricted', 'IDC-IDC_ea1141'}	{'ACRdart', 'IDC'}	16
-MRI Pelvis with contrast	{'MR', nan}	{'IDC-IDC_tcga_blca', 'TCIA-tcga-blca'}	{'IDC', 'TCIA'}	16
-Cardiac^LA_MODEL (Adult)	{'CT'}	{'MIDRC-Open-A1'}	{'MIDRC'}	16
-MRI Pelvis W/WO Contrast=A	{'REG', 'RTSTRUCT', 'MR', nan}	{'IDC-IDC_cc_tumor_heterogeneity', 'TCIA-cc-tumor-heterogeneity'}	{'IDC', 'TCIA'}	16
-Abdomen^01Abdomen_Routine (Adult)	{'CT', nan}	{'IDC-IDC_tcga_ov', 'TCIA-tcga-kirc', 'TCIA-tcga-ov', 'IDC-IDC_tcga_ucec', 'IDC-IDC_tcga_kirc', 'TCIA-tcga-ucec'}	{'IDC', 'TCIA'}	16
-X-RAY KNEE 3 VIEWS - LEFT	{'CR', 'DX'}	{'MIDRC-Open-A1'}	{'MIDRC'}	16
-PET/CT LUNG NODULE	{'SEG', nan}	{'IDC-IDC_nsclc_radiogenomics', 'TCIA-nsclc-radiogenomics'}	{'IDC', 'TCIA'}	16
-Head^DE_CTA_HEAD_NECK (Adult)	{'CT'}	{'MIDRC-Open-A1'}	{'MIDRC'}	16
-CT CHEST W/ CONTRAST	{'CT', 'SEG', nan}	{'IDC-IDC_tcga_sarc', 'IDC-IDC_tcga_lusc', 'TCIA-tcga-sarc', 'TCIA-tcga-lusc', 'TCIA-tcga-kirp', 'IDC-IDC_tcga_kirp'}	{'IDC', 'TCIA'}	16
-CT CAP (LIV)	{'CT', 'SEG', nan}	{'IDC-IDC_hcc_tace_seg', 'TCIA-hcc-tace-seg'}	{'IDC', 'TCIA'}	16
-BIOPSY	{'MR', nan}	{'IDC-IDC_tcga_brca', 'TCIA-tcga-brca'}	{'IDC', 'TCIA'}	16
-MR PELVIS OUTSIDE IMAGING	{'SEG', nan}	{'TCIA-prostate-mri-us-biopsy', 'IDC-IDC_prostate_mri_us_biopsy'}	{'IDC', 'TCIA'}	16
-MAMMO SCREENING BILATERAL TOMOSYNTHESIS (BILATERAL DIAGNOSTIC AN	{'MG'}	{'ACRdart-EA1141Restricted'}	{'ACRdart'}	16
-CT ABDOMEN wo&w	{'CT', nan}	{'TCIA-tcga-lihc', 'IDC-IDC_tcga_lihc'}	{'IDC', 'TCIA'}	16
-*CT ABDOMEN	{'CT', 'SEG', nan}	{'TCIA-tcga-lihc', 'IDC-IDC_tcga_lihc', 'TCIA-tcga-ucec', 'IDC-IDC_tcga_ucec'}	{'IDC', 'TCIA'}	16
-MR BRAIN WO+W CONTRAST	{'MR', nan}	{'IDC-IDC_cptac_cm', 'TCIA-cptac-luad', 'TCIA-cptac-cm', 'IDC-IDC_cptac_luad'}	{'IDC', 'TCIA'}	16
-BREAST 2017^BREAST LESION 2017	{'MR'}	{'ACRdart-EA1141Restricted'}	{'ACRdart'}	16
-CT ABDOMEN W CO	{'CT', nan}	{'IDC-IDC_tcga_read', 'TCIA-tcga-coad', 'IDC-IDC_tcga_coad', 'TCIA-tcga-kirc', 'IDC-IDC_tcga_kich', 'TCIA-tcga-read', 'IDC-IDC_tcga_kirc', 'TCIA-tcga-kich'}	{'IDC', 'TCIA'}	16
-C+C	{'SEG', nan}	{'IDC-IDC_lung_pet_ct_dx', 'TCIA-lung-pet-ct-dx'}	{'IDC', 'TCIA'}	16
-two_phase__abdomen	{'SEG', nan}	{'TCIA-c4kc-kits', 'IDC-IDC_c4kc_kits'}	{'IDC', 'TCIA'}	16
-X-RAY BONE OUTSIDE IMAGE	{'CR', 'DX'}	{'MIDRC-Open-A1'}	{'MIDRC'}	16
-_t1of3External Images for PACS	{'MR', nan}	{'IDC-IDC_vestibular_schwannoma_mc_rc', 'TCIA-vestibular-schwannoma-mc-rc'}	{'IDC', 'TCIA'}	16
-MR ABD IMAGE IMPORT	{'MR', nan}	{'TCIA-prostate-mri-us-biopsy', 'IDC-IDC_prostate_mri_us_biopsy'}	{'IDC', 'TCIA'}	16
-MG Tomosynthesis Breast Screening Bilateral	{'MG'}	{'ACRdart-EA1141Restricted', 'IDC-IDC_ea1141'}	{'ACRdart', 'IDC'}	16
-Thorax^CT_CAP_WITHOUT (Adult)	{'CT'}	{'MIDRC-Open-A1'}	{'MIDRC'}	16
-Breast^Bil tumor ax	{'MR', nan}	{'IDC-IDC_tcga_brca', 'TCIA-tcga-brca'}	{'IDC', 'TCIA'}	16
-CT THORAX W/CONT	{'CT', 'SEG', nan}	{'IDC-IDC_nsclc_radiogenomics', 'TCIA-nsclc-radiogenomics', 'IDC-IDC_acrin_nsclc_fdg_pet', 'TCIA-acrin-nsclc-fdg-pet', 'TCIA-varepop-apollo'}	{'IDC', 'TCIA'}	16
-OSI CT CHEST ABDOMEN PELVIS	{'CT', 'SEG', nan}	{'IDC-IDC_anti_pd_1_lung', 'TCIA-anti-pd-1_lung'}	{'IDC', 'TCIA'}	16
-CT ABDOMEN NONENH & ENHANCED-BODY	{'RTSTRUCT', 'CT', 'SEG', nan}	{'TCIA-tcga-lihc', 'TCIA-cptac-pda', 'IDC-IDC_cptac_pda', 'IDC-IDC_tcga_lihc'}	{'IDC', 'TCIA'}	16
-MR ABBREVIATED BREAST	{'MR'}	{'ACRdart-EA1141Restricted', 'IDC-IDC_ea1141'}	{'ACRdart', 'IDC'}	16
-CT CHEST PELVIS W ABDOMEN WWO	{'CT', nan}	{'MIDRC-Open-A1', 'IDC-IDC_tcga_blca', 'MIDRC-Open-R1', 'TCIA-tcga-blca'}	{'IDC', 'TCIA', 'MIDRC'}	15
-BRST TOMOSYNTHESIS BILAT	{'MG'}	{'ACRdart-EA1141Restricted', 'IDC-IDC_ea1141'}	{'ACRdart', 'IDC'}	15
-Head^Perfusion (Adult)	{'CT'}	{'MIDRC-Open-A1'}	{'MIDRC'}	15
-CT CHEST WITH CONTRAST (PETCT)	{'CT'}	{'MIDRC-Open-R1'}	{'MIDRC'}	15
-THORAX PE + LOW DOSE	{'CT', nan}	{'TCIA-midrc-ricord-1a', 'IDC-IDC_midrc_ricord_1a', 'MIDRC-TCIA-RICORD_1a'}	{'IDC', 'TCIA', 'MIDRC'}	15
-CT CHEST W/CON	{'SEG', nan}	{'TCIA-varepop-apollo', 'IDC-IDC_nsclc_radiogenomics', 'TCIA-nsclc-radiogenomics'}	{'IDC', 'TCIA'}	15
-MR	{'MR'}	{'ACRdart-EA1141Restricted', 'IDC-IDC_ea1141'}	{'ACRdart', 'IDC'}	15
-CT CHEST LOW DOSE SCREENING	{'CT'}	{'MIDRC-Open-R1'}	{'MIDRC'}	15
-CT CHEST ABDOMEN PELVIS W IV CON	{'CT'}	{'MIDRC-Open-R1'}	{'MIDRC'}	15
-MR Breast Bilat WWO Contrast	{'MR'}	{'ACRdart-EA1141Restricted', 'IDC-IDC_ea1141'}	{'ACRdart', 'IDC'}	15
-Abdomen^STONE (Adult)	{'CT'}	{'MIDRC-Open-A1'}	{'MIDRC'}	15
-MRIBB3	{'MR'}	{'ACRdart-EA1141Restricted', 'IDC-IDC_ea1141'}	{'ACRdart', 'IDC'}	15
-PROSTATE/EMPTYAKL	{nan}	{'TCIA-cc-radiomics-phantom'}	{'TCIA'}	15
-MAMM SCR TOMO ECOG ACRIN CLINICAL RSRCH	{'MG'}	{'ACRdart-EA1141Restricted', 'IDC-IDC_ea1141'}	{'ACRdart', 'IDC'}	15
-CT ESOPHAGRAM	{'CT'}	{'MIDRC-Open-R1'}	{'MIDRC'}	15
-PENN IMAGE EXCHANGE IMPORT	{'CR', 'DX'}	{'MIDRC-Open-A1'}	{'MIDRC'}	15
-BREAST (S) US UNIL-BILAT MAMMO	{'US'}	{'ACRdart-ACRIN_6666'}	{'ACRdart'}	15
-PET CT FDG IMAG SKULL TO THIGH	{'OT', 'CT', 'PT', 'OT,PT', nan}	{'MIDRC-TCIA-COVID-19-NY-SBU', 'IDC-IDC_covid_19_ny_sbu', 'TCIA-covid-19-ny-sbu'}	{'IDC', 'TCIA', 'MIDRC'}	15
-CT LUNG CANCER SCREENING	{'CT'}	{'AIMI-COCA', 'MIDRC-Open-R1'}	{'MIDRC', 'AIMI'}	15
-CT Chest W/O Contrast	{'CT', nan}	{'MIDRC-Open-A1_PETAL_BLUECORAL', 'TCIA-acrin-nsclc-fdg-pet', 'MIDRC-Open-A1_PETAL_REDCORAL', 'IDC-IDC_acrin_nsclc_fdg_pet'}	{'IDC', 'TCIA', 'MIDRC'}	14
-MR LUMBAR SPINE WITHOUT CONTRAST	{'MR'}	{'MIDRC-Open-R1'}	{'MIDRC'}	14
-MR HEAD W IV CONTRAST	{'MR', 'SEG', nan}	{'IDC-IDC_upenn_gbm', 'TCIA-upenn-gbm'}	{'IDC', 'TCIA'}	14
-CT THORAX W/O CONT	{'SEG', nan}	{'TCIA-varepop-apollo', 'IDC-IDC_nsclc_radiogenomics', 'TCIA-nsclc-radiogenomics'}	{'IDC', 'TCIA'}	14
-PET/CT NSCLC Restaging	{'SEG', nan}	{'IDC-IDC_anti_pd_1_lung', 'TCIA-anti-pd-1_lung'}	{'IDC', 'TCIA'}	14
-XR THORACIC SPINE 2 VIEWS	{'CR', 'DX'}	{'MIDRC-Open-A1'}	{'MIDRC'}	14
-RT BREAST STUDY	{'MR', nan}	{'IDC-IDC_acrin_contralateral_breast_mr', 'TCIA-acrin-contralateral-breast-mr'}	{'IDC', 'TCIA'}	14
-PET/CT Body Reference Only	{'SEG', 'PT', nan}	{'IDC-IDC_nsclc_radiogenomics', 'TCIA-nsclc-radiogenomics'}	{'IDC', 'TCIA'}	14
-MRI CERVICAL SPINE W/O CONTRAST	{'MR'}	{'MIDRC-Open-A1'}	{'MIDRC'}	14
-CT CHEST W/CONT	{'SEG', nan}	{'IDC-IDC_nsclc_radiogenomics', 'TCIA-nsclc-radiogenomics'}	{'IDC', 'TCIA'}	14
-BI BREAST SCREENING BILATERAL WITH TOMOSYNTHESIS	{'MG'}	{'ACRdart-EA1141Restricted', 'IDC-IDC_ea1141'}	{'ACRdart', 'IDC'}	14
-PET Reference Only	{'SEG', nan}	{'IDC-IDC_nsclc_radiogenomics', 'TCIA-nsclc-radiogenomics'}	{'IDC', 'TCIA'}	14
-CT ABDOMEN/PELVIS WO IV CONTRAST	{'CT'}	{'MIDRC-Open-A1'}	{'MIDRC'}	14
-Thorax^2 CAP ROUTINE	{'CT', nan}	{'TCIA-tcga-kirc', 'TCIA-tcga-ov', 'IDC-IDC_tcga_kirc', 'IDC-IDC_tcga_ov'}	{'IDC', 'TCIA'}	14
-MR NONE HEAD W AND WO IV CONTRAST	{'MR', 'SEG', nan}	{'IDC-IDC_upenn_gbm', 'TCIA-upenn-gbm'}	{'IDC', 'TCIA'}	14
-Chest  3D IMR	{'CT', nan}	{'IDC-IDC_lung_pet_ct_dx', 'TCIA-lung-pet-ct-dx'}	{'IDC', 'TCIA'}	14
-CT KIDNEY PROTOCOL W/ CH/PEL	{'CT', 'SEG', nan}	{'TCIA-tcga-kirc', 'IDC-IDC_tcga_kirc'}	{'IDC', 'TCIA'}	14
-PET^CCF_WholeBody_PETCT_CAP (Adult)	{'CT', 'SEG', nan}	{'TCIA-acrin-nsclc-fdg-pet', 'IDC-IDC_acrin_nsclc_fdg_pet'}	{'IDC', 'TCIA'}	14
-CTA TRAUMA THORACIC AORTA W/O & W/ IV CONTRAST	{'CT'}	{'MIDRC-Open-R1'}	{'MIDRC'}	14
-CT PE PROTOCOL	{'CT'}	{'MIDRC-Open-A1_PETAL_BLUECORAL'}	{'MIDRC'}	14
-XR RIGHT HAND 3+ VIEWS	{'CR', 'DX'}	{'MIDRC-Open-A1'}	{'MIDRC'}	14
-MR BREAST BILATERAL WITHOUT AND WITH IV CONTRAST	{'MR'}	{'ACRdart-EA1141Restricted', 'IDC-IDC_ea1141'}	{'ACRdart', 'IDC'}	14
-MRI BREAST BILAT WWO	{'MR', nan}	{'ACRdart-EA1141Restricted', 'IDC-IDC_tcga_brca', 'TCIA-tcga-brca', 'IDC-IDC_ea1141'}	{'ACRdart', 'TCIA', 'IDC'}	14
-Abdomen^BrzuchMiednica_ (Adult)	{'RTSTRUCT', 'CT', nan}	{'IDC-IDC_cptac_ucec', 'TCIA-cptac-ucec'}	{'IDC', 'TCIA'}	14
-MRI BREAST BILATERAL EXAM	{'MR'}	{'ACRdart-EA1141Restricted', 'IDC-IDC_ea1141'}	{'ACRdart', 'IDC'}	14
-MRI BREAST UNI 2ND EXA	{'MR', nan}	{'IDC-IDC_acrin_contralateral_breast_mr', 'TCIA-acrin-contralateral-breast-mr'}	{'IDC', 'TCIA'}	14
-CT Chest, Abdomen + Pe	{'CT', 'SEG', nan}	{'TCIA-tcga-kirc', 'IDC-IDC_tcga_kich', 'TCIA-tcga-kirp', 'IDC-IDC_tcga_kirp', 'IDC-IDC_tcga_kirc', 'TCIA-tcga-kich'}	{'IDC', 'TCIA'}	14
-4DCT THORAX	{'RTSTRUCT', 'CT'}	{'IDC-IDC_lctsc'}	{'IDC'}	14
-PETCT_SkullMidThigh	{'CT', nan}	{'TCIA-cmb-lca', 'TCIA-cmb-crc', 'IDC-IDC_cmb_lca', 'IDC-IDC_cmb_crc'}	{'IDC', 'TCIA'}	14
-CT THORAX WITH	{'CT', nan}	{'TCIA-acrin-nsclc-fdg-pet', 'IDC-IDC_acrin_nsclc_fdg_pet'}	{'IDC', 'TCIA'}	14
-CARDIAC OP	{'CT'}	{'MIDRC-Open-R1'}	{'MIDRC'}	14
-CT Chest routine	{'CT', nan}	{'TCIA-acrin-nsclc-fdg-pet', 'IDC-IDC_acrin_nsclc_fdg_pet'}	{'IDC', 'TCIA'}	14
-chest_abdomen_pelvis__w	{'SEG', nan}	{'TCIA-c4kc-kits', 'IDC-IDC_c4kc_kits'}	{'IDC', 'TCIA'}	14
-MR BREAST UNILAT	{'MR', 'SEG'}	{'IDC-IDC_ispy1'}	{'IDC'}	14
-Mammo-Digital Screening BILAT w/ Tomosynthesis	{'MG'}	{'ACRdart-EA1141Restricted', 'IDC-IDC_ea1141'}	{'ACRdart', 'IDC'}	14
-CT CHEST AND UPPER ABD WO	{'CT'}	{'MIDRC-Open-A1', 'MIDRC-Open-R1'}	{'MIDRC'}	14
-CT CARDIAC CTA CORONARY W CAL	{'CT', nan}	{'IDC-IDC_rider_lung_pet_ct', 'TCIA-rider-lung-pet-ct'}	{'IDC', 'TCIA'}	14
-MR_LT BREAST	{'MR', nan}	{'IDC-IDC_acrin_contralateral_breast_mr', 'TCIA-acrin-contralateral-breast-mr'}	{'IDC', 'TCIA'}	14
-MRI PELVIS WO/W CONTRAST	{'MR', nan}	{'IDC-IDC_cc_tumor_heterogeneity', 'TCIA-cc-tumor-heterogeneity'}	{'IDC', 'TCIA'}	14
-HEAD^BRAIN	{'MR', 'SEG', nan}	{'IDC-IDC_acrin_nsclc_fdg_pet', 'MIDRC-Open-A1', 'TCIA-acrin-nsclc-fdg-pet', 'TCIA-upenn-gbm', 'IDC-IDC_upenn_gbm'}	{'IDC', 'TCIA', 'MIDRC'}	14
-FOREIGN CT AB/PEL	{'CT', nan}	{'TCIA-tcga-ov', 'IDC-IDC_tcga_ov'}	{'IDC', 'TCIA'}	14
-MRI PELVIS W+WO CONT	{'MR', nan}	{'IDC-IDC_tcga_prad', 'TCIA-tcga-prad'}	{'IDC', 'TCIA'}	14
-ABD W/&W/O CONT	{'MR', nan}	{'TCIA-tcga-kirc', 'IDC-IDC_tcga_kirc'}	{'IDC', 'TCIA'}	14
-X-RAY CERVICAL SPINE 2 OR 3 VIEWS	{'CR', 'DX'}	{'MIDRC-Open-A1'}	{'MIDRC'}	14
-MRI Prostate With and Without Contrast	{'MR', nan}	{'IDC-IDC_prostate_diagnosis', 'TCIA-prostate-diagnosis'}	{'IDC', 'TCIA'}	14
-fubu	{'CT', nan}	{'IDC-IDC_stageii_colorectal_ct', 'TCIA-stageii-colorectal-ct'}	{'IDC', 'TCIA'}	14
-two_phase__abdomen_pelvis	{'SEG', nan}	{'TCIA-c4kc-kits', 'IDC-IDC_c4kc_kits'}	{'IDC', 'TCIA'}	14
-X-RAY FOOT COMPLETE MINIMUM 3 VIEWS - RIGHT	{'CR', 'DX'}	{'MIDRC-Open-A1'}	{'MIDRC'}	13
-Head^CODE_STROKE (Adult)	{'CT'}	{'MIDRC-Open-A1'}	{'MIDRC'}	13
-X-RAY KNEE 1 OR 2 VIEWS - RIGHT	{'CR', 'CR,DX', 'DX'}	{'MIDRC-Open-A1'}	{'MIDRC'}	13
-MRIBB3/4054	{'MR'}	{'ACRdart-EA1141Restricted', 'IDC-IDC_ea1141'}	{'ACRdart', 'IDC'}	13
-ACUTE ABDOMINAL SERIES	{'CR', 'DX'}	{'MIDRC-Open-R1'}	{'MIDRC'}	13
-X-RAY SHOULDER COMPLETE MIN 2 VIEWS - LEFT	{'CR', 'DX'}	{'MIDRC-Open-A1'}	{'MIDRC'}	13
-CT CHEST ANGIOGRAM WITH IV CONTRAST	{'CT'}	{'MIDRC-Open-A1_SCCM_VIRUS'}	{'MIDRC'}	13
-PELVIS 1 OR 2 VIEWS	{'CR', 'DX'}	{'MIDRC-Open-R1'}	{'MIDRC'}	13
-Mammography Tomography Screening	{'MG'}	{'ACRdart-EA1141Restricted', 'IDC-IDC_ea1141'}	{'ACRdart', 'IDC'}	13
-CCTA HEART W CONTRAST+CT CHEST WO CONTRST-CT SURGERY	{'CT'}	{'MIDRC-Open-A1'}	{'MIDRC'}	13
-FL PHARYNX/SWALLOWING EVAL WITH FLUORO	{'XA', 'RF'}	{'MIDRC-Open-R1'}	{'MIDRC'}	13
-Thorax^CHEST_WITHOUT_Customized (Adult)	{'CT'}	{'MIDRC-Open-A1'}	{'MIDRC'}	13
-BREAST SCREENING-BILATERAL WITH CAD	{'MG'}	{'ACRdart-EA1141Restricted'}	{'ACRdart'}	13
-Abdomen^ABDOME_2_FASESVOL (Adult)	{'CT', nan}	{'TCIA-tcga-stad', 'IDC-IDC_tcga_blca', 'IDC-IDC_tcga_stad', 'TCIA-tcga-blca'}	{'IDC', 'TCIA'}	13
-MR ABD, OUTSIDE IMAGING	{'SEG', nan}	{'TCIA-prostate-mri-us-biopsy', 'IDC-IDC_prostate_mri_us_biopsy'}	{'IDC', 'TCIA'}	13
-X-RAY HAND MINIMUM 3 VIEWS - RIGHT	{'CR', 'DX'}	{'MIDRC-Open-A1'}	{'MIDRC'}	13
-NM MYOCARDIAL PHARM STRESS TEST	{'CT', 'NM', 'NM,CT'}	{'MIDRC-Open-R1'}	{'MIDRC'}	13
-MAMMOGRAM SCREENING BILATERAL W / TOMO	{'MG'}	{'IDC-IDC_ea1141'}	{'IDC'}	13
-X-RAY HIP UNILATERAL WITH PELVIS 2 OR 3 VIEWS - LEFT	{'CR', 'DX'}	{'MIDRC-Open-A1'}	{'MIDRC'}	13
-XR REFERENCE IMPORT	{'CR', 'DX'}	{'MIDRC-Open-A1'}	{'MIDRC'}	13
-CT CHEST W/	{'CT', 'SEG', nan}	{'IDC-IDC_nsclc_radiogenomics', 'TCIA-nsclc-radiogenomics', 'IDC-IDC_acrin_nsclc_fdg_pet', 'TCIA-acrin-nsclc-fdg-pet', 'TCIA-varepop-apollo'}	{'IDC', 'TCIA'}	13
-CT CHEST W/O CON	{'CT', 'SEG', nan}	{'TCIA-rider-pilot', 'TCIA-lidc-idri', 'TCIA-varepop-apollo', 'IDC-IDC_lidc_idri', 'IDC-IDC_rider_pilot'}	{'IDC', 'TCIA'}	13
-X-RAY HIP UNILATERAL WITH PELVIS 2 OR 3 VIEWS - RIGHT	{'DX'}	{'MIDRC-Open-A1'}	{'MIDRC'}	13
-Head^CODE_STROKE_Customized (Adult)	{'CT'}	{'MIDRC-Open-A1'}	{'MIDRC'}	13
-chest	{'DX', 'CT', nan}	{'MIDRC-Open-R1', 'IDC-IDC_lung_pet_ct_dx', 'TCIA-lung-pet-ct-dx'}	{'IDC', 'TCIA', 'MIDRC'}	13
-MAMMO TOMO SCREENING BILATERAL	{'MG'}	{'ACRdart-EA1141Restricted', 'IDC-IDC_ea1141'}	{'ACRdart', 'IDC'}	13
-CHEST PA AND LAT	{'CR', 'DX'}	{'MIDRC-Open-A1_PETAL_BLUECORAL', 'MIDRC-Open-A1_PETAL_REDCORAL'}	{'MIDRC'}	13
-ABD PEL/	{'CT', nan}	{'TCIA-ct-colonography', 'IDC-IDC_ct_colonography'}	{'IDC', 'TCIA'}	12
-BODY^MIEDNICA	{'RTSTRUCT', nan}	{'IDC-IDC_cptac_ucec', 'TCIA-cptac-ucec'}	{'IDC', 'TCIA'}	12
-XR RIGHT HAND 1-2 VIEWS	{'CR', 'DX'}	{'MIDRC-Open-A1'}	{'MIDRC'}	12
-_t4of7MRI IAMS	{'MR', nan}	{'IDC-IDC_vestibular_schwannoma_mc_rc', 'TCIA-vestibular-schwannoma-mc-rc'}	{'IDC', 'TCIA'}	12
-MRI BR UNILAT W&WO CONT RIGHT	{'MR', 'SEG'}	{'IDC-IDC_ispy1'}	{'IDC'}	12
-Abdomen^DE_ROUTINE_AP_WITH_UNDER_50_Customized (Adult)	{'CT'}	{'MIDRC-Open-A1'}	{'MIDRC'}	12
-MR ABDOMEN NONENHANCED & ENHANCED-BODY	{'MR', 'SEG', nan}	{'TCIA-tcga-lihc', 'IDC-IDC_tcga_lihc'}	{'IDC', 'TCIA'}	12
-Thorax^CHEST_LOW_DOSE_NODULE_FUP_WO (Adult)	{'CT'}	{'MIDRC-Open-A1'}	{'MIDRC'}	12
-77067TS Scr Mamm bil 2v w/TOMO	{'MG'}	{'ACRdart-EA1141Restricted'}	{'ACRdart'}	12
-MRI RT. BREAST	{'MR', nan}	{'IDC-IDC_acrin_contralateral_breast_mr', 'TCIA-acrin-contralateral-breast-mr'}	{'IDC', 'TCIA'}	12
-BREAST LEFT	{'MR', nan}	{'IDC-IDC_acrin_contralateral_breast_mr', 'TCIA-acrin-contralateral-breast-mr'}	{'IDC', 'TCIA'}	12
-SCRN TOMO SCRM MAMMO DIGT BILAT	{'MG'}	{'ACRdart-EA1141Restricted', 'IDC-IDC_ea1141'}	{'ACRdart', 'IDC'}	12
-PELVIS^PELVIS	{'RTSTRUCT', 'MR', nan}	{'ACRdart-ACRIN_6701', 'TCIA-cptac-ccrcc', 'IDC-IDC_cptac_ccrcc'}	{'ACRdart', 'TCIA', 'IDC'}	12
-AS	{'CT', nan}	{'TCIA-tcga-stad', 'IDC-IDC_tcga_stad'}	{'IDC', 'TCIA'}	12
-PET^CC_PETWB (Adult)	{'CT', 'SEG', nan}	{'TCIA-acrin-nsclc-fdg-pet', 'IDC-IDC_acrin_nsclc_fdg_pet'}	{'IDC', 'TCIA'}	12
-Unspecified MR	{'MR', 'SEG', nan}	{'IDC-IDC_upenn_gbm', 'TCIA-upenn-gbm'}	{'IDC', 'TCIA'}	12
-Thorax^LUNG_CANCER_SCRN_LOW_DOSE_CM (Adult)	{'CT'}	{'MIDRC-Open-A1'}	{'MIDRC'}	12
-PET^1_PETCT_WholeBody (Adult)	{'SEG', nan}	{'TCIA-tcga-lihc', 'TCIA-acrin-nsclc-fdg-pet', 'IDC-IDC_tcga_lihc', 'IDC-IDC_acrin_nsclc_fdg_pet'}	{'IDC', 'TCIA'}	12
-CT Thorax w/o Contrast	{'CT', nan}	{'TCIA-qin-lung-ct', 'MIDRC-Open-A1_PETAL_BLUECORAL', 'MIDRC-Open-R1', 'MIDRC-Open-A1_PETAL_REDCORAL'}	{'TCIA', 'MIDRC'}	12
-MR PROSTATE W ENDORECTAL COIL WO+W CONTRAST	{nan}	{'TCIA-prostate-mri-us-biopsy'}	{'TCIA'}	12
-CTA CORONARY ARTERY	{'CT', nan}	{'IDC-IDC_rider_lung_pet_ct', 'TCIA-rider-lung-pet-ct'}	{'IDC', 'TCIA'}	12
-PRONE BREAST	{'SEG', nan}	{'IDC-IDC_qin_breast', 'TCIA-qin-breast'}	{'IDC', 'TCIA'}	12
-XR LEFT KNEE 1-2 VIEWS	{'CR', 'DX'}	{'MIDRC-Open-A1'}	{'MIDRC'}	12
-CT ANGIO CHEST FOR PE	{'CT'}	{'MIDRC-Open-A1_SCCM_VIRUS', 'MIDRC-Open-A1_PETAL_BLUECORAL', 'MIDRC-Open-A1_PETAL_REDCORAL'}	{'MIDRC'}	12
-CHEST WO CONTRAST CT	{'CT'}	{'MIDRC-Open-A1_PETAL_BLUECORAL', 'MIDRC-Open-A1_PETAL_REDCORAL'}	{'MIDRC'}	12
-Thorax^ILD (Adult)	{'CT'}	{'MIDRC-Open-A1'}	{'MIDRC'}	12
-MA SURGICAL SPECIMEN	{'MG', nan}	{'TCIA-breast-diagnosis', 'IDC-IDC_breast_diagnosis'}	{'IDC', 'TCIA'}	12
-CT ABDOMEN wo & PELVIS wo	{'CT', nan}	{'TCIA-tcga-lihc', 'TCIA-tcga-ov', 'IDC-IDC_tcga_lihc', 'IDC-IDC_tcga_ov'}	{'IDC', 'TCIA'}	12
-CT CHEST w + 3D Depend WS	{'CT', 'SEG', nan}	{'TCIA-tcga-lihc', 'TCIA-tcga-kirc', 'IDC-IDC_tcga_lihc', 'IDC-IDC_tcga_ucec', 'IDC-IDC_tcga_kirc', 'TCIA-tcga-ucec'}	{'IDC', 'TCIA'}	12
-PTUMOR	{'SEG', nan}	{'TCIA-acrin-nsclc-fdg-pet', 'IDC-IDC_acrin_nsclc_fdg_pet'}	{'IDC', 'TCIA'}	12
-CT KIDNEY PROTOCOL W/WO CONTRAST	{'CT', nan}	{'TCIA-tcga-kirc', 'IDC-IDC_tcga_kirc'}	{'IDC', 'TCIA'}	12
-RESEARCH^BREAST RESEARCH	{'MR', nan}	{'IDC-IDC_acrin_contralateral_breast_mr', 'TCIA-acrin-contralateral-breast-mr'}	{'IDC', 'TCIA'}	12
-Abdomen^Jama_Brzuszna_3_Fazy_Opoznione (Adult)	{'RTSTRUCT', nan}	{'TCIA-cptac-ccrcc', 'IDC-IDC_cptac_ccrcc'}	{'IDC', 'TCIA'}	12
-PET CT BODY	{'SEG', 'PT', nan}	{'IDC-IDC_nsclc_radiogenomics', 'TCIA-nsclc-radiogenomics'}	{'IDC', 'TCIA'}	12
-_t2of3  MRI Head	{'MR', nan}	{'IDC-IDC_vestibular_schwannoma_mc_rc', 'TCIA-vestibular-schwannoma-mc-rc'}	{'IDC', 'TCIA'}	12
-MRI ABDOMEN PELVIS W+WO CONT	{'MR', nan}	{'IDC-IDC_tcga_read', 'TCIA-pseudo-phi-dicom-data', 'TCIA-tcga-kirc', 'TCIA-tcga-read', 'TCIA-tcga-kirp', 'IDC-IDC_tcga_kirp', 'IDC-IDC_pseudo_phi_dicom_data', 'IDC-IDC_tcga_kirc'}	{'IDC', 'TCIA'}	12
-MR BREAST RT W/WO	{'MR', nan}	{'IDC-IDC_acrin_contralateral_breast_mr', 'TCIA-acrin-contralateral-breast-mr'}	{'IDC', 'TCIA'}	12
-penqctzengq	{'CT', nan}	{'IDC-IDC_stageii_colorectal_ct', 'TCIA-stageii-colorectal-ct'}	{'IDC', 'TCIA'}	12
-Vascular^3_PULMONARY_VEIN (Adult)	{'CT'}	{'MIDRC-Open-A1'}	{'MIDRC'}	12
-MRI W/WO CONT BILBR	{'MR', nan}	{'IDC-IDC_acrin_contralateral_breast_mr', 'TCIA-acrin-contralateral-breast-mr'}	{'IDC', 'TCIA'}	12
-_t3of3  MRI Head	{'MR', nan}	{'IDC-IDC_vestibular_schwannoma_mc_rc', 'TCIA-vestibular-schwannoma-mc-rc'}	{'IDC', 'TCIA'}	12
-XR LUMBAR SPINE AP AND LATERAL 2 OR 3 VIEWS	{'DX'}	{'MIDRC-Open-R1'}	{'MIDRC'}	12
-CT ABD AND PELVIS WITH IV CONTRAST	{'CT', nan}	{'MIDRC-TCIA-COVID-19-NY-SBU', 'IDC-IDC_covid_19_ny_sbu', 'TCIA-covid-19-ny-sbu'}	{'IDC', 'TCIA', 'MIDRC'}	12
-CT ABDOMEN PELVIS WO CONT	{'CT', nan}	{'TCIA-tcga-lihc', 'TCIA-tcga-kirc', 'IDC-IDC_tcga_kirc', 'IDC-IDC_tcga_lihc'}	{'IDC', 'TCIA'}	12
-MG Screening Digital BL w/Tomo/CAD	{'MG'}	{'ACRdart-EA1141Restricted', 'IDC-IDC_ea1141'}	{'ACRdart', 'IDC'}	12
-CONTRABREAST	{'MR', nan}	{'IDC-IDC_acrin_contralateral_breast_mr', 'TCIA-acrin-contralateral-breast-mr'}	{'IDC', 'TCIA'}	12
-FORFILE CD MR ABDOMEN	{'MR', nan}	{'TCIA-tcga-kirc', 'IDC-IDC_tcga_kirc'}	{'IDC', 'TCIA'}	12
-UNAVAILABLE	{'CT', nan}	{'TCIA-tcga-ov', 'IDC-IDC_tcga_ov'}	{'IDC', 'TCIA'}	12
-MRI BREAST W&WO/CONTRA	{'MR', nan}	{'IDC-IDC_acrin_contralateral_breast_mr', 'TCIA-acrin-contralateral-breast-mr'}	{'IDC', 'TCIA'}	12
-CT CHEST ABD PELVIS WITH CON	{'CT', 'SEG', nan}	{'IDC-IDC_nsclc_radiogenomics', 'TCIA-nsclc-radiogenomics'}	{'IDC', 'TCIA'}	12
-CT CHEST WITHOUT CONTRAST (S)	{'CT'}	{'MIDRC-Open-R1'}	{'MIDRC'}	12
-Chest  3D	{'CT', nan}	{'IDC-IDC_lung_pet_ct_dx', 'TCIA-lung-pet-ct-dx'}	{'IDC', 'TCIA'}	12
-PET/RT planningWhole	{'CT', 'SEG', 'PT', nan}	{'TCIA-acrin-nsclc-fdg-pet', 'IDC-IDC_acrin_nsclc_fdg_pet'}	{'IDC', 'TCIA'}	12
-CT Brain	{'CT', nan}	{'IDC-IDC_cmb_mel', 'IDC-IDC_cmb_crc', 'TCIA-cmb-crc', 'TCIA-cmb-mel'}	{'IDC', 'TCIA'}	12
-Tomografia komputerowa klatki piersiowej	{'CT', nan}	{'TCIA-cptac-lscc', 'TCIA-cptac-luad', 'IDC-IDC_cptac_luad', 'IDC-IDC_cptac_lscc'}	{'IDC', 'TCIA'}	12
-CT Pelvis with	{'CT', nan}	{'IDC-IDC_tcga_ov', 'TCIA-tcga-ov', 'TCIA-tcga-ucec', 'IDC-IDC_tcga_ucec'}	{'IDC', 'TCIA'}	12
-Abdomen^02_0_Abdomen_Pelvis_Routine (Adult)	{'CT', nan}	{'TCIA-tcga-kirc', 'IDC-IDC_tcga_kirc', 'TCIA-tcga-ucec', 'IDC-IDC_tcga_ucec'}	{'IDC', 'TCIA'}	12
-PETCT LIMITED VERTEX TO MID THIGH	{'CT', 'PT'}	{'MIDRC-Open-R1'}	{'MIDRC'}	12
-MRI BREAST UNI 2ND EX?	{'MR', nan}	{'IDC-IDC_acrin_contralateral_breast_mr', 'TCIA-acrin-contralateral-breast-mr'}	{'IDC', 'TCIA'}	12
-PETCT CONTRAST ENHANCE	{'SEG', nan}	{'IDC-IDC_anti_pd_1_lung', 'TCIA-anti-pd-1_lung'}	{'IDC', 'TCIA'}	12
-CT CAP LIVER	{'CT', 'SEG', nan}	{'IDC-IDC_hcc_tace_seg', 'TCIA-hcc-tace-seg'}	{'IDC', 'TCIA'}	12
-MAMMO-DIGITAL SCREENING BILAT W/ TOMOSYNTHESIS	{'MG'}	{'ACRdart-EA1141Restricted', 'IDC-IDC_ea1141'}	{'ACRdart', 'IDC'}	12
-CT ABDOMEN W&WO	{'CT', 'SEG', nan}	{'TCIA-tcga-kirc', 'IDC-IDC_tcga_kich', 'IDC-IDC_tcga_kirc', 'TCIA-tcga-kich'}	{'IDC', 'TCIA'}	12
-CT CHEST W/CONTRAST	{'CT', 'SEG', nan}	{'TCIA-acrin-nsclc-fdg-pet', 'IDC-IDC_nsclc_radiogenomics', 'TCIA-nsclc-radiogenomics', 'IDC-IDC_acrin_nsclc_fdg_pet'}	{'IDC', 'TCIA'}	12
-PET/CT LUNG MASS	{'SEG', nan}	{'IDC-IDC_nsclc_radiogenomics', 'TCIA-nsclc-radiogenomics'}	{'IDC', 'TCIA'}	12
-Abdomen^1AbdomenPETCT	{'SEG', nan}	{'TCIA-acrin-nsclc-fdg-pet', 'IDC-IDC_acrin_nsclc_fdg_pet'}	{'IDC', 'TCIA'}	12
-PET/CT LUNG SPN	{'SEG', nan}	{'IDC-IDC_nsclc_radiogenomics', 'TCIA-nsclc-radiogenomics'}	{'IDC', 'TCIA'}	12
-Whole-body PET	{'PT', nan}	{'TCIA-acrin-nsclc-fdg-pet', 'IDC-IDC_acrin_nsclc_fdg_pet'}	{'IDC', 'TCIA'}	12
-Abdomen^ABD_WO_GR (Adult)	{'CT'}	{'MIDRC-Open-A1'}	{'MIDRC'}	12
-PET SKULL-THIGH PLUS D	{'CT', 'PT', nan}	{'TCIA-breast-diagnosis', 'IDC-IDC_breast_diagnosis'}	{'IDC', 'TCIA'}	12
-Thorax^01ROUTINECHEST (Adult)	{'CT', 'SEG', nan}	{'IDC-IDC_nsclc_radiogenomics', 'TCIA-nsclc-radiogenomics'}	{'IDC', 'TCIA'}	12
-X-RAY PELVIS 1 OR 2 VIEWS	{'DX'}	{'MIDRC-Open-A1'}	{'MIDRC'}	11
-CT ABDOMEN PELVIS WWO (UROGRAM)	{'CT'}	{'MIDRC-Open-A1'}	{'MIDRC'}	11
-CT CARD CORONARY CALCM SCRE WO CON	{'CT'}	{'MIDRC-Open-A1', 'MIDRC-Open-R1'}	{'MIDRC'}	11
-CT CHEST WITH AND WITHOUT CONTRAST	{'CT'}	{'MIDRC-Open-R1'}	{'MIDRC'}	11
-Pelvis^PELVIS_HIP (Adult)	{'CT'}	{'MIDRC-Open-A1'}	{'MIDRC'}	11
-MRI PROSTATE W ENDORECTAL COIL	{'SEG'}	{'IDC-IDC_prostate_mri_us_biopsy'}	{'IDC'}	11
-RIGHT Unilateral with Tomo	{'MG'}	{'ACRdart-EA1141Restricted', 'IDC-IDC_ea1141'}	{'ACRdart', 'IDC'}	11
-BRST TOMOSYNTHESIS BILATERAL	{'MG'}	{'ACRdart-EA1141Restricted', 'IDC-IDC_ea1141'}	{'ACRdart', 'IDC'}	11
-XR LEFT HAND 1-2 VIEWS	{'CR', 'DX'}	{'MIDRC-Open-A1'}	{'MIDRC'}	11
-CT ANGIO CHEST	{'CT', nan}	{'MIDRC-Open-A1', 'MIDRC-Open-A1_PETAL_BLUECORAL', 'IDC-IDC_tcga_ucec', 'MIDRC-Open-A1_SCCM_VIRUS', 'TCIA-tcga-ucec'}	{'IDC', 'TCIA', 'MIDRC'}	11
-CT Chest w/o IV Contrast	{'CT'}	{'MIDRC-Open-R1'}	{'MIDRC'}	11
-BREAST^ROUTINE FOR MASS	{'MR'}	{'IDC-IDC_ispy1'}	{'IDC'}	11
-Thorax^CTA_AAA_Customized (Adult)	{'CT'}	{'MIDRC-Open-A1'}	{'MIDRC'}	11
-RT^RCCT_THORAX_8F_High (Adult)	{'RTSTRUCT', 'CT'}	{'IDC-IDC_lctsc'}	{'IDC'}	11
-Thorax^ROUTINE_CHEST_ABD_PEL_WITHOUT (Adult)	{'CT'}	{'MIDRC-Open-A1'}	{'MIDRC'}	11
-CT CHEST/ABD/PELVIS	{'CT', 'SEG', nan}	{'IDC-IDC_hcc_tace_seg', 'TCIA-hcc-tace-seg', 'IDC-IDC_acrin_nsclc_fdg_pet', 'TCIA-rider-pilot', 'TCIA-acrin-nsclc-fdg-pet', 'TCIA-tcga-kirp', 'IDC-IDC_tcga_kirp'}	{'IDC', 'TCIA'}	11
-CT ABDOMEN/PELVIS WITH CONTRAST (PETCT)	{'CT'}	{'MIDRC-Open-R1'}	{'MIDRC'}	11
-PET LYMPHOMA HODGKINS (W/LOW DOSE CT)	{'PT,CT'}	{'MIDRC-Open-A1'}	{'MIDRC'}	11
-JCCI CT CHEST WITHOUT	{'CT'}	{'MIDRC-Open-R1'}	{'MIDRC'}	11
-PET LYMPHOMA NON HODGK	{'PT,CT'}	{'MIDRC-Open-A1'}	{'MIDRC'}	11
-CT CORONARY CALCIUM SCORE	{'CT'}	{'MIDRC-Open-R1'}	{'MIDRC'}	11
-CHEST, PA AND LAT	{'CR'}	{'MIDRC-Open-R1'}	{'MIDRC'}	11
-Thorax^XL_CHEST_WITH (Adult)	{'CT'}	{'MIDRC-Open-A1'}	{'MIDRC'}	11
-CT CAP W CONTRAST	{'CT'}	{'MIDRC-Open-R1'}	{'MIDRC'}	11
-CT CHEST PE PROTOCOL	{'CT', nan}	{'MIDRC-Open-A1', 'TCIA-acrin-nsclc-fdg-pet', 'MIDRC-Open-A1_PETAL_BLUECORAL', 'IDC-IDC_acrin_nsclc_fdg_pet'}	{'IDC', 'TCIA', 'MIDRC'}	11
-CT THORAX WITHOUT CONTRAST	{'CT', nan}	{'MIDRC-Open-A1_PETAL_BLUECORAL', 'TCIA-varepop-apollo', 'MIDRC-Open-A1_PETAL_REDCORAL'}	{'TCIA', 'MIDRC'}	11
-Thorax^ROUTINE_CHEST_HR (Adult)	{'CT'}	{'MIDRC-Open-A1'}	{'MIDRC'}	11
-MRI BREAST BILAT W+ OR WO CONT	{'MR'}	{'IDC-IDC_ispy1'}	{'IDC'}	11
-MA Surgical Specimen	{'MG', nan}	{'TCIA-breast-diagnosis', 'IDC-IDC_breast_diagnosis'}	{'IDC', 'TCIA'}	10
-59-1-59-2-B	{'SR', nan}	{'TCIA-rider-pilot', 'IDC-IDC_rider_pilot'}	{'IDC', 'TCIA'}	10
-Scanner-Philips_Exp-100_Pitch-1.2_SlCol-16x0.75mm	{'CT', nan}	{'IDC-IDC_phantom_fda', 'TCIA-phantom-fda'}	{'IDC', 'TCIA'}	10
-MAMMO diagnostic digital right	{'MG', nan}	{'TCIA-breast-cancer-screening-dbt', 'IDC-IDC_breast_cancer_screening_dbt'}	{'IDC', 'TCIA'}	10
-58-2-58-1-B	{'SR', nan}	{'TCIA-rider-pilot', 'IDC-IDC_rider_pilot'}	{'IDC', 'TCIA'}	10
-Thorax^C_A_P_WITH (Adult)	{'CT'}	{'MIDRC-Open-A1'}	{'MIDRC'}	10
-27-1-27-2-B	{'SR', nan}	{'TCIA-rider-lung-ct', 'IDC-IDC_rider_lung_ct'}	{'IDC', 'TCIA'}	10
-28-2-28-1-B	{'SR', nan}	{'TCIA-rider-lung-ct', 'IDC-IDC_rider_lung_ct'}	{'IDC', 'TCIA'}	10
-05-2-05-1-B	{'SR', nan}	{'TCIA-rider-lung-ct', 'IDC-IDC_rider_lung_ct'}	{'IDC', 'TCIA'}	10
-CT ABDOMEN wo&w& PELVIS w	{'CT', nan}	{'TCIA-tcga-lihc', 'IDC-IDC_tcga_lihc'}	{'IDC', 'TCIA'}	10
-ABD/PELVIS	{'CT', 'SEG', nan}	{'IDC-IDC_hcc_tace_seg', 'IDC-IDC_tcga_ov', 'TCIA-hcc-tace-seg', 'TCIA-tcga-kirc', 'TCIA-tcga-ov', 'IDC-IDC_tcga_kirc'}	{'IDC', 'TCIA'}	10
-SPINE^CTL	{'MR', 'SEG', nan}	{'IDC-IDC_upenn_gbm', 'TCIA-upenn-gbm'}	{'IDC', 'TCIA'}	10
-Thorax^1ThoraxPETCT	{'CT', 'SEG', nan}	{'TCIA-acrin-nsclc-fdg-pet', 'IDC-IDC_acrin_nsclc_fdg_pet'}	{'IDC', 'TCIA'}	10
-24-2-24-1-B	{'SR', nan}	{'TCIA-rider-lung-ct', 'IDC-IDC_rider_lung_ct'}	{'IDC', 'TCIA'}	10
-PET / CT TUMOR IMAGING	{'RTSTRUCT', 'SEG', nan}	{'IDC-IDC_tcga_lusc', 'TCIA-tcga-luad', 'TCIA-tcga-lusc', 'TCIA-cptac-ucec', 'IDC-IDC_cptac_ucec', 'IDC-IDC_tcga_luad'}	{'IDC', 'TCIA'}	10
-68-1-68-2-B	{'SR', nan}	{'TCIA-rider-pilot', 'IDC-IDC_rider_pilot'}	{'IDC', 'TCIA'}	10
-26-1-26-2-B	{'SR', nan}	{'TCIA-rider-lung-ct', 'IDC-IDC_rider_lung_ct'}	{'IDC', 'TCIA'}	10
-SL4 Treatment:Tx Plan	{'CT', nan}	{'IDC-IDC_pelvic_reference_data', 'TCIA-pelvic-reference-data'}	{'IDC', 'TCIA'}	10
-CT HEAD W/O CM	{'CT'}	{'MIDRC-Open-A1'}	{'MIDRC'}	10
-MR BREAST UNILAT LEFT	{'MR', 'SEG'}	{'IDC-IDC_ispy1'}	{'IDC'}	10
-25-1-25-2-B	{'SR', nan}	{'TCIA-rider-lung-ct', 'IDC-IDC_rider_lung_ct'}	{'IDC', 'TCIA'}	10
-OSI PET CT SKULL TO MID THIGH	{'SEG', nan}	{'IDC-IDC_anti_pd_1_lung', 'TCIA-anti-pd-1_lung'}	{'IDC', 'TCIA'}	10
-67-1-67-2-B	{'SR', nan}	{'TCIA-rider-pilot', 'IDC-IDC_rider_pilot'}	{'IDC', 'TCIA'}	10
-SPECT^SPECT 3D	{'MR', 'SEG', nan}	{'IDC-IDC_upenn_gbm', 'TCIA-upenn-gbm'}	{'IDC', 'TCIA'}	10
-69-2-69-1-B	{'SR', nan}	{'TCIA-rider-pilot', 'IDC-IDC_rider_pilot'}	{'IDC', 'TCIA'}	10
-CT ABDOMEN W/ CONTRAST	{'CT', 'SEG', nan}	{'TCIA-tcga-coad', 'IDC-IDC_tcga_coad', 'TCIA-colorectal-liver-metastases', 'TCIA-tcga-kirc', 'IDC-IDC_colorectal_liver_metastases', 'IDC-IDC_tcga_kirc'}	{'IDC', 'TCIA'}	10
-29-2-29-1-B	{'SR', nan}	{'TCIA-rider-lung-ct', 'IDC-IDC_rider_lung_ct'}	{'IDC', 'TCIA'}	10
-66-2-66-1-B	{'SR', nan}	{'TCIA-rider-pilot', 'IDC-IDC_rider_pilot'}	{'IDC', 'TCIA'}	10
-CT ABDOMEN PELVIS WWO CONTRAST (ISCHEMIA)	{'CT'}	{'MIDRC-Open-A1'}	{'MIDRC'}	10
-_t1of9External Images for PACS	{'MR', nan}	{'IDC-IDC_vestibular_schwannoma_mc_rc', 'TCIA-vestibular-schwannoma-mc-rc'}	{'IDC', 'TCIA'}	10
-CALCIUM SCORING(Adult)	{'CT'}	{'MIDRC-Open-A1'}	{'MIDRC'}	10
-CT Pelvis w/o	{'CT', nan}	{'IDC-IDC_tcga_prad', 'TCIA-tcga-prad', 'TCIA-tcga-ucec', 'IDC-IDC_tcga_ucec'}	{'IDC', 'TCIA'}	10
-XR RIGHT HIP 2-3 VIEWS (UNILATERAL) WITH PELVIS WHEN PERFORMED	{'CR', 'DX'}	{'MIDRC-Open-A1'}	{'MIDRC'}	10
-55-2-55-1-B	{'SR', nan}	{'TCIA-rider-pilot', 'IDC-IDC_rider_pilot'}	{'IDC', 'TCIA'}	10
-54-2-54-1-B	{'SR', nan}	{'TCIA-rider-pilot', 'IDC-IDC_rider_pilot'}	{'IDC', 'TCIA'}	10
-53-2-53-1-B	{'SR', nan}	{'TCIA-rider-pilot', 'IDC-IDC_rider_pilot'}	{'IDC', 'TCIA'}	10
-23-1-23-2-B	{'SR', nan}	{'TCIA-rider-lung-ct', 'IDC-IDC_rider_lung_ct'}	{'IDC', 'TCIA'}	10
-CHEST/ABDOMEN CT	{'CT', nan}	{'TCIA-acrin-nsclc-fdg-pet', 'IDC-IDC_acrin_nsclc_fdg_pet'}	{'IDC', 'TCIA'}	10
-Specials^2415_04_Colonography_ACRIN (Adult)	{'CT', nan}	{'TCIA-ct-colonography', 'IDC-IDC_ct_colonography'}	{'IDC', 'TCIA'}	10
-Thorax^CHEST_CONTRAST (Adult)	{'CT', 'SEG', nan}	{'IDC-IDC_nsclc_radiogenomics', 'TCIA-nsclc-radiogenomics'}	{'IDC', 'TCIA'}	10
-52-1-52-2-B	{'SR', nan}	{'TCIA-rider-pilot', 'IDC-IDC_rider_pilot'}	{'IDC', 'TCIA'}	10
-FORFILE CT CH/AB/PEL - CD	{'CT', 'SEG', nan}	{'IDC-IDC_tcga_ov', 'TCIA-tcga-kirc', 'TCIA-tcga-ov', 'IDC-IDC_tcga_blca', 'IDC-IDC_tcga_kirc', 'TCIA-tcga-blca'}	{'IDC', 'TCIA'}	10
-02-1-02-2-B	{'SR', nan}	{'TCIA-rider-lung-ct', 'IDC-IDC_rider_lung_ct'}	{'IDC', 'TCIA'}	10
-51-1-51-2-B	{'SR', nan}	{'TCIA-rider-pilot', 'IDC-IDC_rider_pilot'}	{'IDC', 'TCIA'}	10
-56-1-56-2-B	{'SR', nan}	{'TCIA-rider-pilot', 'IDC-IDC_rider_pilot'}	{'IDC', 'TCIA'}	10
-03-1-03-2-B	{'SR', nan}	{'TCIA-rider-lung-ct', 'IDC-IDC_rider_lung_ct'}	{'IDC', 'TCIA'}	10
-65-1-65-2-B	{'SR', nan}	{'TCIA-rider-pilot', 'IDC-IDC_rider_pilot'}	{'IDC', 'TCIA'}	10
-CT ABDOMEN WO/W CONT	{'CT', nan}	{'IDC-IDC_rider_lung_pet_ct', 'TCIA-rider-lung-pet-ct'}	{'IDC', 'TCIA'}	10
-64-2-64-1-B	{'SR', nan}	{'TCIA-rider-pilot', 'IDC-IDC_rider_pilot'}	{'IDC', 'TCIA'}	10
-63-1-63-2-B	{'SR', nan}	{'TCIA-rider-pilot', 'IDC-IDC_rider_pilot'}	{'IDC', 'TCIA'}	10
-62-1-62-2-B	{'SR', nan}	{'TCIA-rider-pilot', 'IDC-IDC_rider_pilot'}	{'IDC', 'TCIA'}	10
-57-2-57-1-B	{'SR', nan}	{'TCIA-rider-pilot', 'IDC-IDC_rider_pilot'}	{'IDC', 'TCIA'}	10
-61-2-61-1-B	{'SR', nan}	{'TCIA-rider-pilot', 'IDC-IDC_rider_pilot'}	{'IDC', 'TCIA'}	10
-BRONCHOSCOPY	{'RF'}	{'MIDRC-Open-R1'}	{'MIDRC'}	10
-04-1-04-2-B	{'SR', nan}	{'TCIA-rider-lung-ct', 'IDC-IDC_rider_lung_ct'}	{'IDC', 'TCIA'}	10
-BRAIN^3T ADVANCED IMAGING	{'MR', nan}	{'IDC-IDC_upenn_gbm', 'TCIA-upenn-gbm'}	{'IDC', 'TCIA'}	10
-60-2-60-1-B	{'SR', nan}	{'TCIA-rider-pilot', 'IDC-IDC_rider_pilot'}	{'IDC', 'TCIA'}	10
-CT Urogram w 3D	{'CR', 'CT', nan}	{'TCIA-pseudo-phi-dicom-data', 'TCIA-tcga-kirc', 'IDC-IDC_tcga_ucec', 'IDC-IDC_pseudo_phi_dicom_data', 'IDC-IDC_tcga_kirc', 'TCIA-tcga-ucec'}	{'IDC', 'TCIA'}	10
-01-2-01-1-B	{'SR', nan}	{'TCIA-rider-lung-ct', 'IDC-IDC_rider_lung_ct'}	{'IDC', 'TCIA'}	10
-_t2of3  External Images for PACS	{'MR', nan}	{'IDC-IDC_vestibular_schwannoma_mc_rc', 'TCIA-vestibular-schwannoma-mc-rc'}	{'IDC', 'TCIA'}	10
-CT ABDOMEN w & PELVIS	{'CT', nan}	{'IDC-IDC_tcga_ov', 'TCIA-tcga-kirc', 'TCIA-tcga-ov', 'IDC-IDC_tcga_ucec', 'IDC-IDC_tcga_kirc', 'TCIA-tcga-ucec'}	{'IDC', 'TCIA'}	10
-CT CHEST ABDOMEN & PELVIS ENHANCED=AB	{'RTSTRUCT', nan}	{'TCIA-cptac-pda', 'IDC-IDC_cptac_pda'}	{'IDC', 'TCIA'}	10
-Scanner-Philips_Exp-200_Pitch-1.2_SlCol-16x0.75mm	{'CT', nan}	{'IDC-IDC_phantom_fda', 'TCIA-phantom-fda'}	{'IDC', 'TCIA'}	10
-SCREENING MAMMO/TOMO BIL	{'MG'}	{'ACRdart-EA1141Restricted', 'IDC-IDC_ea1141'}	{'ACRdart', 'IDC'}	10
-Head^CTA_HEAD_NECK (Adult)	{'CT'}	{'MIDRC-Open-A1'}	{'MIDRC'}	10
-XR LEFT CLAVICLE	{'CR', 'DX'}	{'MIDRC-Open-A1'}	{'MIDRC'}	10
-09-2-09-1-B	{'SR', nan}	{'TCIA-rider-lung-ct', 'IDC-IDC_rider_lung_ct'}	{'IDC', 'TCIA'}	10
-30-1-30-2-B	{'SR', nan}	{'TCIA-rider-lung-ct', 'IDC-IDC_rider_lung_ct'}	{'IDC', 'TCIA'}	10
-MRI BREAST RT	{'MR', nan}	{'IDC-IDC_acrin_contralateral_breast_mr', 'TCIA-acrin-contralateral-breast-mr'}	{'IDC', 'TCIA'}	10
-CT ANGIO LIVER WITH PEL	{'SEG', nan}	{'TCIA-colorectal-liver-metastases', 'IDC-IDC_colorectal_liver_metastases'}	{'IDC', 'TCIA'}	10
-CT Chest routine (cont	{'CT', nan}	{'TCIA-acrin-nsclc-fdg-pet', 'IDC-IDC_acrin_nsclc_fdg_pet'}	{'IDC', 'TCIA'}	10
-CT Abdomen with	{'CT', nan}	{'IDC-IDC_tcga_ov', 'IDC-IDC_tcga_prad', 'TCIA-tcga-prad', 'TCIA-tcga-ov', 'IDC-IDC_tcga_ucec', 'TCIA-tcga-ucec'}	{'IDC', 'TCIA'}	10
-Chest 2 Views Frontal and Lat	{'CR', 'CR,DX', 'DX'}	{'MIDRC-Open-A1_PETAL_BLUECORAL', 'MIDRC-Open-A1_PETAL_REDCORAL'}	{'MIDRC'}	10
-15-2-15-1-B	{'SR', nan}	{'TCIA-rider-lung-ct', 'IDC-IDC_rider_lung_ct'}	{'IDC', 'TCIA'}	10
-Abdomen^ROUTINE_ABD_PEL_WITHOUT (Adult)	{'CT'}	{'MIDRC-Open-A1'}	{'MIDRC'}	10
-17-1-17-2-B	{'SR', nan}	{'TCIA-rider-lung-ct', 'IDC-IDC_rider_lung_ct'}	{'IDC', 'TCIA'}	10
-X-RAY THORACIC SPINE 2 VIEWS	{'DX'}	{'MIDRC-Open-A1'}	{'MIDRC'}	10
-16-1-16-2-B	{'SR', nan}	{'TCIA-rider-lung-ct', 'IDC-IDC_rider_lung_ct'}	{'IDC', 'TCIA'}	10
-_t3of3MRI Stereo Gamma Knife	{'MR', nan}	{'IDC-IDC_vestibular_schwannoma_mc_rc', 'TCIA-vestibular-schwannoma-mc-rc'}	{'IDC', 'TCIA'}	10
-CT CHEST ANGIO W OR W AND WO IV CONTRAST	{'CT'}	{'MIDRC-Open-A1'}	{'MIDRC'}	10
-08-2-08-1-B	{'SR', nan}	{'TCIA-rider-lung-ct', 'IDC-IDC_rider_lung_ct'}	{'IDC', 'TCIA'}	10
-Abdomen^STONE_STUDY (Adult)	{'CT'}	{'MIDRC-Open-A1'}	{'MIDRC'}	10
-CT_Biopsy	{'CT', nan}	{'IDC-IDC_cmb_mml', 'TCIA-cmb-aml', 'TCIA-cmb-mml', 'IDC-IDC_cmb_aml'}	{'IDC', 'TCIA'}	10
-CT ANGIOGRAM CHEST (S)	{'CT'}	{'MIDRC-Open-R1'}	{'MIDRC'}	10
-MRI Pelvis w/ + w/o Contrast-Prostate	{'MR'}	{'ACRdart-ACRIN_6701'}	{'ACRdart'}	10
-_t6of6  MRI IAMS	{'MR', nan}	{'IDC-IDC_vestibular_schwannoma_mc_rc', 'TCIA-vestibular-schwannoma-mc-rc'}	{'IDC', 'TCIA'}	10
-31-2-31-1-B	{'SR', nan}	{'TCIA-rider-lung-ct', 'IDC-IDC_rider_lung_ct'}	{'IDC', 'TCIA'}	10
-Abdomen^BrzuchMiednica (Adult)	{'RTSTRUCT', 'CT', nan}	{'IDC-IDC_cptac_ucec', 'TCIA-cptac-ucec'}	{'IDC', 'TCIA'}	10
-MRI BREAST BIL ABBREVIATED W WO CONTRAST WO CAD (77059) [IMG1150	{'MR'}	{'ACRdart-EA1141Restricted'}	{'ACRdart'}	10
-14-1-14-2-B	{'SR', nan}	{'TCIA-rider-lung-ct', 'IDC-IDC_rider_lung_ct'}	{'IDC', 'TCIA'}	10
-70-1-70-2-B	{'SR', nan}	{'TCIA-rider-pilot', 'IDC-IDC_rider_pilot'}	{'IDC', 'TCIA'}	10
-12-1-12-2-B	{'SR', nan}	{'TCIA-rider-lung-ct', 'IDC-IDC_rider_lung_ct'}	{'IDC', 'TCIA'}	10
-CT Abdomen	{'CT', nan}	{'TCIA-cmb-crc', 'TCIA-adrenal-acc-ki67-seg', 'IDC-IDC_adrenal_acc_ki67_seg', 'IDC-IDC_cmb_crc'}	{'IDC', 'TCIA'}	10
-CT_Biopsy_BoneMarrow	{'CT', nan}	{'IDC-IDC_cmb_mml', 'TCIA-cmb-mml'}	{'IDC', 'TCIA'}	10
-PET LUNG CANCER OR PUL	{'PT,CT'}	{'MIDRC-Open-A1'}	{'MIDRC'}	10
-CT ABD LIVER	{'SEG', nan}	{'IDC-IDC_hcc_tace_seg', 'TCIA-hcc-tace-seg'}	{'IDC', 'TCIA'}	10
-11-2-11-1-B	{'SR', nan}	{'TCIA-rider-lung-ct', 'IDC-IDC_rider_lung_ct'}	{'IDC', 'TCIA'}	10
-PETCT_Skull_MidThigh	{'CT', nan}	{'IDC-IDC_cmb_lca', 'TCIA-cmb-crc', 'IDC-IDC_cmb_crc', 'TCIA-cmb-lca', 'TCIA-cmb-mml'}	{'IDC', 'TCIA'}	10
-32-1-32-2-B	{'SR', nan}	{'TCIA-rider-lung-ct', 'IDC-IDC_rider_lung_ct'}	{'IDC', 'TCIA'}	10
-MRI BREAST LT	{'MR', nan}	{'IDC-IDC_acrin_contralateral_breast_mr', 'TCIA-acrin-contralateral-breast-mr'}	{'IDC', 'TCIA'}	10
-10-2-10-1-B	{'SR', nan}	{'TCIA-rider-lung-ct', 'IDC-IDC_rider_lung_ct'}	{'IDC', 'TCIA'}	10
-HEAD^SPECTROSCOPY	{'MR', 'SEG', nan}	{'IDC-IDC_upenn_gbm', 'TCIA-upenn-gbm'}	{'IDC', 'TCIA'}	10
-Abdomen^TRIO_TX_AS_AIVOL (Adult)	{'CT', nan}	{'IDC-IDC_tcga_esca', 'TCIA-tcga-stad', 'IDC-IDC_tcga_stad', 'TCIA-tcga-esca'}	{'IDC', 'TCIA'}	10
-HEAD^BTP/STEALTH/SPECT	{'MR', 'SEG', nan}	{'IDC-IDC_upenn_gbm', 'TCIA-upenn-gbm'}	{'IDC', 'TCIA'}	10
-PET WB LOW BMI	{'CT', 'PT', nan}	{'TCIA-cptac-lscc', 'TCIA-cptac-luad', 'IDC-IDC_cptac_luad', 'IDC-IDC_cptac_lscc'}	{'IDC', 'TCIA'}	10
-06-2-06-1-B	{'SR', nan}	{'TCIA-rider-lung-ct', 'IDC-IDC_rider_lung_ct'}	{'IDC', 'TCIA'}	10
-PET NON-SMALL CELL LUNG RESTAGING	{'SEG', nan}	{'TCIA-acrin-nsclc-fdg-pet', 'IDC-IDC_acrin_nsclc_fdg_pet'}	{'IDC', 'TCIA'}	10
-MR HEAD W AND WO IV CONTRAST TUMOR FOLLOWUP	{'MR', 'SEG', nan}	{'IDC-IDC_upenn_gbm', 'TCIA-upenn-gbm'}	{'IDC', 'TCIA'}	10
-RESEARCH MRI PELVIS	{'MR'}	{'ACRdart-ACRIN_6701'}	{'ACRdart'}	10
-MR HEAD W AND WO IV CONTRAST METASTASIS	{'MR', 'SEG', nan}	{'IDC-IDC_upenn_gbm', 'TCIA-upenn-gbm'}	{'IDC', 'TCIA'}	10
-LUNG LW DOSE_LUNG SCREEN(Adult)	{'CT'}	{'MIDRC-Open-A1'}	{'MIDRC'}	10
-06. Chest, Abdomen CE	{'CT', 'SEG', nan}	{'IDC-IDC_cptac_lscc', 'IDC-IDC_cptac_luad', 'TCIA-cptac-luad', 'TCIA-cptac-ccrcc', 'IDC-IDC_cptac_ccrcc', 'TCIA-cptac-lscc', 'TCIA-cptac-sar', 'IDC-IDC_cptac_sar'}	{'IDC', 'TCIA'}	10
-chest_abdomen__w	{'SEG', nan}	{'TCIA-c4kc-kits', 'IDC-IDC_c4kc_kits'}	{'IDC', 'TCIA'}	10
-_t2of3_MR IAM's	{'MR'}	{'IDC-IDC_vestibular_schwannoma_mc_rc'}	{'IDC'}	10
-21-1-21-2-B	{'SR', nan}	{'TCIA-rider-lung-ct', 'IDC-IDC_rider_lung_ct'}	{'IDC', 'TCIA'}	10
-22-2-22-1-B	{'SR', nan}	{'TCIA-rider-lung-ct', 'IDC-IDC_rider_lung_ct'}	{'IDC', 'TCIA'}	10
-MR CERVICAL SPINE WITHOUT CONTRAST	{'MR'}	{'MIDRC-Open-R1'}	{'MIDRC'}	10
-coffee break exam - t+0 mins	{'MR', nan}	{'TCIA-rider-breast-mri', 'IDC-IDC_rider_breast_mri'}	{'IDC', 'TCIA'}	10
-MR Breast WWO Research ECOG-ACRIN	{'MR'}	{'ACRdart-EA1141Restricted', 'IDC-IDC_ea1141'}	{'ACRdart', 'IDC'}	10
-coffee break exam - t+15 mins	{'MR', nan}	{'TCIA-rider-breast-mri', 'IDC-IDC_rider_breast_mri'}	{'IDC', 'TCIA'}	10
-20-2-20-1-B	{'SR', nan}	{'TCIA-rider-lung-ct', 'IDC-IDC_rider_lung_ct'}	{'IDC', 'TCIA'}	10
-13-2-13-1-B	{'SR', nan}	{'TCIA-rider-lung-ct', 'IDC-IDC_rider_lung_ct'}	{'IDC', 'TCIA'}	10
-Adult Chest - 1 View	{'DX'}	{'MIDRC-Open-R1'}	{'MIDRC'}	10
-UPPER GI	{'RTDOSE', 'RTSTRUCT', 'CT', nan}	{'IDC-IDC_pancreatic_ct_cbct_seg', 'TCIA-pancreatic-ct-cbct-seg'}	{'IDC', 'TCIA'}	10
-_t2of3_MR IAMs	{nan}	{'TCIA-vestibular-schwannoma-mc-rc'}	{'TCIA'}	10
-19-1-19-2-B	{'SR', nan}	{'TCIA-rider-lung-ct', 'IDC-IDC_rider_lung_ct'}	{'IDC', 'TCIA'}	10
-_t3of3  External Images for PACS	{'MR', nan}	{'IDC-IDC_vestibular_schwannoma_mc_rc', 'TCIA-vestibular-schwannoma-mc-rc'}	{'IDC', 'TCIA'}	10
-DIGITAL MAMMOGRAM, BILATERAL	{'MG', nan}	{'TCIA-breast-diagnosis', 'IDC-IDC_pseudo_phi_dicom_data', 'TCIA-pseudo-phi-dicom-data', 'IDC-IDC_breast_diagnosis'}	{'IDC', 'TCIA'}	10
-RESEARCH001^BREAST RESEARCH	{'MR', nan}	{'IDC-IDC_acrin_contralateral_breast_mr', 'TCIA-acrin-contralateral-breast-mr'}	{'IDC', 'TCIA'}	10
-ch+c	{'CT', 'SEG', nan}	{'IDC-IDC_lung_pet_ct_dx', 'TCIA-lung-pet-ct-dx'}	{'IDC', 'TCIA'}	10
-18-2-18-1-B	{'SR', nan}	{'TCIA-rider-lung-ct', 'IDC-IDC_rider_lung_ct'}	{'IDC', 'TCIA'}	10
-MRI_L_Spine	{'MR', nan}	{'IDC-IDC_cmb_mml', 'TCIA-cmb-mml'}	{'IDC', 'TCIA'}	10
-07-1-07-2-B	{'SR', nan}	{'TCIA-rider-lung-ct', 'IDC-IDC_rider_lung_ct'}	{'IDC', 'TCIA'}	10
-X-RAY KNEE 1 OR 2 VIEWS - LEFT	{'CR', 'DX'}	{'MIDRC-Open-A1'}	{'MIDRC'}	10
-CHEST PE IP	{'CT', nan}	{'TCIA-acrin-nsclc-fdg-pet', 'MIDRC-Open-R1', 'IDC-IDC_acrin_nsclc_fdg_pet'}	{'IDC', 'TCIA', 'MIDRC'}	9
-CT CHEST W O CONTRAST	{'CT'}	{'MIDRC-Open-A1_PETAL_BLUECORAL', 'MIDRC-Open-A1_PETAL_REDCORAL'}	{'MIDRC'}	9
-CT CHEST W IVCON PE	{'CT'}	{'MIDRC-Open-A1_PETAL_BLUECORAL', 'MIDRC-Open-A1_PETAL_REDCORAL'}	{'MIDRC'}	9
-CT CHEST W/ CON	{'SEG', nan}	{'TCIA-varepop-apollo', 'IDC-IDC_nsclc_radiogenomics', 'TCIA-nsclc-radiogenomics'}	{'IDC', 'TCIA'}	9
-CT CHEST WO IVCON	{'CT'}	{'MIDRC-Open-A1_PETAL_BLUECORAL', 'MIDRC-Open-A1_PETAL_REDCORAL'}	{'MIDRC'}	9
-CT CHEST ABDOMEN PELVIS W CONTRAST (PANCREAS)	{'CT'}	{'MIDRC-Open-A1'}	{'MIDRC'}	9
-PET LUNG CANCER OR PULMONARY NODULE (W/LOW DOSE CT)	{'PT,CT'}	{'MIDRC-Open-A1'}	{'MIDRC'}	9
-BRST BILAT DIAGNOSTIC MAMMO W/ TOMO	{'MG'}	{'ACRdart-EA1141Restricted', 'IDC-IDC_ea1141'}	{'ACRdart', 'IDC'}	9
-Ultrasound	{'US'}	{'ACRdart-ACRIN_6666'}	{'ACRdart'}	9
-THORAX + CONT	{'CT', nan}	{'IDC-IDC_midrc_ricord_1a', 'TCIA-midrc-ricord-1b', 'TCIA-midrc-ricord-1a', 'MIDRC-TCIA-RICORD_1b', 'IDC-IDC_midrc_ricord_1b', 'MIDRC-TCIA-RICORD_1a'}	{'IDC', 'TCIA', 'MIDRC'}	9
-CT ABDOMEN PELVIS W CONTRAST	{'CT'}	{'MIDRC-Open-A1_PETAL_BLUECORAL', 'MIDRC-Open-R1', 'MIDRC-Open-A1_PETAL_REDCORAL'}	{'MIDRC'}	9
-ABDOMEN 1 VW(PORTABLE) - FEEDING (NG/PEG) TUBE CHK WO INJ BY RAD	{'CR', 'DX'}	{'MIDRC-Open-R1'}	{'MIDRC'}	9
-CT PULMONARY W/CONTRAS	{'CT'}	{'MIDRC-Open-A1_PETAL_BLUECORAL', 'MIDRC-Open-A1_PETAL_REDCORAL'}	{'MIDRC'}	9
-MRI BREAST UNI/MBRU	{'MR', 'SEG'}	{'IDC-IDC_ispy1'}	{'IDC'}	9
-Thorax^CAP_WITH_Customized (Adult)	{'CT'}	{'MIDRC-Open-A1'}	{'MIDRC'}	9
-JOINY CT CHEST WO	{'CT'}	{'MIDRC-Open-R1'}	{'MIDRC'}	9
-XR RIGHT FOREARM 2 VIEWS	{'CR', 'DX'}	{'MIDRC-Open-A1'}	{'MIDRC'}	9
-Thorax^FLASH_CAP_WO (Adult)	{'CT'}	{'MIDRC-Open-A1'}	{'MIDRC'}	9
-Abdomen^HEMATURIA_OVER_45 (Adult)	{'CT'}	{'MIDRC-Open-A1'}	{'MIDRC'}	9
-ABD UPRT VIEWONLY	{'CR', 'DX', nan}	{'MIDRC-TCIA-COVID-19-NY-SBU', 'IDC-IDC_covid_19_ny_sbu', 'TCIA-covid-19-ny-sbu'}	{'IDC', 'TCIA', 'MIDRC'}	9
-MR BREAST BILAT W WO CONTRAST	{'MR'}	{'ACRdart-EA1141Restricted', 'IDC-IDC_ea1141'}	{'ACRdart', 'IDC'}	9
-XR RIGHT FOOT 1-2 VIEWS	{'CR', 'DX'}	{'MIDRC-Open-A1'}	{'MIDRC'}	9
-CT Thorax W/O Contrast	{'CT'}	{'MIDRC-Open-A1_PETAL_BLUECORAL', 'MIDRC-Open-A1_PETAL_REDCORAL'}	{'MIDRC'}	9
-MR BREAST UNILAT RIGHT	{'MR', 'SEG'}	{'IDC-IDC_ispy1'}	{'IDC'}	9
-CHEST - 2 VIEW	{'CR'}	{'MIDRC-Open-A1'}	{'MIDRC'}	9
-MR CARDIAC FUNCTION / MORPHOLOGY WITH AND WITHOUT CONTRAST	{'MR'}	{'MIDRC-Open-R1'}	{'MIDRC'}	9
-CT VIRTUAL COLONSCOPY SCREENING	{'CT', nan}	{'TCIA-ct-colonography', 'IDC-IDC_ct_colonography'}	{'IDC', 'TCIA'}	9
-MR Breast Research Grant Study	{'MR', 'SEG'}	{'IDC-IDC_ispy1'}	{'IDC'}	9
-LUNG PERFU SION IMAGING	{'CT', 'NM', nan}	{'MIDRC-TCIA-COVID-19-NY-SBU', 'IDC-IDC_covid_19_ny_sbu', 'TCIA-covid-19-ny-sbu'}	{'IDC', 'TCIA', 'MIDRC'}	9
-CT ABD AND PELVIS WO CONTRAST-CS	{'CT'}	{'MIDRC-Open-A1'}	{'MIDRC'}	9
-FOOT LEFT COMPLETE MIN 3 VIEWS	{'CR', 'DX'}	{'MIDRC-Open-R1'}	{'MIDRC'}	9
-CT, LUNG, MED, PLEURA	{'SEG', nan}	{'TCIA-tcga-kirc', 'TCIA-lidc-idri', 'IDC-IDC_lidc_idri', 'IDC-IDC_tcga_kirc'}	{'IDC', 'TCIA'}	8
-CR DIAG-CHEST PA OR AP	{'CR'}	{'MIDRC-Open-A1_PETAL_BLUECORAL', 'MIDRC-Open-A1_PETAL_REDCORAL'}	{'MIDRC'}	8
-X-RAY FOOT COMPLETE MINIMUM 3 VIEWS - LEFT	{'CR', 'DX'}	{'MIDRC-Open-A1'}	{'MIDRC'}	8
-X-RAY ANKLE COMPLETE MINIMUM 3 VIEWS - LEFT	{'DX'}	{'MIDRC-Open-A1'}	{'MIDRC'}	8
-Thorax^CHEST_ABD_PELVIS_WO (Adult)	{'CT'}	{'MIDRC-Open-A1'}	{'MIDRC'}	8
-CT ABD & PELVIS W/O &	{'CT', 'SEG', nan}	{'IDC-IDC_hcc_tace_seg', 'IDC-IDC_tcga_blca', 'TCIA-hcc-tace-seg', 'TCIA-tcga-blca'}	{'IDC', 'TCIA'}	8
-HEAD^ BRAIN	{'SEG', nan}	{'IDC-IDC_upenn_gbm', 'TCIA-upenn-gbm'}	{'IDC', 'TCIA'}	8
-MAMMO WITH TOMOSYNTHESIS SCREENING BILATERAL	{'MG'}	{'ACRdart-EA1141Restricted', 'IDC-IDC_ea1141'}	{'ACRdart', 'IDC'}	8
-US	{'US'}	{'ACRdart-ACRIN_6666'}	{'ACRdart'}	8
-CT THORAX W/O	{'CT', 'SEG', nan}	{'TCIA-acrin-nsclc-fdg-pet', 'IDC-IDC_nsclc_radiogenomics', 'TCIA-nsclc-radiogenomics', 'IDC-IDC_acrin_nsclc_fdg_pet'}	{'IDC', 'TCIA'}	8
-CONTRABREAST - RT	{'MR', nan}	{'IDC-IDC_acrin_contralateral_breast_mr', 'TCIA-acrin-contralateral-breast-mr'}	{'IDC', 'TCIA'}	8
-CT ABD/PEL EXTERNAL IMAGING	{'RTSTRUCT', nan}	{'TCIA-cptac-pda', 'IDC-IDC_cptac_pda'}	{'IDC', 'TCIA'}	8
-CTA CHEST	{'CT'}	{'MIDRC-Open-A1', 'MIDRC-Open-A1_SCCM_VIRUS', 'MIDRC-Open-A1_PETAL_BLUECORAL'}	{'MIDRC'}	8
-Vascular^THORACIC_DISSECTION_CTA (Adult)	{'CT'}	{'MIDRC-Open-A1'}	{'MIDRC'}	8
-CAP IV IP	{'CT'}	{'MIDRC-Open-R1'}	{'MIDRC'}	8
-CT  C/A/P  LIVER	{'CT', 'SEG', nan}	{'IDC-IDC_hcc_tace_seg', 'TCIA-hcc-tace-seg'}	{'IDC', 'TCIA'}	8
-LUMBAR SACRAL SPINE 2/3 VIEWS	{'CR', 'DX'}	{'MIDRC-Open-R1'}	{'MIDRC'}	8
-Thorax^Thorax+abdo (Adult)	{'CT', nan}	{'IDC-IDC_lung_pet_ct_dx', 'TCIA-lung-pet-ct-dx'}	{'IDC', 'TCIA'}	8
-C/A/P LIVER	{'SEG', nan}	{'IDC-IDC_hcc_tace_seg', 'TCIA-hcc-tace-seg'}	{'IDC', 'TCIA'}	8
-Thorax^NEWHIRES_WO _2019 (Adult)	{'CT'}	{'MIDRC-Open-A1'}	{'MIDRC'}	8
-MAMMO DIGITAL SCREENING BILATERAL WITH TOMOSYNTHESIS_CAD	{'MG'}	{'ACRdart-EA1141Restricted', 'IDC-IDC_ea1141'}	{'ACRdart', 'IDC'}	8
-CT_Biopsy_Lung	{'CT', nan}	{'TCIA-cmb-lca', 'TCIA-cmb-crc', 'IDC-IDC_cmb_lca', 'IDC-IDC_cmb_crc'}	{'IDC', 'TCIA'}	8
-CT AB/PEL WITH LIVER TRIPHASIC	{'SEG', nan}	{'TCIA-colorectal-liver-metastases', 'IDC-IDC_colorectal_liver_metastases'}	{'IDC', 'TCIA'}	8
-MAMMO DIGITAL SCREENING BILAT WITH TOMOSYNTHESIS_CAD	{'MG'}	{'ACRdart-EA1141Restricted', 'IDC-IDC_ea1141'}	{'ACRdart', 'IDC'}	8
-CT ABDOMEN + PELVIS AUGMENTED=AB	{'RTSTRUCT', 'CT', nan}	{'TCIA-cptac-pda', 'IDC-IDC_cptac_pda'}	{'IDC', 'TCIA'}	8
-CABI MRI	{'MR'}	{'ACRdart-ACRIN_6701'}	{'ACRdart'}	8
-FDG 5AFOV LUNG	{'SEG', 'PT', nan}	{'IDC-IDC_rider_lung_pet_ct', 'TCIA-rider-lung-pet-ct'}	{'IDC', 'TCIA'}	8
-XR LEFT FOOT 1-2 VIEWS	{'CR', 'DX'}	{'MIDRC-Open-A1'}	{'MIDRC'}	8
-XR LEFT KNEE 4+ VIEWS (NON-TRAUMA, PAIN/ARTHRITIS)	{'CR', 'DX'}	{'MIDRC-Open-A1'}	{'MIDRC'}	8
-CHEST/ABDOMEN W CONTRA	{'CT', nan}	{'TCIA-acrin-nsclc-fdg-pet', 'IDC-IDC_acrin_nsclc_fdg_pet'}	{'IDC', 'TCIA'}	8
-CTA CHEST WO/W CONT	{'CT', nan}	{'IDC-IDC_rider_lung_pet_ct', 'TCIA-rider-lung-pet-ct'}	{'IDC', 'TCIA'}	8
-KT KLATKI PIERSIOWEJ ZE WZMOCNIENIEM KONTRASTOWYM	{'CT', nan}	{'TCIA-cptac-lscc', 'TCIA-cptac-luad', 'IDC-IDC_cptac_luad', 'IDC-IDC_cptac_lscc'}	{'IDC', 'TCIA'}	8
-Thorax^CTA_CAP (Adult)	{'CT'}	{'MIDRC-Open-A1'}	{'MIDRC'}	8
-CTA CHEST WAND WITHOUT C AND RECONS	{'CT'}	{'MIDRC-Open-A1_PETAL_BLUECORAL', 'MIDRC-Open-A1_PETAL_REDCORAL'}	{'MIDRC'}	8
-CBC	{'CT', nan}	{'TCIA-acrin-nsclc-fdg-pet', 'IDC-IDC_acrin_nsclc_fdg_pet'}	{'IDC', 'TCIA'}	8
-XR LEFT HUMERUS	{'CR', 'DX'}	{'MIDRC-Open-A1'}	{'MIDRC'}	8
-Thorax^HI_RES (Adult)	{'CT'}	{'MIDRC-Open-A1'}	{'MIDRC'}	8
-ULTRASOUND T0 INITIAL	{'US'}	{'ACRdart-ACRIN_6666'}	{'ACRdart'}	8
-CHEST WITH	{'CT', 'SEG', nan}	{'IDC-IDC_tcga_lusc', 'IDC-IDC_acrin_nsclc_fdg_pet', 'TCIA-tcga-lusc', 'TCIA-tcga-kirc', 'TCIA-acrin-nsclc-fdg-pet', 'IDC-IDC_tcga_kirc'}	{'IDC', 'TCIA'}	8
-MRI ABDOMEN + PELVIS WO/W CONTRAST	{'MR'}	{'MIDRC-Open-A1'}	{'MIDRC'}	8
-MR RENAL PROTOCOL W/WO CONTRAST	{'MR', nan}	{'TCIA-tcga-kirc', 'IDC-IDC_tcga_kirc'}	{'IDC', 'TCIA'}	8
-PTCTSKTHPET / CT TUMOR	{'SEG', nan}	{'TCIA-tcga-lusc', 'IDC-IDC_tcga_lusc', 'TCIA-tcga-luad', 'IDC-IDC_tcga_luad'}	{'IDC', 'TCIA'}	8
-MRI BREAST BIL/MBRB	{'MR', 'SEG'}	{'IDC-IDC_ispy1'}	{'IDC'}	8
-_t5of8MRI IAMS	{'MR', nan}	{'IDC-IDC_vestibular_schwannoma_mc_rc', 'TCIA-vestibular-schwannoma-mc-rc'}	{'IDC', 'TCIA'}	8
-_t5of8  MRI IAMS	{'MR', nan}	{'IDC-IDC_vestibular_schwannoma_mc_rc', 'TCIA-vestibular-schwannoma-mc-rc'}	{'IDC', 'TCIA'}	8
-Abdomen^01_Abd_Pelvis_Routine (Adult)	{'CT', nan}	{'TCIA-tcga-kirc', 'TCIA-tcga-ov', 'IDC-IDC_tcga_kirc', 'IDC-IDC_tcga_ov'}	{'IDC', 'TCIA'}	8
-MRI BREAST	{'MR', nan}	{'IDC-IDC_tcga_brca', 'IDC-IDC_acrin_contralateral_breast_mr', 'TCIA-tcga-brca', 'TCIA-acrin-contralateral-breast-mr'}	{'IDC', 'TCIA'}	8
-CT ANGIOGRAPHY HEAD	{'CT'}	{'MIDRC-Open-A1'}	{'MIDRC'}	8
-CT ANGIOGRAPHY CHEST	{'CT', nan}	{'MIDRC-Open-A1', 'MIDRC-Open-A1_PETAL_BLUECORAL', 'TCIA-varepop-apollo', 'MIDRC-Open-A1_PETAL_REDCORAL'}	{'TCIA', 'MIDRC'}	8
-MRI Pelvis	{'MR', nan}	{'TCIA-cmb-lca', 'TCIA-cmb-crc', 'IDC-IDC_cmb_lca', 'IDC-IDC_cmb_crc'}	{'IDC', 'TCIA'}	8
-CT Chest W/ Non Ionic	{'CT', nan}	{'TCIA-acrin-nsclc-fdg-pet', 'IDC-IDC_acrin_nsclc_fdg_pet'}	{'IDC', 'TCIA'}	8
-CT CHEST NON CON	{'SEG', nan}	{'IDC-IDC_nsclc_radiogenomics', 'TCIA-nsclc-radiogenomics'}	{'IDC', 'TCIA'}	8
-MRI ABDOMEN W AND W/O GADOLINIUM	{'RTSTRUCT', 'MR', nan}	{'TCIA-cptac-ccrcc', 'IDC-IDC_cptac_ccrcc'}	{'IDC', 'TCIA'}	8
-Abdomen^ROUTINE_AP_WITH_OVER_50_OVER_250_Customized (Adult)	{'CT'}	{'MIDRC-Open-A1'}	{'MIDRC'}	8
-CT GUIDED LUNG BIOPSY	{'CT', 'SEG', nan}	{'TCIA-lidc-idri', 'IDC-IDC_lidc_idri'}	{'IDC', 'TCIA'}	8
-MR SCREENING BREAST W&W/O CONTRAST	{'MR'}	{'ACRdart-EA1141Restricted', 'IDC-IDC_ea1141'}	{'ACRdart', 'IDC'}	8
-CT Biopsy	{'CT', nan}	{'TCIA-cmb-crc', 'IDC-IDC_cmb_crc', 'IDC-IDC_tcga_ucec', 'IDC-IDC_cmb_mml', 'TCIA-cmb-mml', 'TCIA-tcga-ucec'}	{'IDC', 'TCIA'}	8
-CT Chest/Abdomen/Pelvis +C	{'CT', nan}	{'IDC-IDC_ctpred_sunitinib_pannet', 'TCIA-ctpred-sunitinib-pannet'}	{'IDC', 'TCIA'}	8
-Abdomen^urogram_gr (Adult)	{'CT'}	{'MIDRC-Open-A1'}	{'MIDRC'}	8
-MR PELVIS WITH + WITHOUT IV CONTRAST	{'MR'}	{'ACRdart-ACRIN_6701'}	{'ACRdart'}	8
-AgilityS Treatme:Tx Plan	{'CT', nan}	{'IDC-IDC_pelvic_reference_data', 'TCIA-pelvic-reference-data'}	{'IDC', 'TCIA'}	8
-RESEARCH PET PLUS CT N	{'CT', nan}	{'TCIA-breast-diagnosis', 'IDC-IDC_breast_diagnosis'}	{'IDC', 'TCIA'}	8
-RT  BREAST	{'MR', nan}	{'IDC-IDC_acrin_contralateral_breast_mr', 'TCIA-acrin-contralateral-breast-mr'}	{'IDC', 'TCIA'}	8
-MR HEAD W AND WO IV CONTRAST POST-OP	{'SEG', nan}	{'IDC-IDC_upenn_gbm', 'TCIA-upenn-gbm'}	{'IDC', 'TCIA'}	8
-MR GUIDED BREAST BIOPSY; FIRST LESION	{'MR'}	{'ACRdart-EA1141Restricted', 'IDC-IDC_ea1141'}	{'ACRdart', 'IDC'}	8
-Ribs R	{'CR'}	{'MIDRC-Open-A1'}	{'MIDRC'}	8
-Thorax^1Chest_Abdomen (Adult)	{'CT', nan}	{'TCIA-acrin-nsclc-fdg-pet', 'IDC-IDC_acrin_nsclc_fdg_pet'}	{'IDC', 'TCIA'}	8
-Abdomen^01_Abdomen_Routine (Adult)	{'CT', nan}	{'TCIA-tcga-ov', 'IDC-IDC_tcga_ov'}	{'IDC', 'TCIA'}	8
-CT CHEST/ABD/PELV W CONTRAST	{'CT'}	{'MIDRC-Open-A1_PETAL_BLUECORAL', 'MIDRC-Open-A1_PETAL_REDCORAL'}	{'MIDRC'}	8
-CT Abdo Un+En	{'OT', 'CT', nan}	{'TCIA-tcga-ov', 'IDC-IDC_tcga_ov'}	{'IDC', 'TCIA'}	8
-PET/CT CHEST	{'SEG', 'PT', nan}	{'IDC-IDC_tcga_lusc', 'TCIA-tcga-luad', 'IDC-IDC_acrin_nsclc_fdg_pet', 'TCIA-tcga-lusc', 'TCIA-acrin-nsclc-fdg-pet', 'IDC-IDC_tcga_luad'}	{'IDC', 'TCIA'}	8
-PET-CT	{'SEG', 'PT', nan}	{'TCIA-acrin-nsclc-fdg-pet', 'IDC-IDC_acrin_nsclc_fdg_pet'}	{'IDC', 'TCIA'}	8
-Abdomen^12_CTA_CAP (Adult)	{'CT'}	{'MIDRC-Open-A1'}	{'MIDRC'}	8
-CT CHEST WITH	{'CT', 'SEG', nan}	{'IDC-IDC_tcga_luad', 'TCIA-tcga-luad', 'IDC-IDC_nsclc_radiogenomics', 'TCIA-nsclc-radiogenomics'}	{'IDC', 'TCIA'}	8
-PET/CT NSCLC INITIAL S	{'SEG', nan}	{'TCIA-acrin-nsclc-fdg-pet', 'IDC-IDC_acrin_nsclc_fdg_pet'}	{'IDC', 'TCIA'}	8
-CT Biopsy BoneMarrow	{'CT', nan}	{'IDC-IDC_cmb_mml', 'TCIA-cmb-mml'}	{'IDC', 'TCIA'}	8
-Abdomen^12_0_Liver_Biphase (Adult)	{'CT', 'SEG', nan}	{'TCIA-tcga-lihc', 'IDC-IDC_tcga_lihc'}	{'IDC', 'TCIA'}	8
-_t9of9MRI IAMS	{'MR', nan}	{'IDC-IDC_vestibular_schwannoma_mc_rc', 'TCIA-vestibular-schwannoma-mc-rc'}	{'IDC', 'TCIA'}	8
-_t8of8_MRI IAMS	{'MR', nan}	{'IDC-IDC_vestibular_schwannoma_mc_rc', 'TCIA-vestibular-schwannoma-mc-rc'}	{'IDC', 'TCIA'}	8
-CT Abdomen/Pelvis	{'US', 'DX', 'CT', nan}	{'TCIA-cmb-crc', 'IDC-IDC_cmb_crc'}	{'IDC', 'TCIA'}	8
-Abdomen^4_BOWEL_ISCHEMIA (Adult)	{'CT'}	{'MIDRC-Open-A1'}	{'MIDRC'}	8
-CT Abdomen w/ + w/o Contrast	{'CT', nan}	{'IDC-IDC_tcga_blca', 'TCIA-acrin-nsclc-fdg-pet', 'IDC-IDC_acrin_nsclc_fdg_pet', 'TCIA-tcga-blca'}	{'IDC', 'TCIA'}	8
-PETCT SKULL BASE TO MI	{'CT', 'PT', nan}	{'TCIA-acrin-nsclc-fdg-pet', 'IDC-IDC_acrin_nsclc_fdg_pet'}	{'IDC', 'TCIA'}	8
-Abdomen^ABDOMEN_PELVIS_WO_ROUTINE (Adult)	{'CT'}	{'MIDRC-Open-A1'}	{'MIDRC'}	8
-CT CHEST WO W CONT	{'CT', nan}	{'IDC-IDC_rider_lung_pet_ct', 'TCIA-rider-lung-pet-ct'}	{'IDC', 'TCIA'}	8
-PETCT WholeBody	{'CT', 'PT', nan}	{'IDC-IDC_cmb_mel', 'IDC-IDC_cmb_mml', 'TCIA-cmb-mml', 'TCIA-cmb-mel'}	{'IDC', 'TCIA'}	8
-PETCT_Skull-MidThigh	{'CT', nan}	{'TCIA-cmb-crc', 'IDC-IDC_cmb_crc', 'TCIA-cmb-lca', 'IDC-IDC_cmb_pca', 'IDC-IDC_cmb_lca', 'TCIA-cmb-pca'}	{'IDC', 'TCIA'}	8
-MRI BREAST BILATERAL WWO CONTRAST W 3D	{'SEG', nan}	{'TCIA-duke-breast-cancer-mri', 'IDC-IDC_duke_breast_cancer_mri'}	{'IDC', 'TCIA'}	8
-PET^01_Wholebody_First_Body (Adult)	{'CT', 'SEG', nan}	{'IDC-IDC_lung_pet_ct_dx', 'TCIA-lung-pet-ct-dx'}	{'IDC', 'TCIA'}	8
-CT CHEST wo	{'CT', 'SEG', nan}	{'TCIA-tcga-lihc', 'TCIA-tcga-ov', 'IDC-IDC_tcga_lihc', 'IDC-IDC_tcga_ov'}	{'IDC', 'TCIA'}	8
-MRI BREAST BILATERAL W W/O CONTRAST	{'MR'}	{'ACRdart-EA1141Restricted', 'IDC-IDC_ea1141'}	{'ACRdart', 'IDC'}	8
-PET^1PETCT_LUNGS (Adult)	{'CT', 'PT', nan}	{'TCIA-acrin-nsclc-fdg-pet', 'IDC-IDC_acrin_nsclc_fdg_pet'}	{'IDC', 'TCIA'}	8
-mammogram/ultrasound exam	{'US'}	{'ACRdart-ACRIN_6666'}	{'ACRdart'}	8
-SCREENING MAMMOGRAM PLUS TOMO	{'MG'}	{'ACRdart-EA1141Restricted', 'IDC-IDC_ea1141'}	{'ACRdart', 'IDC'}	8
-ch	{'CT', 'SEG', nan}	{'IDC-IDC_lung_pet_ct_dx', 'TCIA-lung-pet-ct-dx'}	{'IDC', 'TCIA'}	8
-CT ABDOMEN W/WO CONTRAST	{'CT', 'SEG', nan}	{'TCIA-tcga-lihc', 'IDC-IDC_tcga_kirp', 'TCIA-tcga-kirp', 'IDC-IDC_tcga_lihc'}	{'IDC', 'TCIA'}	8
-Specials^1_PETCT_WB_HEADtoFEET	{'SEG', nan}	{'TCIA-acrin-nsclc-fdg-pet', 'IDC-IDC_acrin_nsclc_fdg_pet'}	{'IDC', 'TCIA'}	8
-MR ABDOMEN NONENHANCED & ENHANCED=AB	{'RTSTRUCT', 'MR', nan}	{'TCIA-cptac-pda', 'IDC-IDC_cptac_pda'}	{'IDC', 'TCIA'}	8
-BREAST^BREAST MRI	{'MR'}	{'ACRdart-EA1141Restricted', 'IDC-IDC_ea1141'}	{'ACRdart', 'IDC'}	8
-ACRIN 6667 RESEARCH	{'MR', nan}	{'IDC-IDC_acrin_contralateral_breast_mr', 'TCIA-acrin-contralateral-breast-mr'}	{'IDC', 'TCIA'}	8
-NM WB Bone	{'NM', nan}	{'IDC-IDC_cmb_pca', 'TCIA-cmb-lca', 'IDC-IDC_cmb_lca', 'TCIA-cmb-pca'}	{'IDC', 'TCIA'}	8
-Scanner-Philips_Exp-25_Pitch-0.9_SlCol-16x0.75mm	{'CT', nan}	{'IDC-IDC_phantom_fda', 'TCIA-phantom-fda'}	{'IDC', 'TCIA'}	8
-ACRIN 6667 CONTRALAT B	{'MR', nan}	{'IDC-IDC_acrin_contralateral_breast_mr', 'TCIA-acrin-contralateral-breast-mr'}	{'IDC', 'TCIA'}	8
-MR ABD/PEL W&W/O CONT	{'MR', nan}	{'TCIA-tcga-kirc', 'IDC-IDC_tcga_blca', 'IDC-IDC_tcga_kirc', 'TCIA-tcga-blca'}	{'IDC', 'TCIA'}	8
-Scanner-Philips_Exp-200_Pitch-0.9_SlCol-16x0.75mm	{'CT', nan}	{'IDC-IDC_phantom_fda', 'TCIA-phantom-fda'}	{'IDC', 'TCIA'}	8
-CT Neck	{'CT', nan}	{'IDC-IDC_cmb_mel', 'TCIA-cmb-mel'}	{'IDC', 'TCIA'}	8
-Scanner-Philips_Exp-25_Pitch-1.2_SlCol-16x0.75mm	{'CT', nan}	{'IDC-IDC_phantom_fda', 'TCIA-phantom-fda'}	{'IDC', 'TCIA'}	8
-MR_BREAST-RT	{'MR', nan}	{'IDC-IDC_acrin_contralateral_breast_mr', 'TCIA-acrin-contralateral-breast-mr'}	{'IDC', 'TCIA'}	8
-ABD/PEL	{'CT', nan}	{'IDC-IDC_acrin_nsclc_fdg_pet', 'TCIA-tcga-kirc', 'TCIA-acrin-nsclc-fdg-pet', 'IDC-IDC_tcga_ucec', 'IDC-IDC_tcga_blca', 'IDC-IDC_tcga_kirc', 'TCIA-tcga-ucec', 'TCIA-tcga-blca'}	{'IDC', 'TCIA'}	8
-BREAST- BREAST MASS	{'MR', nan}	{'IDC-IDC_acrin_contralateral_breast_mr', 'TCIA-acrin-contralateral-breast-mr'}	{'IDC', 'TCIA'}	8
-Screening- Bilateral Mammography TomoHD	{'MG'}	{'ACRdart-EA1141Restricted', 'IDC-IDC_ea1141'}	{'ACRdart', 'IDC'}	8
-MR BREAST BI	{'MR', nan}	{'IDC-IDC_acrin_contralateral_breast_mr', 'TCIA-acrin-contralateral-breast-mr'}	{'IDC', 'TCIA'}	8
-ABDOMEN/PELVIS	{'MR', 'CT', nan}	{'TCIA-pseudo-phi-dicom-data', 'IDC-IDC_tcga_ov', 'TCIA-tcga-kirc', 'TCIA-tcga-ov', 'IDC-IDC_pseudo_phi_dicom_data', 'IDC-IDC_tcga_kirc'}	{'IDC', 'TCIA'}	8
-CT CHEST ABDOMEN PELVIS	{'CT', nan}	{'TCIA-adrenal-acc-ki67-seg', 'IDC-IDC_adrenal_acc_ki67_seg'}	{'IDC', 'TCIA'}	8
-CT KIDNEY PROTOCOL W/ PELVIS	{'CT', nan}	{'TCIA-tcga-kirc', 'IDC-IDC_tcga_kirc'}	{'IDC', 'TCIA'}	8
-CT THORAX  WITH CONTRA	{'CT', nan}	{'TCIA-tcga-lusc', 'IDC-IDC_tcga_lusc', 'TCIA-tcga-luad', 'IDC-IDC_tcga_luad'}	{'IDC', 'TCIA'}	8
-MR BREAST BILAT W/WO C	{'MR', 'SEG'}	{'IDC-IDC_ispy1'}	{'IDC'}	8
-6667 CONTRALAT. BREAST	{'MR', nan}	{'IDC-IDC_acrin_contralateral_breast_mr', 'TCIA-acrin-contralateral-breast-mr'}	{'IDC', 'TCIA'}	8
-MG Screen Bilat W/Tomo/CAD Stnd Protocol	{'MG'}	{'ACRdart-EA1141Restricted', 'IDC-IDC_ea1141'}	{'ACRdart', 'IDC'}	8
-CT ABDOMEN, COMBINED,NON & ENH-BODY	{'CT', 'SEG', nan}	{'TCIA-tcga-lihc', 'IDC-IDC_tcga_lihc'}	{'IDC', 'TCIA'}	8
-Scanner-Philips_Exp-100_Pitch-0.9_SlCol-16x0.75mm	{'CT', nan}	{'IDC-IDC_phantom_fda', 'TCIA-phantom-fda'}	{'IDC', 'TCIA'}	8
-XR_Biopsy_BoneMarrow	{'XA', nan}	{'IDC-IDC_cmb_mml', 'TCIA-cmb-aml', 'TCIA-cmb-mml', 'IDC-IDC_cmb_aml'}	{'IDC', 'TCIA'}	8
-MRI_Pelvis	{'MR', nan}	{'IDC-IDC_cmb_mml', 'TCIA-cmb-crc', 'TCIA-cmb-mml', 'IDC-IDC_cmb_crc'}	{'IDC', 'TCIA'}	8
-Thorax^01_CHEST	{'CT', nan}	{'TCIA-acrin-nsclc-fdg-pet', 'IDC-IDC_acrin_nsclc_fdg_pet'}	{'IDC', 'TCIA'}	8
-/BD/PRO   Pelvis w&w/oCon	{'SEG', nan}	{'IDC-IDC_qin_prostate_repeatability', 'TCIA-qin-prostate-repeatability'}	{'IDC', 'TCIA'}	8
-CHEST 1 VIEW PA OR AP	{'CR', 'DX'}	{'MIDRC-Open-R1'}	{'MIDRC'}	7
-CT ABDOMEN PELVIS W CONTRAST(PANCREAS)	{'CT'}	{'MIDRC-Open-A1'}	{'MIDRC'}	7
-XR RIGHT KNEE 4+ VIEWS (NON-TRAUMA, PAIN/ARTHRITIS)	{'CR', 'DX'}	{'MIDRC-Open-A1'}	{'MIDRC'}	7
-US PELVIC TRANSABD/TRANSVAG COMBINATION	{'US'}	{'MIDRC-Open-A1'}	{'MIDRC'}	7
-Head^DE_CTA_HEAD_NECK_Customized (Adult)	{'CT'}	{'MIDRC-Open-A1'}	{'MIDRC'}	7
-JCCI CT C/A/P	{'CT'}	{'MIDRC-Open-R1'}	{'MIDRC'}	7
-Thorax^NEWHIRES_WO_GR_2019 (Adult)	{'CT'}	{'MIDRC-Open-A1'}	{'MIDRC'}	7
-CT CHEST WO IV CONTRAST LUNG NODULE FOLLOW UP	{'CT'}	{'AIMI-COCA'}	{'AIMI'}	7
-MAMMO SCREENING BI(DIAG&BI US IF NEEDED)	{'MG'}	{'ACRdart-EA1141Restricted', 'IDC-IDC_ea1141'}	{'ACRdart', 'IDC'}	7
-XR CERVICAL SPINE 1 VIEW	{'CR', 'DX'}	{'MIDRC-Open-A1'}	{'MIDRC'}	7
-BREAST^AB MRI	{'MR'}	{'ACRdart-EA1141Restricted'}	{'ACRdart'}	7
-CT CHEST WO IV CONTRAST LUNG PARENCHYMA	{'CT'}	{'MIDRC-Open-A1'}	{'MIDRC'}	7
-X-RAY ANKLE COMPLETE MINIMUM 3 VIEWS - RIGHT	{'CR', 'DX'}	{'MIDRC-Open-A1'}	{'MIDRC'}	7
-US KIDNEY COMPLETE	{'US'}	{'MIDRC-Open-A1'}	{'MIDRC'}	7
-MRI KNEE WITHOUT CONTRAST - LEFT	{'MR'}	{'MIDRC-Open-A1'}	{'MIDRC'}	7
-CHEST PA AND LATERAL	{'CR', 'DX', nan}	{'TCIA-lidc-idri', 'IDC-IDC_lidc_idri', 'MIDRC-Open-A1_PETAL_REDCORAL'}	{'IDC', 'TCIA', 'MIDRC'}	7
-CHEST,SINGLE VIEW	{'CR'}	{'MIDRC-Open-R1'}	{'MIDRC'}	7
-CHEST PA/LT	{'CR'}	{'MIDRC-Open-R1'}	{'MIDRC'}	7
-ABDOMEN SERIES FLAT AND ERECT	{'CR', nan}	{'MIDRC-TCIA-COVID-19-NY-SBU', 'IDC-IDC_covid_19_ny_sbu', 'TCIA-covid-19-ny-sbu'}	{'IDC', 'TCIA', 'MIDRC'}	7
-FL C-ARM (PAIN MANAGMENT ONLY)	{'RF', 'XA'}	{'MIDRC-Open-R1'}	{'MIDRC'}	7
-ABDOMEN PELVIS WO(Adult)	{'CT'}	{'MIDRC-Open-A1'}	{'MIDRC'}	7
-Thorax^XL_CHEST_WO_Customized (Adult)	{'CT'}	{'MIDRC-Open-A1'}	{'MIDRC'}	7
-FOOT RIGHT COMPLETE MIN 3 VIEWS	{'CR', 'DX'}	{'MIDRC-Open-R1'}	{'MIDRC'}	7
-MR BRAIN WITHOUT CONTRAST	{'MR'}	{'MIDRC-Open-R1'}	{'MIDRC'}	7
-CT ANGIOGRAM ABDOMEN/PELVIS WITH AND WITHOUT CONTRAST	{'CT'}	{'MIDRC-Open-R1'}	{'MIDRC'}	7
-ACRIN ABR BREAST	{'MR'}	{'ACRdart-EA1141Restricted', 'IDC-IDC_ea1141'}	{'ACRdart', 'IDC'}	7
-ADULT CHEST - 1 VIEW	{'CR', 'DX'}	{'MIDRC-Open-R1'}	{'MIDRC'}	7
-XR LEFT HIP 2-3 VIEWS (UNILATERAL) WITH PELVIS WHEN PERFORMED	{'DX'}	{'MIDRC-Open-A1'}	{'MIDRC'}	7
-CTA CHEST W/O & W IV CON	{'CT'}	{'MIDRC-Open-R1'}	{'MIDRC'}	7
-Thorax^FLASH_PE_Customized (Adult)	{'CT'}	{'MIDRC-Open-A1'}	{'MIDRC'}	7
-Thorax^CTA_CHEST_ABDOMEN (Adult)	{'CT'}	{'MIDRC-Open-A1'}	{'MIDRC'}	7
-Mammo 3D Tomo Screening Bilateral	{'MG'}	{'ACRdart-EA1141Restricted', 'IDC-IDC_ea1141'}	{'ACRdart', 'IDC'}	7
-CT CHEST ABDOMEN WO CONTRAST (ROUTINE)	{'CT'}	{'MIDRC-Open-A1'}	{'MIDRC'}	7
-CT FACE SINUSES W CONTRAST	{'CT'}	{'MIDRC-Open-A1'}	{'MIDRC'}	7
-MR CERVICAL SPINE WITH AND WITHOUT CONTRAST	{'MR'}	{'MIDRC-Open-R1'}	{'MIDRC'}	7
-X-RAY HAND 2 VIEWS - LEFT	{'CR', 'DX'}	{'MIDRC-Open-A1'}	{'MIDRC'}	7
-Thorax^CTA_AAA (Adult)	{'CT'}	{'MIDRC-Open-A1'}	{'MIDRC'}	7
-CT ABD PELVIS WITH CONTRAST-CS	{'CT'}	{'MIDRC-Open-A1'}	{'MIDRC'}	7
-CT ABDOMEN/PELVIS ANGIO W OR W AND WO IV CONTRAST	{'CT'}	{'MIDRC-Open-A1'}	{'MIDRC'}	7
-JHN CHEST WO OP	{'CT'}	{'MIDRC-Open-R1'}	{'MIDRC'}	7
-CT CERVICAL SPINE WITHOUT CONTRAST	{'CT'}	{'MIDRC-Open-R1'}	{'MIDRC'}	7
-MRI BR UNI W/IN/MBUI	{'MR', 'SEG'}	{'IDC-IDC_ispy1'}	{'IDC'}	7
-CT CERVICAL SPINE WO IV CONTRAST	{'RTSTRUCT', 'CT', nan}	{'MIDRC-Open-A1', 'TCIA-cptac-ccrcc', 'IDC-IDC_cptac_ccrcc'}	{'IDC', 'TCIA', 'MIDRC'}	7
-Head^BRAIN_LAB_HEAD (Adult)	{'CT'}	{'MIDRC-Open-A1'}	{'MIDRC'}	7
-CT CHEST ABDOMEN PELVIS W IV CONTRAST	{'RTSTRUCT', 'CT', nan}	{'TCIA-cptac-ccrcc', 'IDC-IDC_cptac_ccrcc', 'MIDRC-Open-A1_PETAL_REDCORAL', 'TCIA-cptac-ucec', 'IDC-IDC_cptac_ucec'}	{'IDC', 'TCIA', 'MIDRC'}	7
-X-RAY HAND MINIMUM 3 VIEWS - LEFT	{'CR', 'DX'}	{'MIDRC-Open-A1'}	{'MIDRC'}	7
-RADIATION ONCOLOGY CT TREATMENT PLAN	{'CT'}	{'MIDRC-Open-R1'}	{'MIDRC'}	7
-CT CARDIAC MORPHOLOGY WO/W	{'CT', nan}	{'IDC-IDC_rider_lung_pet_ct', 'TCIA-rider-lung-pet-ct'}	{'IDC', 'TCIA'}	6
-CODE_T_CT_THOR_LMBR_SPINAL_REFORMATS	{'CT', nan}	{'MIDRC-TCIA-COVID-19-NY-SBU', 'IDC-IDC_covid_19_ny_sbu', 'TCIA-covid-19-ny-sbu'}	{'IDC', 'TCIA', 'MIDRC'}	6
-*CT Colonography	{'CT', nan}	{'TCIA-ct-colonography', 'IDC-IDC_ct_colonography'}	{'IDC', 'TCIA'}	6
-CT CHEST ABDOMEN & PELVIS ENHANCED-BODY	{'CT', nan}	{'TCIA-tcga-lihc', 'IDC-IDC_tcga_lihc'}	{'IDC', 'TCIA'}	6
-X-RAY FOOT 2 VIEWS - RIGHT	{'DX'}	{'MIDRC-Open-A1'}	{'MIDRC'}	6
-no comment	{'PT', nan}	{'TCIA-acrin-nsclc-fdg-pet', 'IDC-IDC_acrin_nsclc_fdg_pet'}	{'IDC', 'TCIA'}	6
-CHEST/ABD/PEL	{'SEG', nan}	{'IDC-IDC_hcc_tace_seg', 'TCIA-hcc-tace-seg'}	{'IDC', 'TCIA'}	6
-CT CAP WO CONTRAST	{'CT'}	{'MIDRC-Open-A1', 'MIDRC-Open-R1'}	{'MIDRC'}	6
-CONTRA BREAST (LEFT)	{'MR', nan}	{'IDC-IDC_acrin_contralateral_breast_mr', 'TCIA-acrin-contralateral-breast-mr'}	{'IDC', 'TCIA'}	6
-CT CHEST ANGIOGRAPH W IV CONTRAST PULMONAR EMBOLISM	{'CT'}	{'MIDRC-Open-A1_PETAL_BLUECORAL'}	{'MIDRC'}	6
-CONTRA BREAST RIGHT	{'MR', nan}	{'IDC-IDC_acrin_contralateral_breast_mr', 'TCIA-acrin-contralateral-breast-mr'}	{'IDC', 'TCIA'}	6
-CT C/A	{'CT', 'SEG', nan}	{'TCIA-lidc-idri', 'TCIA-acrin-nsclc-fdg-pet', 'IDC-IDC_lidc_idri', 'IDC-IDC_acrin_nsclc_fdg_pet'}	{'IDC', 'TCIA'}	6
-CT CAP W	{'SEG', nan}	{'TCIA-lidc-idri', 'IDC-IDC_anti_pd_1_lung', 'IDC-IDC_lidc_idri', 'TCIA-anti-pd-1_lung'}	{'IDC', 'TCIA'}	6
-CT C/A/P LIVER PR.	{'SEG', nan}	{'IDC-IDC_hcc_tace_seg', 'TCIA-hcc-tace-seg'}	{'IDC', 'TCIA'}	6
-ct ap	{'CT', nan}	{'TCIA-tcga-ov', 'IDC-IDC_tcga_ov'}	{'IDC', 'TCIA'}	6
-X-RAY HAND 2 VIEWS - RIGHT	{'CR', 'DX'}	{'MIDRC-Open-A1'}	{'MIDRC'}	6
-CODE_T_CT_ANGIO_ABD_AND_PEL_WITH_IV_CON_WITH_CHEST_IMAG	{'CT', nan}	{'MIDRC-TCIA-COVID-19-NY-SBU', 'IDC-IDC_covid_19_ny_sbu', 'TCIA-covid-19-ny-sbu'}	{'IDC', 'TCIA', 'MIDRC'}	6
-CODE T CHEST AP PORTABLE	{'CR', nan}	{'MIDRC-TCIA-COVID-19-NY-SBU', 'IDC-IDC_covid_19_ny_sbu', 'TCIA-covid-19-ny-sbu'}	{'IDC', 'TCIA', 'MIDRC'}	6
-XR SPINE LUMBAR (AP+LAT)	{'CR', 'DX'}	{'MIDRC-Open-A1'}	{'MIDRC'}	6
-cap	{'CT', nan}	{'TCIA-tcga-ov', 'IDC-IDC_tcga_ov'}	{'IDC', 'TCIA'}	6
-_t1of7  External Images for PACS	{'MR', nan}	{'IDC-IDC_vestibular_schwannoma_mc_rc', 'TCIA-vestibular-schwannoma-mc-rc'}	{'IDC', 'TCIA'}	6
-CT HEAD WO(Adult)	{'CT'}	{'MIDRC-Open-A1'}	{'MIDRC'}	6
-CT, ABDOMEN W/O CONTRA	{'CT', nan}	{'IDC-IDC_tcga_blca', 'IDC-IDC_ct_colonography', 'TCIA-ct-colonography', 'TCIA-tcga-blca'}	{'IDC', 'TCIA'}	6
-CT ABD/PELV W CONTRAST	{'CT', nan}	{'IDC-IDC_cptac_ucec', 'TCIA-cptac-ucec'}	{'IDC', 'TCIA'}	6
-XR RIBS, RIGHT	{'DX'}	{'MIDRC-Open-R1'}	{'MIDRC'}	6
-CT UPPER ABD AND PELVIS WWO	{'CT', nan}	{'IDC-IDC_tcga_blca', 'TCIA-tcga-blca'}	{'IDC', 'TCIA'}	6
-CT ABDOMEN  W/CONTRAST	{'CT', nan}	{'TCIA-tcga-lihc', 'IDC-IDC_tcga_lihc', 'TCIA-tcga-luad', 'IDC-IDC_tcga_luad'}	{'IDC', 'TCIA'}	6
-CT LUNG SCREEN WO CONTRAST	{'CT'}	{'MIDRC-Open-A1'}	{'MIDRC'}	6
-CT NECK/THYROID W CONTRAST	{'CT'}	{'MIDRC-Open-A1'}	{'MIDRC'}	6
-CT ABDOMEN WITH IV CON	{'CT', nan}	{'TCIA-acrin-nsclc-fdg-pet', 'IDC-IDC_acrin_nsclc_fdg_pet'}	{'IDC', 'TCIA'}	6
-_t1of8External Images for PACS	{'MR', nan}	{'IDC-IDC_vestibular_schwannoma_mc_rc', 'TCIA-vestibular-schwannoma-mc-rc'}	{'IDC', 'TCIA'}	6
-CT TRAUMA T-SPINE RECONSTRUCT (RAD ONLY)	{'CT'}	{'MIDRC-Open-R1'}	{'MIDRC'}	6
-CT ABDOMEN WITH AND WI	{'CT', nan}	{'TCIA-tcga-kirc', 'TCIA-tcga-ov', 'IDC-IDC_tcga_kirc', 'IDC-IDC_tcga_ov'}	{'IDC', 'TCIA'}	6
-_t1of6  External Images for PACS	{'MR', nan}	{'IDC-IDC_vestibular_schwannoma_mc_rc', 'TCIA-vestibular-schwannoma-mc-rc'}	{'IDC', 'TCIA'}	6
-CT ABD/PEL	{'CT', 'SEG', nan}	{'IDC-IDC_hcc_tace_seg', 'TCIA-hcc-tace-seg', 'TCIA-tcga-kirc', 'IDC-IDC_tcga_ucec', 'IDC-IDC_tcga_kirc', 'TCIA-tcga-ucec'}	{'IDC', 'TCIA'}	6
-CT ABDOMEN AND PELVIS ANGIOGRAM=AB	{'RTSTRUCT', nan}	{'TCIA-cptac-pda', 'IDC-IDC_cptac_pda'}	{'IDC', 'TCIA'}	6
-CT P CHEST W	{'CT'}	{'MIDRC-Open-A1', 'MIDRC-Open-R1'}	{'MIDRC'}	6
-CT PELVIS W CONTRAST (ROUTINE)	{'CT'}	{'MIDRC-Open-A1'}	{'MIDRC'}	6
-CT PELVIS WO CONTRAST (ROUTINE)	{'CT'}	{'MIDRC-Open-A1'}	{'MIDRC'}	6
-CT ABDOMEN W IV CONTRAST	{'RTSTRUCT', 'CT', nan}	{'TCIA-cptac-pda', 'IDC-IDC_cptac_pda', 'TCIA-cptac-ccrcc', 'IDC-IDC_cptac_ccrcc', 'MIDRC-Open-A1'}	{'IDC', 'TCIA', 'MIDRC'}	6
-CT ABDOMEN W CONTRAST (ROUTINE)	{'CT'}	{'MIDRC-Open-A1'}	{'MIDRC'}	6
-_t1of3_MR IAMs	{nan}	{'TCIA-vestibular-schwannoma-mc-rc'}	{'TCIA'}	6
-_t1of3_MR IAM's	{'MR'}	{'IDC-IDC_vestibular_schwannoma_mc_rc'}	{'IDC'}	6
-_t1of2  External Images for PACS	{'MR', nan}	{'IDC-IDC_vestibular_schwannoma_mc_rc', 'TCIA-vestibular-schwannoma-mc-rc'}	{'IDC', 'TCIA'}	6
-CT THORAX  WITHOUT CONTRAST	{'CT', nan}	{'IDC-IDC_cptac_sar', 'TCIA-cptac-sar'}	{'IDC', 'TCIA'}	6
-CT ABDOMEN PELVIS W CONT (2)	{'CT', nan}	{'TCIA-tcga-kirc', 'TCIA-tcga-coad', 'IDC-IDC_tcga_coad', 'IDC-IDC_tcga_kirc'}	{'IDC', 'TCIA'}	6
-CT THORAX W CONT FIC	{'CT', nan}	{'TCIA-acrin-nsclc-fdg-pet', 'IDC-IDC_acrin_nsclc_fdg_pet'}	{'IDC', 'TCIA'}	6
-CT ABDOMEN/PELVIS WITH CONTRAST (S)	{'CT'}	{'MIDRC-Open-R1'}	{'MIDRC'}	6
-CT ABD+PELVIS W/WO 74178	{'CT', nan}	{'IDC-IDC_tcga_blca', 'TCIA-tcga-blca'}	{'IDC', 'TCIA'}	6
-CT CHEST W/O IV CONTRAST	{'RTSTRUCT', 'CT', nan}	{'TCIA-cptac-pda', 'IDC-IDC_cptac_pda', 'IDC-IDC_cptac_luad', 'TCIA-cptac-ccrcc', 'TCIA-cptac-luad', 'IDC-IDC_cptac_ccrcc'}	{'IDC', 'TCIA'}	6
-CT ABD & PELVIS W/CONTRAST	{nan}	{'TCIA-varepop-apollo'}	{'TCIA'}	6
-X-RAY KNEE COMPLETE 4 OR MORE VIEWS - RIGHT	{'CR', 'DX'}	{'MIDRC-Open-A1'}	{'MIDRC'}	6
-X-RAY LUMBOSACRAL SPINE MINIMUM 4 VIEWS	{'CR', 'DX'}	{'MIDRC-Open-A1'}	{'MIDRC'}	6
-CT CHEST WITH IV CONT	{'CT', nan}	{'MIDRC-TCIA-COVID-19-NY-SBU', 'IDC-IDC_covid_19_ny_sbu', 'TCIA-covid-19-ny-sbu'}	{'IDC', 'TCIA', 'MIDRC'}	6
-_t9of9MRI IAMS post Gad	{'MR', nan}	{'IDC-IDC_vestibular_schwannoma_mc_rc', 'TCIA-vestibular-schwannoma-mc-rc'}	{'IDC', 'TCIA'}	6
-Chest 3D	{'CT', nan}	{'IDC-IDC_lung_pet_ct_dx', 'TCIA-lung-pet-ct-dx'}	{'IDC', 'TCIA'}	6
-X-RAY WRIST COMPLETE MINIMUM 3 VWS - RIGHT	{'CR', 'DX'}	{'MIDRC-Open-A1'}	{'MIDRC'}	6
-CT CHEST WWO CONTRAST	{'CT', nan}	{'MIDRC-Open-A1', 'TCIA-acrin-nsclc-fdg-pet', 'IDC-IDC_acrin_nsclc_fdg_pet'}	{'IDC', 'TCIA', 'MIDRC'}	6
-CT_biopsylung	{'CT', nan}	{'IDC-IDC_cmb_pca', 'IDC-IDC_cmb_crc', 'TCIA-cmb-crc', 'TCIA-cmb-pca'}	{'IDC', 'TCIA'}	6
-CT_Pelvisbonebiopsy	{'CT', nan}	{'IDC-IDC_cmb_mml', 'TCIA-cmb-mml'}	{'IDC', 'TCIA'}	6
-CT Abdomen W/O, W/Contrast	{'CT', nan}	{'TCIA-tcga-lihc', 'IDC-IDC_tcga_lihc'}	{'IDC', 'TCIA'}	6
-CT_Pelvis	{'CT', nan}	{'IDC-IDC_cmb_mel', 'IDC-IDC_cmb_mml', 'TCIA-cmb-mml', 'TCIA-cmb-mel'}	{'IDC', 'TCIA'}	6
-CT CHEST/ABD (LIVER)	{'CT', 'SEG', nan}	{'IDC-IDC_hcc_tace_seg', 'TCIA-hcc-tace-seg'}	{'IDC', 'TCIA'}	6
-CT Abd/Pelvis	{'CT', nan}	{'IDC-IDC_cmb_mml', 'TCIA-cmb-crc', 'TCIA-cmb-mml', 'IDC-IDC_cmb_crc'}	{'IDC', 'TCIA'}	6
-CT ABD WO IV CONT	{'CT', nan}	{'MIDRC-TCIA-COVID-19-NY-SBU', 'IDC-IDC_covid_19_ny_sbu', 'TCIA-covid-19-ny-sbu'}	{'IDC', 'TCIA', 'MIDRC'}	6
-CT_Abdomen	{'CT', nan}	{'TCIA-cmb-gec', 'TCIA-cmb-crc', 'IDC-IDC_cmb_gec', 'IDC-IDC_cmb_crc'}	{'IDC', 'TCIA'}	6
-_t5of9MRI Stereo Gamma Knife	{'MR', nan}	{'IDC-IDC_vestibular_schwannoma_mc_rc', 'TCIA-vestibular-schwannoma-mc-rc'}	{'IDC', 'TCIA'}	6
-CTCH2	{'CT', nan}	{'TCIA-acrin-nsclc-fdg-pet', 'IDC-IDC_acrin_nsclc_fdg_pet'}	{'IDC', 'TCIA'}	6
-_t4of7  MRI IAMS	{'MR', nan}	{'IDC-IDC_vestibular_schwannoma_mc_rc', 'TCIA-vestibular-schwannoma-mc-rc'}	{'IDC', 'TCIA'}	6
-XR LEFT ELBOW 3+ VIEWS	{'CR', 'DX'}	{'MIDRC-Open-A1'}	{'MIDRC'}	6
-_t4of6MRI IAMS	{'MR', nan}	{'IDC-IDC_vestibular_schwannoma_mc_rc', 'TCIA-vestibular-schwannoma-mc-rc'}	{'IDC', 'TCIA'}	6
-CT Chest Abdomen and Pelvis With Contrast	{'RTSTRUCT', nan}	{'IDC-IDC_cptac_ucec', 'TCIA-cptac-ucec'}	{'IDC', 'TCIA'}	6
-CT ANGIOGRAM CHEST PULMONARY EMBOLISM W CONTRAST	{'CT'}	{'MIDRC-Open-A1_PETAL_BLUECORAL'}	{'MIDRC'}	6
-CT Chest w/ IV Contrast	{'CT'}	{'MIDRC-Open-R1'}	{'MIDRC'}	6
-CT Chest without contrast	{'CT', 'SEG', nan}	{'TCIA-tcga-lusc', 'IDC-IDC_tcga_lusc'}	{'IDC', 'TCIA'}	6
-_t3of3MRI Stereo Gamma Knife gad	{'MR', nan}	{'IDC-IDC_vestibular_schwannoma_mc_rc', 'TCIA-vestibular-schwannoma-mc-rc'}	{'IDC', 'TCIA'}	6
-_t3of3MRI Head	{'MR', nan}	{'IDC-IDC_vestibular_schwannoma_mc_rc', 'TCIA-vestibular-schwannoma-mc-rc'}	{'IDC', 'TCIA'}	6
-CT ABD (LIVER)	{'SEG', nan}	{'IDC-IDC_hcc_tace_seg', 'TCIA-hcc-tace-seg'}	{'IDC', 'TCIA'}	6
-Outside Read or Comparison NEURO CT	{'CT', nan}	{'TCIA-tcga-thca', 'IDC-IDC_tcga_thca'}	{'IDC', 'TCIA'}	6
-Thorax^NON_CONTRAST_CHEST (Adult)	{'CT', nan}	{'IDC-IDC_nsclc_radiogenomics', 'TCIA-nsclc-radiogenomics'}	{'IDC', 'TCIA'}	6
-Thorax^1ROUTINECHEST (Adult)	{'CT', nan}	{'TCIA-acrin-nsclc-fdg-pet', 'IDC-IDC_acrin_nsclc_fdg_pet'}	{'IDC', 'TCIA'}	6
-Thorax^CHEST_WITHOUT_WITH_HI_RES_CUTS (Adult)	{'CT'}	{'MIDRC-Open-A1'}	{'MIDRC'}	6
-Thorax^CHEST_ROUTINE (Adult)	{'CT', nan}	{'IDC-IDC_cptac_luad', 'TCIA-cptac-ccrcc', 'TCIA-cptac-luad', 'IDC-IDC_cptac_ccrcc', 'IDC-IDC_acrin_nsclc_fdg_pet', 'TCIA-acrin-nsclc-fdg-pet'}	{'IDC', 'TCIA'}	6
-PET RESEARCH	{'CT', nan}	{'IDC-IDC_cc_tumor_heterogeneity', 'TCIA-cc-tumor-heterogeneity'}	{'IDC', 'TCIA'}	6
-Thorax^CHEST_LIVER (Adult)	{'CT', nan}	{'TCIA-acrin-nsclc-fdg-pet', 'IDC-IDC_acrin_nsclc_fdg_pet'}	{'IDC', 'TCIA'}	6
-C/A ADRENAL CHAR	{'CT', nan}	{'TCIA-adrenal-acc-ki67-seg', 'IDC-IDC_adrenal_acc_ki67_seg'}	{'IDC', 'TCIA'}	6
-PET TUM SKULL/MID-THIGH-CT W/O	{'SEG', nan}	{'TCIA-acrin-nsclc-fdg-pet', 'IDC-IDC_acrin_nsclc_fdg_pet'}	{'IDC', 'TCIA'}	6
-MRI CERVICAL SPINE WO/W IV CONTRAST	{'MR'}	{'MIDRC-Open-A1'}	{'MIDRC'}	6
-Thorax^1_CHEST_WITH (Adult)	{'CT', nan}	{'TCIA-acrin-nsclc-fdg-pet', 'IDC-IDC_acrin_nsclc_fdg_pet'}	{'IDC', 'TCIA'}	6
-Abdomen^1CAP_WC (Adult)	{'CT', nan}	{'TCIA-acrin-nsclc-fdg-pet', 'IDC-IDC_acrin_nsclc_fdg_pet'}	{'IDC', 'TCIA'}	6
-MRI KNEE WITHOUT CONTRAST - RIGHT	{'MR'}	{'MIDRC-Open-A1'}	{'MIDRC'}	6
-MRI Bladder	{'MR', nan}	{'IDC-IDC_tcga_blca', 'TCIA-tcga-blca'}	{'IDC', 'TCIA'}	6
-Thorax^1ChestRoutine (Adult)	{'CT', nan}	{'TCIA-acrin-nsclc-fdg-pet', 'IDC-IDC_acrin_nsclc_fdg_pet'}	{'IDC', 'TCIA'}	6
-MRI BREAST/UNILAT WO/WITH CON	{'MR'}	{'IDC-IDC_ispy1'}	{'IDC'}	6
-BRZUCH+C	{'RTSTRUCT', 'SEG', nan}	{'TCIA-cptac-pda', 'TCIA-cptac-ccrcc', 'IDC-IDC_cptac_ccrcc', 'IDC-IDC_cptac_pda'}	{'IDC', 'TCIA'}	6
-MRI BREAST, BILATERAL	{'MR'}	{'IDC-IDC_tcga_brca'}	{'IDC'}	6
-PET/CT SPN	{'SEG', nan}	{'IDC-IDC_nsclc_radiogenomics', 'TCIA-nsclc-radiogenomics'}	{'IDC', 'TCIA'}	6
-PET/CT Tumor Img. Skull Base to Mid-thigh	{'CT', 'SEG', nan}	{'TCIA-tcga-thca', 'TCIA-tcga-luad', 'IDC-IDC_tcga_luad', 'IDC-IDC_tcga_thca'}	{'IDC', 'TCIA'}	6
-Thorax^02CAP_Routine (Adult)	{'CT', nan}	{'TCIA-tcga-lihc', 'TCIA-tcga-kirc', 'IDC-IDC_tcga_kirc', 'IDC-IDC_tcga_lihc'}	{'IDC', 'TCIA'}	6
-Thorax^CHEST_WITH_Customized (Adult)	{'CT'}	{'MIDRC-Open-A1'}	{'MIDRC'}	6
-MRI ABD W WO CON	{'MR', nan}	{'TCIA-tcga-lihc', 'IDC-IDC_tcga_lihc'}	{'IDC', 'TCIA'}	6
-AP	{'CT', nan}	{'TCIA-tcga-ov', 'IDC-IDC_tcga_ov'}	{'IDC', 'TCIA'}	6
-LT BREAST STUDY	{'MR', nan}	{'IDC-IDC_acrin_contralateral_breast_mr', 'TCIA-acrin-contralateral-breast-mr'}	{'IDC', 'TCIA'}	6
-Abdomen	{'US', 'DX', 'SEG', nan}	{'ACRdart-ACRIN_6666', 'TCIA-adrenal-acc-ki67-seg', 'IDC-IDC_adrenal_acc_ki67_seg', 'MIDRC-Open-A1_PETAL_REDCORAL'}	{'ACRdart', 'TCIA', 'IDC', 'MIDRC'}	6
-JHN CHEST OP	{'CT'}	{'MIDRC-Open-R1'}	{'MIDRC'}	6
-JOIEN CT CHEST	{'CT'}	{'MIDRC-Open-R1'}	{'MIDRC'}	6
-Abdomen acute series	{'CR'}	{'MIDRC-Open-A1'}	{'MIDRC'}	6
-Abdomen^01 ABD_PEL	{'CT', nan}	{'TCIA-tcga-ov', 'IDC-IDC_tcga_ov'}	{'IDC', 'TCIA'}	6
-PET Lung Cancer Restage I	{'SEG', nan}	{'TCIA-acrin-nsclc-fdg-pet', 'IDC-IDC_acrin_nsclc_fdg_pet'}	{'IDC', 'TCIA'}	6
-L SPINE	{'SEG', nan}	{'TCIA-spine-mets-ct-seg', 'IDC-IDC_spine_mets_ct_seg'}	{'IDC', 'TCIA'}	6
-LEFT THIGH C+	{'MR', nan}	{'IDC-IDC_soft_tissue_sarcoma', 'TCIA-soft-tissue-sarcoma'}	{'IDC', 'TCIA'}	6
-PET MULTIPLE MYELOMA (W/LOW DOSE CT)	{'PT,CT'}	{'MIDRC-Open-A1'}	{'MIDRC'}	6
-Abdomen^04 CA one Run	{'CT', nan}	{'TCIA-acrin-nsclc-fdg-pet', 'IDC-IDC_acrin_nsclc_fdg_pet'}	{'IDC', 'TCIA'}	6
-CAP WITH	{'CT', 'SEG', nan}	{'TCIA-anti-pd-1_lung', 'IDC-IDC_tcga_ov', 'IDC-IDC_anti_pd_1_lung', 'TCIA-tcga-kirc', 'TCIA-tcga-ov', 'IDC-IDC_tcga_kirc'}	{'IDC', 'TCIA'}	6
-LUNG MASS	{'PT', nan}	{'TCIA-acrin-nsclc-fdg-pet', 'IDC-IDC_acrin_nsclc_fdg_pet'}	{'IDC', 'TCIA'}	6
-MRI PELVIS wo&w	{'MR', nan}	{'TCIA-tcga-kirc', 'IDC-IDC_tcga_kirc', 'TCIA-tcga-ucec', 'IDC-IDC_tcga_ucec'}	{'IDC', 'TCIA'}	6
-CAP W/O	{'CT', nan}	{'TCIA-tcga-kirc', 'IDC-IDC_tcga_kirc'}	{'IDC', 'TCIA'}	6
-Abdomen^02_0_AP_Routine_Abdomen_Pelvis (Adult)	{'CT', nan}	{'TCIA-tcga-lihc', 'TCIA-tcga-kirc', 'IDC-IDC_tcga_kirc', 'IDC-IDC_tcga_lihc'}	{'IDC', 'TCIA'}	6
-MRI PELVIS	{'MR', nan}	{'IDC-IDC_tcga_blca', 'IDC-IDC_tcga_prad', 'TCIA-tcga-prad', 'TCIA-tcga-blca'}	{'IDC', 'TCIA'}	6
-CAP LIVER	{'CT', 'SEG', nan}	{'IDC-IDC_hcc_tace_seg', 'TCIA-hcc-tace-seg'}	{'IDC', 'TCIA'}	6
-Thorax^CTA_CHEST_THORACIC_DISSECTION (Adult)	{'CT'}	{'MIDRC-Open-A1'}	{'MIDRC'}	6
-Thorax^01_NONCONCHEST (Adult)	{'SEG', nan}	{'IDC-IDC_nsclc_radiogenomics', 'TCIA-nsclc-radiogenomics'}	{'IDC', 'TCIA'}	6
-Thorax^01_CHEST.ABD W-ABD.W	{'CT', nan}	{'TCIA-acrin-nsclc-fdg-pet', 'IDC-IDC_acrin_nsclc_fdg_pet'}	{'IDC', 'TCIA'}	6
-Thorax^01 CHEST .75 COLLIMATOR	{'CT', nan}	{'TCIA-acrin-nsclc-fdg-pet', 'IDC-IDC_acrin_nsclc_fdg_pet'}	{'IDC', 'TCIA'}	6
-MR PELVIS WITH AND WITHOUT CONTRAST	{'RTSTRUCT', nan}	{'IDC-IDC_cptac_ucec', 'TCIA-cptac-ucec'}	{'IDC', 'TCIA'}	6
-PET^WHOLEBODY_LD90 (Adult)	{'RTSTRUCT', 'PT', nan}	{'IDC-IDC_cptac_cm', 'IDC-IDC_cptac_ucec', 'TCIA-cptac-cm', 'TCIA-cptac-ucec'}	{'IDC', 'TCIA'}	6
-PET^WHOLEBODY_LONG_LD90 (Adult)	{'CT', 'PT', nan}	{'IDC-IDC_cptac_cm', 'IDC-IDC_cptac_sar', 'TCIA-cptac-sar', 'TCIA-cptac-cm'}	{'IDC', 'TCIA'}	6
-Abdomen^DE_ROUTINE_AP_WITH_OVER_50 (Adult)	{'CT'}	{'MIDRC-Open-A1'}	{'MIDRC'}	6
-MR BREAST, BIL	{'MR', 'SEG', nan}	{'TCIA-breast-mri-nact-pilot', 'IDC-IDC_breast_mri_nact_pilot'}	{'IDC', 'TCIA'}	6
-MR BREAST, UNILATERAL W/WO CONT	{'MR'}	{'ACRdart-EA1141Restricted', 'IDC-IDC_tcga_brca', 'IDC-IDC_ea1141'}	{'ACRdart', 'IDC'}	6
-Research	{'RTSTRUCT', 'SEG', nan}	{'IDC-IDC_upenn_gbm', 'TCIA-vestibular-schwannoma-seg', 'TCIA-upenn-gbm', 'IDC-IDC_vestibular_schwannoma_seg'}	{'IDC', 'TCIA'}	6
-MRI Abdomen WWO Contrast	{'SEG', nan}	{'TCIA-tcga-lihc', 'IDC-IDC_tcga_lihc'}	{'IDC', 'TCIA'}	6
-MR NONE SPECTROSCOPY	{'MR', 'SEG', nan}	{'IDC-IDC_upenn_gbm', 'TCIA-upenn-gbm'}	{'IDC', 'TCIA'}	6
-RECTUM	{'CT', nan}	{'IDC-IDC_pelvic_reference_data', 'TCIA-pelvic-reference-data'}	{'IDC', 'TCIA'}	6
-TRAUMA CT ABD PEL 2PHASE WITH IV CON WITH CHEST IMAGES	{'CT', nan}	{'MIDRC-TCIA-COVID-19-NY-SBU', 'IDC-IDC_covid_19_ny_sbu', 'TCIA-covid-19-ny-sbu'}	{'IDC', 'TCIA', 'MIDRC'}	6
-MR PROSTATE WO CONTRAST	{'SEG', nan}	{'TCIA-prostate-mri-us-biopsy', 'IDC-IDC_prostate_mri_us_biopsy'}	{'IDC', 'TCIA'}	6
-R-BREAST	{'MR', nan}	{'IDC-IDC_acrin_contralateral_breast_mr', 'TCIA-acrin-contralateral-breast-mr'}	{'IDC', 'TCIA'}	6
-MR Research wo w 30 minutes	{'MR'}	{'ACRdart-EA1141Restricted', 'IDC-IDC_ea1141'}	{'ACRdart', 'IDC'}	6
-Abdomen^ROUTINE_AP_WITH_UNDER_50_OVER_250_Customized (Adult)	{'CT'}	{'MIDRC-Open-A1'}	{'MIDRC'}	6
-MRI ABDOMEN W+WO CONTRAST	{'MR', 'SEG', nan}	{'TCIA-tcga-lihc', 'IDC-IDC_tcga_kirp', 'TCIA-tcga-kirp', 'IDC-IDC_tcga_lihc'}	{'IDC', 'TCIA'}	6
-Pelvis^CT_PELVIS_WITH (Adult)	{'CT'}	{'MIDRC-Open-A1'}	{'MIDRC'}	6
-PROSTATE BOOST	{'CT', nan}	{'IDC-IDC_pelvic_reference_data', 'TCIA-pelvic-reference-data'}	{'IDC', 'TCIA'}	6
-MRI ABD WWO IV CONT	{'MR', nan}	{'MIDRC-TCIA-COVID-19-NY-SBU', 'IDC-IDC_covid_19_ny_sbu', 'TCIA-covid-19-ny-sbu'}	{'IDC', 'TCIA', 'MIDRC'}	6
-Scanner-Philips_Exp-100_Pitch-1.2_SlCol-16x1.5mm	{'CT', nan}	{'IDC-IDC_phantom_fda', 'TCIA-phantom-fda'}	{'IDC', 'TCIA'}	6
-Abdomen^CA.AP W (Adult)	{'CT', nan}	{'TCIA-acrin-nsclc-fdg-pet', 'IDC-IDC_acrin_nsclc_fdg_pet'}	{'IDC', 'TCIA'}	6
-Abdomen^BRZUCH_3_FAZOWY (Adult)	{'RTSTRUCT', nan}	{'TCIA-cptac-ccrcc', 'IDC-IDC_cptac_ccrcc'}	{'IDC', 'TCIA'}	6
-FOREIGN CT ABD AND/OR PEL - CD	{'CT', nan}	{'IDC-IDC_tcga_blca', 'TCIA-tcga-blca'}	{'IDC', 'TCIA'}	6
-MM MAMMOGRAM SCREENING DIGITAL DDI	{'MG'}	{'ACRdart-EA1141Restricted', 'IDC-IDC_ea1141'}	{'ACRdart', 'IDC'}	6
-Abdomen^23NIH_COLO_IRB1221-00 (Adult)	{'CT', nan}	{'TCIA-ct-colonography', 'IDC-IDC_ct_colonography'}	{'IDC', 'TCIA'}	6
-PETCT FDG VERTEX TO MID THIGH (NON DIAGNOSTIC CT)	{'CT', 'PT'}	{'MIDRC-Open-R1'}	{'MIDRC'}	6
-TAVR OP	{'CT'}	{'MIDRC-Open-R1'}	{'MIDRC'}	6
-T/A/P W/C	{'CT', 'SEG', nan}	{'IDC-IDC_hcc_tace_seg', 'TCIA-hcc-tace-seg', 'TCIA-lidc-idri', 'IDC-IDC_lidc_idri', 'IDC-IDC_tcga_blca', 'TCIA-tcga-blca'}	{'IDC', 'TCIA'}	6
-BREAST^BREAST MASS	{'MR', nan}	{'IDC-IDC_acrin_contralateral_breast_mr', 'TCIA-acrin-contralateral-breast-mr'}	{'IDC', 'TCIA'}	6
-PETCT INITIAL TREATMEN	{'SEG', nan}	{'IDC-IDC_anti_pd_1_lung', 'TCIA-anti-pd-1_lung'}	{'IDC', 'TCIA'}	6
-Abdomen^7MCV_VIRTUAL_COLONOSCOPY (Adult)	{'CT', nan}	{'TCIA-ct-colonography', 'IDC-IDC_ct_colonography'}	{'IDC', 'TCIA'}	6
-T SPINE	{'CT', 'SEG', nan}	{'TCIA-spine-mets-ct-seg', 'IDC-IDC_spine_mets_ct_seg'}	{'IDC', 'TCIA'}	6
-Specials^1PETCT_WholeBody	{'SEG', nan}	{'TCIA-acrin-nsclc-fdg-pet', 'IDC-IDC_acrin_nsclc_fdg_pet'}	{'IDC', 'TCIA'}	6
-PETCT LUNG NOD	{'SEG', nan}	{'IDC-IDC_nsclc_radiogenomics', 'TCIA-nsclc-radiogenomics'}	{'IDC', 'TCIA'}	6
-PETCT SUBSEQUENT TREATMENT STRATEGY [IMG15078]	{'SEG', nan}	{'IDC-IDC_anti_pd_1_lung', 'TCIA-anti-pd-1_lung'}	{'IDC', 'TCIA'}	6
-PET^1PETCTMATCH_TX_WholeBody (Adult)	{'SEG', nan}	{'TCIA-acrin-nsclc-fdg-pet', 'IDC-IDC_acrin_nsclc_fdg_pet'}	{'IDC', 'TCIA'}	6
-PET^1PETCTMATCH_WholeBody (Adult)	{'CT', 'SEG', nan}	{'TCIA-acrin-nsclc-fdg-pet', 'IDC-IDC_acrin_nsclc_fdg_pet'}	{'IDC', 'TCIA'}	6
-BREAST LESION	{'MR'}	{'IDC-IDC_ea1141'}	{'IDC'}	6
-Abdomen^BRZUCH (Adult)	{'RTSTRUCT', 'CT', nan}	{'IDC-IDC_cptac_ucec', 'IDC-IDC_cptac_sar', 'TCIA-cptac-sar', 'TCIA-cptac-ucec'}	{'IDC', 'TCIA'}	6
-Scanner-Philips_Exp-200_Pitch-1.2_SlCol-16x1.5mm	{'CT', nan}	{'IDC-IDC_phantom_fda', 'TCIA-phantom-fda'}	{'IDC', 'TCIA'}	6
-CH/ABD/PELVIS	{'SEG', nan}	{'IDC-IDC_hcc_tace_seg', 'TCIA-lidc-idri', 'IDC-IDC_lidc_idri', 'TCIA-hcc-tace-seg'}	{'IDC', 'TCIA'}	6
-CAP (LIVER)	{'CT', 'SEG', nan}	{'IDC-IDC_hcc_tace_seg', 'TCIA-hcc-tace-seg'}	{'IDC', 'TCIA'}	6
-Pelvic Cavity CT Enhanced	{'CT', nan}	{'IDC-IDC_stageii_colorectal_ct', 'TCIA-stageii-colorectal-ct'}	{'IDC', 'TCIA'}	6
-UROGRAM OVER 35(Adult)	{'CT'}	{'MIDRC-Open-A1'}	{'MIDRC'}	6
-Thorax^PEDS__CAP_WITH (Child)	{'CT'}	{'MIDRC-Open-A1'}	{'MIDRC'}	6
-Vascular^CH03C_FLASH_CHST_W_PE (Adult)	{'CT'}	{'MIDRC-Open-A1_PETAL_BLUECORAL'}	{'MIDRC'}	6
-PELVIS FULL	{'CT', nan}	{'IDC-IDC_pelvic_reference_data', 'TCIA-pelvic-reference-data'}	{'IDC', 'TCIA'}	6
-MRI W/WO CONT UN	{'MR', nan}	{'IDC-IDC_acrin_contralateral_breast_mr', 'TCIA-acrin-contralateral-breast-mr'}	{'IDC', 'TCIA'}	6
-US_Abdomen	{'US', 'CT', 'XA', nan}	{'IDC-IDC_cmb_mel', 'IDC-IDC_cmb_crc', 'TCIA-cmb-crc', 'TCIA-cmb-mel'}	{'IDC', 'TCIA'}	6
-CHEST PULMONARY EMBOLISM CTA	{'CT'}	{'MIDRC-Open-A1_PETAL_BLUECORAL', 'MIDRC-Open-A1_PETAL_REDCORAL'}	{'MIDRC'}	6
-Mamm bil 2v w/TOMO	{'MG'}	{'IDC-IDC_ea1141'}	{'IDC'}	6
-Head^CODE_STROKE_CTA_WITH_PERFUSION_WS (Adult)	{'CT'}	{'MIDRC-Open-A1'}	{'MIDRC'}	6
-MR_BREAST-LT	{'MR', nan}	{'IDC-IDC_acrin_contralateral_breast_mr', 'TCIA-acrin-contralateral-breast-mr'}	{'IDC', 'TCIA'}	6
-CHEST IV IP	{'CT'}	{'MIDRC-Open-R1'}	{'MIDRC'}	6
-CHEST W/CONTRAST	{'CT', nan}	{'IDC-IDC_acrin_nsclc_fdg_pet', 'TCIA-acrin-nsclc-fdg-pet', 'TCIA-tcga-ucec', 'IDC-IDC_tcga_ucec'}	{'IDC', 'TCIA'}	6
-Head^FACE_WITHOUT (Adult)	{'CT'}	{'MIDRC-Open-A1'}	{'MIDRC'}	6
-Thorax^PEDS__CHEST_WITHOUT (Child)	{'CT'}	{'MIDRC-Open-A1'}	{'MIDRC'}	6
-MRM-6667	{'MR', nan}	{'IDC-IDC_acrin_contralateral_breast_mr', 'TCIA-acrin-contralateral-breast-mr'}	{'IDC', 'TCIA'}	6
-ANUS	{'CT', nan}	{'IDC-IDC_pelvic_reference_data', 'TCIA-pelvic-reference-data'}	{'IDC', 'TCIA'}	6
-PET BREAST CANCER (W/LOW DOSE CT)	{'PT,CT'}	{'MIDRC-Open-A1'}	{'MIDRC'}	6
-MRI_T_Spine	{'MR', nan}	{'IDC-IDC_cmb_mml', 'TCIA-cmb-mml'}	{'IDC', 'TCIA'}	6
-ACRIN6667	{'MR', nan}	{'IDC-IDC_acrin_contralateral_breast_mr', 'TCIA-acrin-contralateral-breast-mr'}	{'IDC', 'TCIA'}	6
-Thorax^XL_CAP_WO (Adult)	{'CT'}	{'MIDRC-Open-A1'}	{'MIDRC'}	6
-MRI_CSpine	{'MR', nan}	{'IDC-IDC_cmb_mml', 'TCIA-cmb-mml'}	{'IDC', 'TCIA'}	6
-MRI T Spine	{'MR', nan}	{'TCIA-cmb-crc', 'IDC-IDC_cmb_crc', 'TCIA-cmb-lca', 'IDC-IDC_cmb_mml', 'TCIA-cmb-mml', 'IDC-IDC_cmb_lca'}	{'IDC', 'TCIA'}	6
-ACRIN6667 RESEARCH	{'MR', nan}	{'IDC-IDC_acrin_contralateral_breast_mr', 'TCIA-acrin-contralateral-breast-mr'}	{'IDC', 'TCIA'}	6
-ABD/PEL (LIVER)	{'SEG', nan}	{'IDC-IDC_hcc_tace_seg', 'TCIA-hcc-tace-seg'}	{'IDC', 'TCIA'}	6
-FORFILE CD CT ABD WITHOUT CONTRAST	{'CT', nan}	{'TCIA-tcga-kirc', 'IDC-IDC_tcga_kirc'}	{'IDC', 'TCIA'}	6
-Thorax^LUNG_CANCER_SCREENING_CHEST_WO (Adult)	{'CT'}	{'MIDRC-Open-A1'}	{'MIDRC'}	6
-Group-487 Cells	{'MR', nan}	{'TCIA-mouse-astrocytoma', 'IDC-IDC_mouse_astrocytoma'}	{'IDC', 'TCIA'}	6
-WB FDG LUNG	{'SEG', 'PT', nan}	{'TCIA-acrin-nsclc-fdg-pet', 'IDC-IDC_acrin_nsclc_fdg_pet'}	{'IDC', 'TCIA'}	6
-OSF CT ABDOMEN	{'CT', 'SEG', nan}	{'IDC-IDC_hcc_tace_seg', 'TCIA-hcc-tace-seg', 'TCIA-tcga-kirc', 'IDC-IDC_tcga_ucec', 'IDC-IDC_tcga_kirc', 'TCIA-tcga-ucec'}	{'IDC', 'TCIA'}	6
-Head^FACE_WITHOUT_Customized (Adult)	{'CT'}	{'MIDRC-Open-A1'}	{'MIDRC'}	5
-RM CHEST PA AND LEFT LATERAL ONLY	{'DX'}	{'MIDRC-Open-A1_PETAL_BLUECORAL', 'MIDRC-Open-A1_PETAL_REDCORAL'}	{'MIDRC'}	5
-CT ANGIOGRAM FOR PULMONARY EMBOLISM [CH]	{'CT'}	{'MIDRC-Open-A1_PETAL_BLUECORAL'}	{'MIDRC'}	5
-CHEST IP	{'CT', nan}	{'TCIA-acrin-nsclc-fdg-pet', 'MIDRC-Open-R1', 'IDC-IDC_acrin_nsclc_fdg_pet'}	{'IDC', 'TCIA', 'MIDRC'}	5
-MG	{'MG'}	{'ACRdart-EA1141Restricted'}	{'ACRdart'}	5
-CT ABDOMEN PELVIS WO C	{'CT'}	{'MIDRC-Open-A1'}	{'MIDRC'}	5
-CT CHEST WITH CONTRAST (S)	{'CT'}	{'MIDRC-Open-R1'}	{'MIDRC'}	5
-CT ABDOMEN PELVIS W WO CONTRAST	{'CT', 'SEG', nan}	{'MIDRC-Open-R1', 'TCIA-adrenal-acc-ki67-seg', 'IDC-IDC_adrenal_acc_ki67_seg'}	{'IDC', 'TCIA', 'MIDRC'}	5
-MR BREAST BILAT	{'MR'}	{'IDC-IDC_ispy1'}	{'IDC'}	5
-CT BRAIN WITHOUT CONTRAST (S)	{'CT'}	{'MIDRC-Open-R1'}	{'MIDRC'}	5
-MRI BONE OUTSIDE IMAGE	{'MR'}	{'MIDRC-Open-A1'}	{'MIDRC'}	5
-Head^Maxillofacial1 (Adult)	{'CT'}	{'MIDRC-Open-A1'}	{'MIDRC'}	5
-Abdomen^HEMATURIA_GR_OVER45 (Adult)	{'CT'}	{'MIDRC-Open-A1'}	{'MIDRC'}	5
-Abdomen^12_CTA_AAA (Adult)	{'CT'}	{'MIDRC-Open-A1'}	{'MIDRC'}	5
-MRI Breast w/w/o Contrast bilat (Birad)	{'MR'}	{'ACRdart-EA1141Restricted', 'IDC-IDC_ea1141'}	{'ACRdart', 'IDC'}	5
-Thorax^CHEST_ABD_PELVIS (Adult)	{'RTSTRUCT', 'CT', nan}	{'MIDRC-Open-A1', 'IDC-IDC_cptac_ucec', 'TCIA-cptac-ucec'}	{'IDC', 'TCIA', 'MIDRC'}	5
-X-RAY WRIST COMPLETE MINIMUM 3 VWS - LEFT	{'DX'}	{'MIDRC-Open-A1'}	{'MIDRC'}	5
-CT ABDOMEN AND PELVIS WITHOUT CONTRAST	{'CT', nan}	{'MIDRC-Open-A1', 'TCIA-cptac-ccrcc', 'IDC-IDC_cptac_ccrcc'}	{'IDC', 'TCIA', 'MIDRC'}	5
-Frozen	{'CT'}	{'IDC-IDC_nlm_visible_human_project'}	{'IDC'}	5
-XR RIGHT KNEE 4+ VIEWS (TRAUMA)	{'CR', 'DX'}	{'MIDRC-Open-A1'}	{'MIDRC'}	5
-Bilateral Ribs	{'CR'}	{'MIDRC-Open-A1'}	{'MIDRC'}	5
-MRI BR BILAT W&WO CONTRAST	{'MR'}	{'IDC-IDC_ispy1'}	{'IDC'}	5
-X-RAY KNEE COMPLETE 4 OR MORE VIEWS - LEFT	{'CR', 'DX'}	{'MIDRC-Open-A1'}	{'MIDRC'}	5
-HIP COMPLETE LEFT MIN 2 VWS	{'CR', 'DX'}	{'MIDRC-Open-R1'}	{'MIDRC'}	5
-Vascular^CT_PE (Adult)	{'CT'}	{'MIDRC-Open-A1'}	{'MIDRC'}	5
-CHEST W/O	{'CT', nan}	{'IDC-IDC_tcga_lusc', 'TCIA-tcga-luad', 'TCIA-tcga-lusc', 'MIDRC-Open-R1', 'IDC-IDC_tcga_luad'}	{'IDC', 'TCIA', 'MIDRC'}	5
-PORT - CXR	{'CR', 'DX'}	{'MIDRC-Open-R1'}	{'MIDRC'}	5
-ABDOMEN PELVIS WITH(Adult)	{'CT'}	{'MIDRC-Open-A1'}	{'MIDRC'}	5
-CT HEART CALCIUM SCORE WITHOUT CONTRAST	{'CT'}	{'MIDRC-Open-A1'}	{'MIDRC'}	5
-/PRO/BD Pelvis w	{nan}	{'TCIA-qin-prostate-repeatability'}	{'TCIA'}	5
-NM PET CANCER ANY SITE	{'PT,CT'}	{'MIDRC-Open-A1'}	{'MIDRC'}	5
-BREAST RESEARCH	{'MR', 'SEG', nan}	{'TCIA-acrin-contralateral-breast-mr', 'TCIA-qin-breast', 'ACRdart-EA1141Restricted', 'IDC-IDC_qin_breast', 'IDC-IDC_acrin_contralateral_breast_mr'}	{'IDC', 'TCIA', 'ACRdart'}	5
-CT CT PULMONARY ANGIOGRAPHY	{'CT'}	{'MIDRC-Open-A1_PETAL_BLUECORAL', 'MIDRC-Open-A1_PETAL_REDCORAL'}	{'MIDRC'}	5
-Abdomen^ABD_PELVIS_WITH (Adult)	{'CT'}	{'MIDRC-Open-A1'}	{'MIDRC'}	5
-TomoHD bds	{'CT', 'MG'}	{'ACRdart-EA1141Restricted', 'IDC-IDC_ea1141'}	{'ACRdart', 'IDC'}	5
-PRO/BD Pelvis w	{'SEG'}	{'IDC-IDC_qin_prostate_repeatability'}	{'IDC'}	5
-CT HEAD W CONTRAST	{'CT'}	{'MIDRC-Open-A1'}	{'MIDRC'}	5
-CT CT-CHEST W/O CONTRAST	{'CT'}	{'MIDRC-Open-A1_PETAL_BLUECORAL', 'MIDRC-Open-A1_PETAL_REDCORAL'}	{'MIDRC'}	5
-X-RAY FOOT 2 VIEWS - LEFT	{'DX'}	{'MIDRC-Open-A1'}	{'MIDRC'}	5
-PETCT FDG VERTEX TO TOES (NON DIAGNOSTIC CT)	{'NM,PT', 'CT', 'PT'}	{'MIDRC-Open-R1'}	{'MIDRC'}	5
-BREAST^BREAST 8.25.14	{'MR'}	{'ACRdart-EA1141Restricted'}	{'ACRdart'}	5
-SHOULDER 3 VIEWS LEFT	{'CR', 'DX'}	{'MIDRC-Open-R1'}	{'MIDRC'}	5
-CT PELVIS WO CONTRAST (CYSTOGRAM)	{'CT'}	{'MIDRC-Open-A1'}	{'MIDRC'}	5
-X-RAY ESOPHAGUS DOUBLE CONTRAST W/CXR1V	{'DX'}	{'MIDRC-Open-A1'}	{'MIDRC'}	5
-TO - INITIAL ULTRASOUND	{'US'}	{'ACRdart-ACRIN_6666'}	{'ACRdart'}	5
-CHEST PA	{'CR'}	{'MIDRC-Open-R1'}	{'MIDRC'}	5
-BREAST ULTRASOUND	{'US'}	{'ACRdart-ACRIN_6666'}	{'ACRdart'}	5
-CT CHEST LUNG CANCER S	{'CT'}	{'MIDRC-Open-R1'}	{'MIDRC'}	5
-XR EG TUBE PLACEMENT	{'CR', 'DX'}	{'MIDRC-Open-A1_PETAL_BLUECORAL', 'MIDRC-Open-A1_PETAL_REDCORAL'}	{'MIDRC'}	5
-CAP COMBO IP	{'CT'}	{'MIDRC-Open-R1'}	{'MIDRC'}	5
-CH-CHEST 1V CR	{'CR'}	{'MIDRC-Open-A1_PETAL_REDCORAL'}	{'MIDRC'}	5
-XR KNEE LT 3 VIEWS	{'CR', 'DX'}	{'MIDRC-Open-A1'}	{'MIDRC'}	5
-CT CHEST W IVCON	{'CT'}	{'MIDRC-Open-R1', 'MIDRC-Open-A1_PETAL_REDCORAL'}	{'MIDRC'}	5
-CT_Neck	{'CT', nan}	{'IDC-IDC_cmb_mel', 'TCIA-cmb-mel'}	{'IDC', 'TCIA'}	5
-Thorax^LOW_DOSE_CHEST_UNDER_30_BMI (Adult)	{'CT'}	{'MIDRC-Open-A1'}	{'MIDRC'}	5
-CT ABD-PELV W/ CM	{'CT'}	{'MIDRC-Open-A1'}	{'MIDRC'}	5
-XR FOOT RIGHT (ROUTINE: AP,LAT,OBL)	{'CR', 'DX'}	{'MIDRC-Open-A1'}	{'MIDRC'}	5
-JCCI CT CAP COMB	{'CT'}	{'MIDRC-Open-R1'}	{'MIDRC'}	5
-Thorax^LARGE_CHEST_WITH_IV_CONTRAST (Adult)	{nan}	{'TCIA-varepop-apollo'}	{'TCIA'}	5
-XR LEFT FOREARM 2 VIEWS	{'CR', 'DX'}	{'MIDRC-Open-A1'}	{'MIDRC'}	5
-XR LEFT HIP 1 VIEW PORTABLE	{'CR', 'DX'}	{'MIDRC-Open-A1'}	{'MIDRC'}	5
-KNEE 3 VIEWS RIGHT	{'CR', 'DX'}	{'MIDRC-Open-R1'}	{'MIDRC'}	5
-MRI SHOULDER WO CONTRAST - RIGHT	{'MR'}	{'MIDRC-Open-A1'}	{'MIDRC'}	5
-Thorax^C_A_P_WO_GR (Adult)	{'CT'}	{'MIDRC-Open-A1'}	{'MIDRC'}	5
-CT ABD/PEL RENAL STONE LOW DOSE W/O CONTRAST	{'CT'}	{'MIDRC-Open-A1'}	{'MIDRC'}	5
-LCMC CT CHEST PE PROTOCOL	{'CT'}	{'MIDRC-Open-A1_PETAL_REDCORAL'}	{'MIDRC'}	5
-XR ABDOMEN (W/UPRIGHT)	{'CR', 'DX'}	{'MIDRC-Open-A1'}	{'MIDRC'}	5
-Thorax^PEDS__CHEST_WITH (Child)	{'CT'}	{'MIDRC-Open-A1'}	{'MIDRC'}	5
-MAMMO SCREEN BILAT DIGITAL	{'MG'}	{'ACRdart-EA1141Restricted', 'IDC-IDC_ea1141'}	{'ACRdart', 'IDC'}	5
-PET MULTIPLE MYELOMA (	{'PT,CT'}	{'MIDRC-Open-A1'}	{'MIDRC'}	5
-Thorax^FLASH_CHEST_WITH (Adult)	{'CT'}	{'MIDRC-Open-A1'}	{'MIDRC'}	5
-CTA CHEST FOR PULMONARY EMBOLUS WITH CONTRAST	{'CT'}	{'MIDRC-Open-A1_PETAL_BLUECORAL', 'MIDRC-Open-A1_PETAL_REDCORAL'}	{'MIDRC'}	5
-XR LEFT SHOULDER 1 VIEW	{'CR', 'DX'}	{'MIDRC-Open-A1'}	{'MIDRC'}	5
-XR RIGHT ANKLE 2 VIEWS	{'CR', 'DX'}	{'MIDRC-Open-A1'}	{'MIDRC'}	5
-MA MAMMOGRAM SCREENING BILATERAL W / TOMO	{'MG'}	{'ACRdart-EA1141Restricted'}	{'ACRdart'}	5
-MAMMO 3D DIAG LEFT	{'MG'}	{'ACRdart-EA1141Restricted', 'IDC-IDC_ea1141'}	{'ACRdart', 'IDC'}	5
-CT CHEST W, ABDOMEN PELVIS WWO	{'CT'}	{'MIDRC-Open-A1'}	{'MIDRC'}	5
-Thorax^XL_CAP_WITH (Adult)	{'CT'}	{'MIDRC-Open-A1'}	{'MIDRC'}	5
-MRI HIP WITHOUT CONTRAST-RIGHT	{'MR'}	{'MIDRC-Open-A1'}	{'MIDRC'}	5
-CHEST - 2 VIEWS	{'CR'}	{'MIDRC-Open-A1_SCCM_VIRUS'}	{'MIDRC'}	5
-MAM MAMMOGRAPHY UNILATERAL WITH TOMOSYNTHESIS	{'MG'}	{'ACRdart-EA1141Restricted', 'IDC-IDC_ea1141'}	{'ACRdart', 'IDC'}	5
-Thorax^LOW_DOSE_LUNG_OVER_30_BMI (Adult)	{'CT'}	{'MIDRC-Open-A1'}	{'MIDRC'}	5
-Cardiac^LAMODELTEST (Adult)	{'CT'}	{'MIDRC-Open-A1'}	{'MIDRC'}	5
-IR CHEST TUBE PLACEMENT (ORERABLE BY IR SERVICE ONLY)	{'US', 'CT'}	{'MIDRC-Open-R1'}	{'MIDRC'}	5
-OS CT CHEST COMPARE-NO READ	{'CT', nan}	{'TCIA-acrin-nsclc-fdg-pet', 'IDC-IDC_acrin_nsclc_fdg_pet'}	{'IDC', 'TCIA'}	4
-MRI Spine	{'MR', nan}	{'IDC-IDC_cmb_pca', 'TCIA-cmb-lca', 'IDC-IDC_cmb_lca', 'TCIA-cmb-pca'}	{'IDC', 'TCIA'}	4
-MRI Pelvis W/O&W Contrast	{'MR'}	{'ACRdart-ACRIN_6701'}	{'ACRdart'}	4
-_t4of5  External Images for PACS	{'MR', nan}	{'IDC-IDC_vestibular_schwannoma_mc_rc', 'TCIA-vestibular-schwannoma-mc-rc'}	{'IDC', 'TCIA'}	4
-Outside Digital Media	{'CT', nan}	{'TCIA-tcga-lihc', 'IDC-IDC_tcga_lihc', 'TCIA-tcga-ucec', 'IDC-IDC_tcga_ucec'}	{'IDC', 'TCIA'}	4
-_t5of8MRI Stereo Gamma Knife	{'MR', nan}	{'IDC-IDC_vestibular_schwannoma_mc_rc', 'TCIA-vestibular-schwannoma-mc-rc'}	{'IDC', 'TCIA'}	4
-CT COLONGRAPHY	{'CT', nan}	{'TCIA-ct-colonography', 'IDC-IDC_ct_colonography'}	{'IDC', 'TCIA'}	4
-CT Chest Without Contrast	{'CT', nan}	{'TCIA-cptac-lscc', 'TCIA-cptac-luad', 'IDC-IDC_cptac_luad', 'IDC-IDC_cptac_lscc'}	{'IDC', 'TCIA'}	4
-_t5of9MRI Stereo Gamma Knife gad	{'MR', nan}	{'IDC-IDC_vestibular_schwannoma_mc_rc', 'TCIA-vestibular-schwannoma-mc-rc'}	{'IDC', 'TCIA'}	4
-MRI BREAST BILAT W-WO-RH	{'SEG', nan}	{'TCIA-duke-breast-cancer-mri', 'IDC-IDC_duke_breast_cancer_mri'}	{'IDC', 'TCIA'}	4
-CT CHEST & ABDOMEN-CHEST	{'CT', nan}	{'TCIA-acrin-nsclc-fdg-pet', 'IDC-IDC_acrin_nsclc_fdg_pet'}	{'IDC', 'TCIA'}	4
-CT CHEST/THORAX W/CON	{'CT', nan}	{'TCIA-acrin-nsclc-fdg-pet', 'IDC-IDC_acrin_nsclc_fdg_pet'}	{'IDC', 'TCIA'}	4
-CT CHEST NO CONTRAST	{'CT', nan}	{'TCIA-acrin-nsclc-fdg-pet', 'IDC-IDC_acrin_nsclc_fdg_pet'}	{'IDC', 'TCIA'}	4
-CT CHEST & ABDOMEN, ENHANCED-CHEST	{'CT', nan}	{'TCIA-acrin-nsclc-fdg-pet', 'IDC-IDC_acrin_nsclc_fdg_pet'}	{'IDC', 'TCIA'}	4
-CT CHEST/ABDOMEN W/CON	{'CT', nan}	{'TCIA-acrin-nsclc-fdg-pet', 'IDC-IDC_acrin_nsclc_fdg_pet'}	{'IDC', 'TCIA'}	4
-_t3of6  MRI IAMS	{'MR', nan}	{'IDC-IDC_vestibular_schwannoma_mc_rc', 'TCIA-vestibular-schwannoma-mc-rc'}	{'IDC', 'TCIA'}	4
-PET^CC_PETWB_CT_CAP (Adult)	{'CT', 'SEG', nan}	{'TCIA-acrin-nsclc-fdg-pet', 'IDC-IDC_acrin_nsclc_fdg_pet'}	{'IDC', 'TCIA'}	4
-CT CORONARY ANGIO	{'CT'}	{'AIMI-COCA'}	{'AIMI'}	4
-POS	{'CT', nan}	{'IDC-IDC_lung_pet_ct_dx', 'TCIA-lung-pet-ct-dx'}	{'IDC', 'TCIA'}	4
-_t5of5  MRI IAMS	{'MR', nan}	{'IDC-IDC_vestibular_schwannoma_mc_rc', 'TCIA-vestibular-schwannoma-mc-rc'}	{'IDC', 'TCIA'}	4
-Neck^DE_CTA_NECK (Adult)	{'CT'}	{'MIDRC-Open-A1'}	{'MIDRC'}	4
-MRI ABDOMEN W/WO CONTRAST (74183)	{'MR', nan}	{'TCIA-tcga-lihc', 'IDC-IDC_tcga_lihc'}	{'IDC', 'TCIA'}	4
-CT Chest W/ Contrast	{'CT'}	{'MIDRC-Open-A1_PETAL_BLUECORAL', 'MIDRC-Open-A1_PETAL_REDCORAL'}	{'MIDRC'}	4
-OS STDY CT BODY INTERPRET	{'CT', 'SEG', nan}	{'TCIA-tcga-lihc', 'IDC-IDC_tcga_blca', 'IDC-IDC_tcga_lihc', 'TCIA-tcga-blca'}	{'IDC', 'TCIA'}	4
-_t4of6  MRI Head	{'MR', nan}	{'IDC-IDC_vestibular_schwannoma_mc_rc', 'TCIA-vestibular-schwannoma-mc-rc'}	{'IDC', 'TCIA'}	4
-OSF CT ABD	{'SEG', nan}	{'IDC-IDC_tcga_kirp', 'IDC-IDC_tcga_kich', 'TCIA-tcga-kirp', 'TCIA-tcga-kich'}	{'IDC', 'TCIA'}	4
-PRONE PELVIS	{'CT', nan}	{'IDC-IDC_pelvic_reference_data', 'TCIA-pelvic-reference-data'}	{'IDC', 'TCIA'}	4
-CT CHEST ABDOMEN AND PELVIS WO CONTRAST	{'CT'}	{'MIDRC-Open-A1_PETAL_BLUECORAL', 'MIDRC-Open-A1_PETAL_REDCORAL'}	{'MIDRC'}	4
-CT CHEST OUTSIDE IMAGE	{'CT'}	{'MIDRC-Open-A1'}	{'MIDRC'}	4
-PET ENDOMETRIAL OR CER	{'PT,CT'}	{'MIDRC-Open-A1'}	{'MIDRC'}	4
-MRI Right Breast with and without Contrast	{'MR', nan}	{'TCIA-breast-diagnosis', 'IDC-IDC_breast_diagnosis'}	{'IDC', 'TCIA'}	4
-PORTABLE CHEST - 1 VIEW	{'CR'}	{'MIDRC-Open-A1_SCCM_VIRUS'}	{'MIDRC'}	4
-_t4of7  External Images for PACS	{'MR', nan}	{'IDC-IDC_vestibular_schwannoma_mc_rc', 'TCIA-vestibular-schwannoma-mc-rc'}	{'IDC', 'TCIA'}	4
-PET CT Wholebody	{'CT', nan}	{'IDC-IDC_cmb_mel', 'IDC-IDC_cmb_crc', 'TCIA-cmb-crc', 'TCIA-cmb-mel'}	{'IDC', 'TCIA'}	4
-CT CHEST PE	{'CT', 'SEG', nan}	{'TCIA-tcga-ov', 'IDC-IDC_lidc_idri', 'TCIA-lidc-idri', 'IDC-IDC_tcga_ov'}	{'IDC', 'TCIA'}	4
-CT Chest With Contrast	{'CT', nan}	{'TCIA-cptac-lscc', 'TCIA-cptac-luad', 'IDC-IDC_cptac_luad', 'IDC-IDC_cptac_lscc'}	{'IDC', 'TCIA'}	4
-CT CHEST ENHANCED=CH	{'RTSTRUCT', nan}	{'TCIA-cptac-pda', 'IDC-IDC_cptac_pda'}	{'IDC', 'TCIA'}	4
-MRI ABDOMEN W/O CONTRAST	{'MR'}	{'MIDRC-Open-A1'}	{'MIDRC'}	4
-NSCL CA RESTG	{'SEG', nan}	{'TCIA-acrin-nsclc-fdg-pet', 'IDC-IDC_acrin_nsclc_fdg_pet'}	{'IDC', 'TCIA'}	4
-POST CHEST	{'SEG', nan}	{'TCIA-lidc-idri', 'IDC-IDC_lidc_idri'}	{'IDC', 'TCIA'}	4
-MRI Abd wo	{'MR', nan}	{'TCIA-tcga-lihc', 'IDC-IDC_tcga_lihc'}	{'IDC', 'TCIA'}	4
-_t6of11  MRI IAMS	{'MR', nan}	{'IDC-IDC_vestibular_schwannoma_mc_rc', 'TCIA-vestibular-schwannoma-mc-rc'}	{'IDC', 'TCIA'}	4
-MRI ELBOW W/O CONTRAST-LEFT	{'MR'}	{'MIDRC-Open-A1'}	{'MIDRC'}	4
-MRI BREAST BILATERAL - WITH AND WITHOUT CONTRAST	{'MR'}	{'ACRdart-EA1141Restricted', 'IDC-IDC_ea1141'}	{'ACRdart', 'IDC'}	4
-MRM-6667-	{'MR', nan}	{'IDC-IDC_acrin_contralateral_breast_mr', 'TCIA-acrin-contralateral-breast-mr'}	{'IDC', 'TCIA'}	4
-MRI Left Breast with and without Contrast	{'MR', nan}	{'TCIA-breast-diagnosis', 'IDC-IDC_breast_diagnosis'}	{'IDC', 'TCIA'}	4
-PET REFERENCE ONLY	{'SEG', nan}	{'IDC-IDC_nsclc_radiogenomics', 'TCIA-nsclc-radiogenomics'}	{'IDC', 'TCIA'}	4
-MRI LT. BREAST	{'MR', nan}	{'IDC-IDC_acrin_contralateral_breast_mr', 'TCIA-acrin-contralateral-breast-mr'}	{'IDC', 'TCIA'}	4
-PET/CT Sk-Thigh	{'SEG', nan}	{'TCIA-tcga-lusc', 'IDC-IDC_tcga_lusc'}	{'IDC', 'TCIA'}	4
-MRI LOWER EXTREMITY NOT JOINT WITHOUT CONTRAST RIGHT	{'MR', nan}	{'IDC-IDC_cptac_sar', 'TCIA-cptac-sar'}	{'IDC', 'TCIA'}	4
-MRI L Spine	{'MR', nan}	{'IDC-IDC_cmb_mml', 'TCIA-cmb-crc', 'TCIA-cmb-mml', 'IDC-IDC_cmb_crc'}	{'IDC', 'TCIA'}	4
-a p	{'CT', nan}	{'TCIA-tcga-ov', 'IDC-IDC_tcga_ov'}	{'IDC', 'TCIA'}	4
-MRM - 6667	{'MR', nan}	{'IDC-IDC_acrin_contralateral_breast_mr', 'TCIA-acrin-contralateral-breast-mr'}	{'IDC', 'TCIA'}	4
-MRI BREAST W/CONTRAST	{'MR', nan}	{'IDC-IDC_acrin_contralateral_breast_mr', 'TCIA-acrin-contralateral-breast-mr'}	{'IDC', 'TCIA'}	4
-ap	{'CT', nan}	{'TCIA-tcga-ov', 'IDC-IDC_tcga_ov'}	{'IDC', 'TCIA'}	4
-PET/CT NCAP	{'SEG', nan}	{'TCIA-tcga-lusc', 'IDC-IDC_tcga_lusc', 'TCIA-tcga-luad', 'IDC-IDC_tcga_luad'}	{'IDC', 'TCIA'}	4
-MRI_WholeBody	{'MR', nan}	{'IDC-IDC_cmb_mml', 'TCIA-cmb-gec', 'IDC-IDC_cmb_gec', 'TCIA-cmb-mml'}	{'IDC', 'TCIA'}	4
-PET/CT LUNGS	{'SEG', nan}	{'TCIA-acrin-nsclc-fdg-pet', 'IDC-IDC_acrin_nsclc_fdg_pet'}	{'IDC', 'TCIA'}	4
-PET CT TUMOR, WHOLE BO	{'CT', nan}	{'TCIA-breast-diagnosis', 'IDC-IDC_breast_diagnosis'}	{'IDC', 'TCIA'}	4
-MRI_TSpine	{'MR', nan}	{'IDC-IDC_cmb_pca', 'IDC-IDC_cmb_mml', 'TCIA-cmb-mml', 'TCIA-cmb-pca'}	{'IDC', 'TCIA'}	4
-PET/CT LUNG NODULES	{'SEG', nan}	{'IDC-IDC_nsclc_radiogenomics', 'TCIA-nsclc-radiogenomics'}	{'IDC', 'TCIA'}	4
-MRI Kidneys	{'MR', nan}	{'TCIA-tcga-kirc', 'IDC-IDC_tcga_kich', 'IDC-IDC_tcga_kirc', 'TCIA-tcga-kich'}	{'IDC', 'TCIA'}	4
-PET CARDIAC FLOW	{'CT', nan}	{'IDC-IDC_rider_lung_pet_ct', 'TCIA-rider-lung-pet-ct'}	{'IDC', 'TCIA'}	4
-MRI_Brain	{'MR', nan}	{'IDC-IDC_cmb_crc', 'TCIA-cmb-crc', 'TCIA-cmb-aml', 'IDC-IDC_cmb_aml'}	{'IDC', 'TCIA'}	4
-MRI INTERPRETATION OF OUTSIDE ABDOMINAL IMAGES	{'SEG', nan}	{'TCIA-prostate-mri-us-biopsy', 'IDC-IDC_prostate_mri_us_biopsy'}	{'IDC', 'TCIA'}	4
-MRI C Spine	{'MR', nan}	{'IDC-IDC_cmb_mml', 'TCIA-cmb-crc', 'TCIA-cmb-mml', 'IDC-IDC_cmb_crc'}	{'IDC', 'TCIA'}	4
-CT CHEST AND ABDOMEN W	{'CT', nan}	{'TCIA-acrin-nsclc-fdg-pet', 'IDC-IDC_acrin_nsclc_fdg_pet'}	{'IDC', 'TCIA'}	4
-PET TUMOR METABOLISM	{'SEG', 'PT', nan}	{'IDC-IDC_rider_lung_pet_ct', 'TCIA-rider-lung-pet-ct'}	{'IDC', 'TCIA'}	4
-MRI GUIDED BREAST BIOPSY AUT VAC ROT LEFT	{'MR'}	{'ACRdart-EA1141Restricted', 'IDC-IDC_ea1141'}	{'ACRdart', 'IDC'}	4
-MRI FOREIGN IMAGES	{'MR', nan}	{'TCIA-cptac-ccrcc', 'IDC-IDC_cptac_ccrcc'}	{'IDC', 'TCIA'}	4
-PET/CT WB	{'SEG', nan}	{'TCIA-acrin-nsclc-fdg-pet', 'IDC-IDC_acrin_nsclc_fdg_pet'}	{'IDC', 'TCIA'}	4
-ct cap	{'CT', nan}	{'TCIA-tcga-ov', 'IDC-IDC_tcga_ov'}	{'IDC', 'TCIA'}	4
-CT CHEST/ABD/PEL LIVER	{'CT', 'SEG', nan}	{'IDC-IDC_hcc_tace_seg', 'TCIA-hcc-tace-seg'}	{'IDC', 'TCIA'}	4
-_t8of8_MRI HEAD	{'MR', nan}	{'IDC-IDC_vestibular_schwannoma_mc_rc', 'TCIA-vestibular-schwannoma-mc-rc'}	{'IDC', 'TCIA'}	4
-PET NON-SMALL CELL LUNG INITIAL STAGING	{'SEG', nan}	{'TCIA-acrin-nsclc-fdg-pet', 'IDC-IDC_acrin_nsclc_fdg_pet'}	{'IDC', 'TCIA'}	4
-NM PET SCAN RADIATION	{'RTSTRUCT', 'CT'}	{'IDC-IDC_lctsc'}	{'IDC'}	4
-CT CHEST-CHEST	{'CT', nan}	{'TCIA-acrin-nsclc-fdg-pet', 'IDC-IDC_acrin_nsclc_fdg_pet'}	{'IDC', 'TCIA'}	4
-NM PET CT Routine Skull to Thigh 18 FDG Solid Tumor	{'CT', 'PT', nan}	{'TCIA-cptac-lscc', 'TCIA-cptac-luad', 'IDC-IDC_cptac_luad', 'IDC-IDC_cptac_lscc'}	{'IDC', 'TCIA'}	4
-PET^02_CBM_Lung_Only (Adult)	{'CT', 'SEG', nan}	{'IDC-IDC_lung_pet_ct_dx', 'TCIA-lung-pet-ct-dx'}	{'IDC', 'TCIA'}	4
-PET NSC LUNG INIT STG	{'SEG', nan}	{'TCIA-acrin-nsclc-fdg-pet', 'IDC-IDC_acrin_nsclc_fdg_pet'}	{'IDC', 'TCIA'}	4
-MRI BREAST RESEARCH ECOG ACRIN W WO CONTRAST	{'MR'}	{'ACRdart-EA1141Restricted', 'IDC-IDC_ea1141'}	{'ACRdart', 'IDC'}	4
-PET NSC LUNG RESTAGE R	{'SEG', nan}	{'TCIA-acrin-nsclc-fdg-pet', 'IDC-IDC_acrin_nsclc_fdg_pet'}	{'IDC', 'TCIA'}	4
-MRI BREAST UNI 1ST EX?	{'MR', nan}	{'IDC-IDC_acrin_contralateral_breast_mr', 'TCIA-acrin-contralateral-breast-mr'}	{'IDC', 'TCIA'}	4
-Mammogram Screening Digital	{'MG'}	{'ACRdart-EA1141Restricted'}	{'ACRdart'}	4
-MRI-PELVIS	{'RTSTRUCT', nan}	{'IDC-IDC_soft_tissue_sarcoma', 'TCIA-soft-tissue-sarcoma'}	{'IDC', 'TCIA'}	4
-MSK - Thigh (C+)	{'RTSTRUCT', 'MR', nan}	{'IDC-IDC_soft_tissue_sarcoma', 'TCIA-soft-tissue-sarcoma'}	{'IDC', 'TCIA'}	4
-lung3D	{'SEG', nan}	{'IDC-IDC_lung_pet_ct_dx', 'TCIA-lung-pet-ct-dx'}	{'IDC', 'TCIA'}	4
-PET CT WHOLE BODY	{'CT', 'SEG', nan}	{'TCIA-tcga-lusc', 'IDC-IDC_tcga_lusc', 'IDC-IDC_rider_lung_pet_ct', 'TCIA-rider-lung-pet-ct'}	{'IDC', 'TCIA'}	4
-lung+c GSI	{'CT', nan}	{'IDC-IDC_lung_pet_ct_dx', 'TCIA-lung-pet-ct-dx'}	{'IDC', 'TCIA'}	4
-CT CHEST ABDOMEN PELVIS W/O IV CON	{'CT'}	{'MIDRC-Open-R1'}	{'MIDRC'}	4
-_t7of7  MRI IAMS	{'MR', nan}	{'IDC-IDC_vestibular_schwannoma_mc_rc', 'TCIA-vestibular-schwannoma-mc-rc'}	{'IDC', 'TCIA'}	4
-CT CHEST W CON	{'CT', 'SEG', nan}	{'MIDRC-Open-R1', 'TCIA-nsclc-radiogenomics', 'IDC-IDC_nsclc_radiogenomics'}	{'IDC', 'TCIA', 'MIDRC'}	4
-_t7of7MRI Head	{'MR', nan}	{'IDC-IDC_vestibular_schwannoma_mc_rc', 'TCIA-vestibular-schwannoma-mc-rc'}	{'IDC', 'TCIA'}	4
-CT CHEST ABDOMEN PELVIS W/WO CONTRAST	{'CT', 'SEG', nan}	{'TCIA-adrenal-acc-ki67-seg', 'IDC-IDC_adrenal_acc_ki67_seg'}	{'IDC', 'TCIA'}	4
-_t7of7MRI IAMS	{'MR', nan}	{'IDC-IDC_vestibular_schwannoma_mc_rc', 'TCIA-vestibular-schwannoma-mc-rc'}	{'IDC', 'TCIA'}	4
-PET PHILIPS	{'PT', nan}	{'TCIA-acrin-nsclc-fdg-pet', 'IDC-IDC_acrin_nsclc_fdg_pet'}	{'IDC', 'TCIA'}	4
-_t7of7_MRI IAMS	{'MR', nan}	{'IDC-IDC_vestibular_schwannoma_mc_rc', 'TCIA-vestibular-schwannoma-mc-rc'}	{'IDC', 'TCIA'}	4
-e+1 ACRIN 6667 CONTRAL	{'MR', nan}	{'IDC-IDC_acrin_contralateral_breast_mr', 'TCIA-acrin-contralateral-breast-mr'}	{'IDC', 'TCIA'}	4
-_t8of8MRI IAMS	{'MR', nan}	{'IDC-IDC_vestibular_schwannoma_mc_rc', 'TCIA-vestibular-schwannoma-mc-rc'}	{'IDC', 'TCIA'}	4
-_t9of9_MRI HEAD	{'MR', nan}	{'IDC-IDC_vestibular_schwannoma_mc_rc', 'TCIA-vestibular-schwannoma-mc-rc'}	{'IDC', 'TCIA'}	4
-Whole-Body PET	{'PT', nan}	{'TCIA-acrin-nsclc-fdg-pet', 'IDC-IDC_acrin_nsclc_fdg_pet'}	{'IDC', 'TCIA'}	4
-PT706B/READ	{'SEG', nan}	{'IDC-IDC_qin_breast', 'TCIA-qin-breast'}	{'IDC', 'TCIA'}	4
-CT THORAX WO CONTRAST	{'CT'}	{'MIDRC-Open-R1'}	{'MIDRC'}	4
-LUNG NODULE	{'PT', nan}	{'TCIA-acrin-nsclc-fdg-pet', 'IDC-IDC_acrin_nsclc_fdg_pet'}	{'IDC', 'TCIA'}	4
-CTA CHEST ABDOMEN PELVIS ANGIO	{'CT'}	{'MIDRC-Open-A1_PETAL_BLUECORAL'}	{'MIDRC'}	4
-Thorax^FLASH_CTA_CHEST (Adult)	{'CT'}	{'MIDRC-Open-A1'}	{'MIDRC'}	4
-LTRC	{'CT', nan}	{'TCIA-tcga-luad', 'IDC-IDC_tcga_luad'}	{'IDC', 'TCIA'}	4
-LEFT Unilat Mammogram with Tomo	{'MG'}	{'ACRdart-EA1141Restricted', 'IDC-IDC_ea1141'}	{'ACRdart', 'IDC'}	4
-L I V E R	{'SEG', nan}	{'IDC-IDC_hcc_tace_seg', 'TCIA-hcc-tace-seg'}	{'IDC', 'TCIA'}	4
-KT klatki piersiowej bez i z CE z ujeciem nadbrzusza	{'CT', nan}	{'TCIA-cptac-lscc', 'IDC-IDC_cptac_lscc'}	{'IDC', 'TCIA'}	4
-Thorax^LARGE_CHEST_LOW_DOSE (Adult)	{nan}	{'TCIA-varepop-apollo'}	{'TCIA'}	4
-KLP +C	{'CT', nan}	{'TCIA-cptac-lscc', 'TCIA-cptac-luad', 'IDC-IDC_cptac_luad', 'IDC-IDC_cptac_lscc'}	{'IDC', 'TCIA'}	4
-JOINY CT C/A/P WITH	{'CT'}	{'MIDRC-Open-R1'}	{'MIDRC'}	4
-JHN CAP W/WO IP	{'CT'}	{'MIDRC-Open-R1'}	{'MIDRC'}	4
-JHN CAP W IP	{'CT'}	{'MIDRC-Open-R1'}	{'MIDRC'}	4
-CTABDPELW	{'RTSTRUCT', nan}	{'IDC-IDC_cptac_ucec', 'TCIA-cptac-ccrcc', 'IDC-IDC_cptac_ccrcc', 'TCIA-cptac-ucec'}	{'IDC', 'TCIA'}	4
-JCCI CT LUNG SCREENING	{'CT'}	{'MIDRC-Open-R1'}	{'MIDRC'}	4
-CT_Abd/Pel	{'CT', nan}	{'IDC-IDC_cmb_crc', 'TCIA-cmb-crc', 'TCIA-cmb-aml', 'IDC-IDC_cmb_aml'}	{'IDC', 'TCIA'}	4
-XR LEFT ANKLE 2 VIEWS	{'CR', 'DX'}	{'MIDRC-Open-A1'}	{'MIDRC'}	4
-XR KUB 1V PORTABLE	{'CR'}	{'MIDRC-Open-A1_PETAL_BLUECORAL'}	{'MIDRC'}	4
-JCCI CT CHEST ENHANCED	{'CT'}	{'MIDRC-Open-R1'}	{'MIDRC'}	4
-Thorax^LOW_DOSE_LUNG_UNDER_30_BMI (Adult)	{'CT'}	{'MIDRC-Open-A1'}	{'MIDRC'}	4
-XR RIBS RIGHT - 2 VIEWS	{'CR'}	{'MIDRC-Open-A1'}	{'MIDRC'}	4
-CTA ABDOMEN PELVIS WWO CONTRAST (AORTA)	{'CT'}	{'MIDRC-Open-A1'}	{'MIDRC'}	4
-CT008   CT ABDOMEN W CO	{'CT', nan}	{'TCIA-tcga-kirc', 'TCIA-tcga-read', 'IDC-IDC_tcga_kirc', 'IDC-IDC_tcga_read'}	{'IDC', 'TCIA'}	4
-CT UROGRAM WITHOUT 3D RECONSTRUCTIONS	{'RTSTRUCT', 'CT', nan}	{'TCIA-cptac-ccrcc', 'IDC-IDC_cptac_ccrcc'}	{'IDC', 'TCIA'}	4
-MAMMO DIAGNOSTIC DIGITAL LEFT	{'MG', nan}	{'TCIA-breast-cancer-screening-dbt', 'IDC-IDC_breast_cancer_screening_dbt'}	{'IDC', 'TCIA'}	4
-Thorax^CHEST_W_CONTRAST (Adult)	{'SEG', nan}	{'IDC-IDC_nsclc_radiogenomics', 'TCIA-nsclc-radiogenomics'}	{'IDC', 'TCIA'}	4
-MAMMO 3D DIAG RIGHT	{'MG'}	{'ACRdart-EA1141Restricted', 'IDC-IDC_ea1141'}	{'ACRdart', 'IDC'}	4
-CT Thorax w/ Contrast	{'CT'}	{'MIDRC-Open-A1_PETAL_BLUECORAL', 'MIDRC-Open-A1_PETAL_REDCORAL'}	{'MIDRC'}	4
-XR RIGHT FINGERS	{'CR', 'DX'}	{'MIDRC-Open-A1'}	{'MIDRC'}	4
-XR RIGHT ELBOW 3+ VIEWS	{'CR', 'DX'}	{'MIDRC-Open-A1'}	{'MIDRC'}	4
-CT Thorax with Contrast	{'SEG', nan}	{'IDC-IDC_nsclc_radiogenomics', 'TCIA-nsclc-radiogenomics'}	{'IDC', 'TCIA'}	4
-CT UROGRAM WITH CHEST	{'CT', nan}	{'TCIA-tcga-kirc', 'IDC-IDC_tcga_blca', 'IDC-IDC_tcga_kirc', 'TCIA-tcga-blca'}	{'IDC', 'TCIA'}	4
-CT UROGRAPHY CT ABDOME	{'RTSTRUCT', 'SEG', nan}	{'IDC-IDC_cptac_ucec', 'TCIA-cptac-ccrcc', 'IDC-IDC_cptac_ccrcc', 'TCIA-cptac-ucec'}	{'IDC', 'TCIA'}	4
-CT/C-A-P	{'CT', 'SEG', nan}	{'IDC-IDC_tcga_blca', 'TCIA-lidc-idri', 'IDC-IDC_lidc_idri', 'TCIA-tcga-blca'}	{'IDC', 'TCIA'}	4
-CT Urogram (1)	{'CT', nan}	{'TCIA-tcga-kirc', 'TCIA-tcga-ov', 'IDC-IDC_tcga_kirc', 'IDC-IDC_tcga_ov'}	{'IDC', 'TCIA'}	4
-Thorax^CT_CA_WITH (Adult)	{'CT'}	{'MIDRC-Open-A1'}	{'MIDRC'}	4
-XR RIBS, LEFT	{'DX'}	{'MIDRC-Open-R1'}	{'MIDRC'}	4
-Lung V/Q Scan	{'NM', nan}	{'TCIA-tcga-lusc', 'IDC-IDC_tcga_lusc'}	{'IDC', 'TCIA'}	4
-XR RIBS, BILATERAL	{'DX'}	{'MIDRC-Open-R1'}	{'MIDRC'}	4
-Lung Perfusion Scan	{'CT', nan}	{'TCIA-acrin-nsclc-fdg-pet', 'IDC-IDC_acrin_nsclc_fdg_pet'}	{'IDC', 'TCIA'}	4
-CT,ABDOMEN W&W/O CONTRAST	{'CT', nan}	{'TCIA-tcga-ov', 'IDC-IDC_tcga_ov'}	{'IDC', 'TCIA'}	4
-CT-CH/A/P	{'CT', 'SEG', nan}	{'IDC-IDC_tcga_blca', 'TCIA-lidc-idri', 'IDC-IDC_lidc_idri', 'TCIA-tcga-blca'}	{'IDC', 'TCIA'}	4
-Thorax^LOW_DOSE_NODULE_FU_WO_CM (Adult)	{'CT'}	{'MIDRC-Open-A1'}	{'MIDRC'}	4
-Thorax^LungRoutine	{'CT', nan}	{'TCIA-acrin-nsclc-fdg-pet', 'IDC-IDC_acrin_nsclc_fdg_pet'}	{'IDC', 'TCIA'}	4
-Implant Screening - ComboHD	{'MG', nan}	{'TCIA-breast-cancer-screening-dbt', 'IDC-IDC_breast_cancer_screening_dbt'}	{'IDC', 'TCIA'}	4
-Vascular^NEW_PE_CTA_ 22 (Adult)	{'CT'}	{'MIDRC-Open-A1'}	{'MIDRC'}	4
-DIGITAL MAMMOGRAM,UNILATERAL	{'MG', nan}	{'TCIA-breast-diagnosis', 'IDC-IDC_breast_diagnosis'}	{'IDC', 'TCIA'}	4
-Diagnostic Acquisition	{'PT', nan}	{'IDC-IDC_rider_lung_pet_ct', 'TCIA-rider-lung-pet-ct'}	{'IDC', 'TCIA'}	4
-Diagnostic Mammography	{'MG'}	{'ACRdart-EA1141Restricted', 'IDC-IDC_ea1141'}	{'ACRdart', 'IDC'}	4
-Upper-Abdomen +c	{'CT', nan}	{'IDC-IDC_ctpred_sunitinib_pannet', 'TCIA-ctpred-sunitinib-pannet'}	{'IDC', 'TCIA'}	4
-Diagnostic Mammography Combo	{'MR', 'MG'}	{'ACRdart-EA1141Restricted'}	{'ACRdart'}	4
-Vascular^02_PE (Adult)	{'CT', nan}	{'TCIA-tcga-lihc', 'TCIA-tcga-ov', 'IDC-IDC_tcga_lihc', 'IDC-IDC_tcga_ov'}	{'IDC', 'TCIA'}	4
-Digital Right Mammogram Diagnostic	{'MG', nan}	{'TCIA-breast-diagnosis', 'IDC-IDC_breast_diagnosis'}	{'IDC', 'TCIA'}	4
-Vascular^DISSECTION_CAP_CTA (Adult)	{'CT'}	{'MIDRC-Open-A1'}	{'MIDRC'}	4
-X-RAY CERVICAL SPINE MINIMUM 4 VIEWS	{'CR', 'DX'}	{'MIDRC-Open-A1'}	{'MIDRC'}	4
-US PELVIS W TRANSVAGINAL	{'US', nan}	{'IDC-IDC_cptac_ucec', 'TCIA-cptac-ucec'}	{'IDC', 'TCIA'}	4
-F/U	{'CT', nan}	{'TCIA-acrin-nsclc-fdg-pet', 'IDC-IDC_acrin_nsclc_fdg_pet'}	{'IDC', 'TCIA'}	4
-FDG 5 AFOV TORSO	{'CT', 'SEG', nan}	{'IDC-IDC_rider_lung_pet_ct', 'TCIA-rider-lung-pet-ct'}	{'IDC', 'TCIA'}	4
-H DIGITAL SCREEN/TOMO,CVIEW & CAD	{'MG'}	{'ACRdart-EA1141Restricted', 'IDC-IDC_ea1141'}	{'ACRdart', 'IDC'}	4
-H DIGITAL SCREEN TOMO CVIEW AND CAD	{'MG'}	{'ACRdart-EA1141Restricted', 'IDC-IDC_ea1141'}	{'ACRdart', 'IDC'}	4
-WB PET-CT	{'CT', 'SEG', nan}	{'TCIA-acrin-nsclc-fdg-pet', 'IDC-IDC_acrin_nsclc_fdg_pet'}	{'IDC', 'TCIA'}	4
-WB PET/CT W/ DELAYS	{'SEG', nan}	{'TCIA-acrin-nsclc-fdg-pet', 'IDC-IDC_acrin_nsclc_fdg_pet'}	{'IDC', 'TCIA'}	4
-WB emission scan 2i/8s	{'PT', nan}	{'TCIA-tcga-luad', 'IDC-IDC_tcga_luad'}	{'IDC', 'TCIA'}	4
-FL ESOPHAGRAM	{'RF'}	{'MIDRC-Open-R1'}	{'MIDRC'}	4
-USABDLCON/4228	{'US', nan}	{'TCIA-b-mode-and-ceus-liver', 'IDC-IDC_b_mode_and_ceus_liver'}	{'IDC', 'TCIA'}	4
-US Kidney	{'US', nan}	{'TCIA-cmb-crc', 'IDC-IDC_cmb_crc'}	{'IDC', 'TCIA'}	4
-Outside Read or Comparison PET	{'SEG', 'PT', nan}	{'TCIA-tcga-lusc', 'IDC-IDC_tcga_lusc'}	{'IDC', 'TCIA'}	4
-Trio RoutineHead	{'RTPLAN', nan}	{'TCIA-vestibular-schwannoma-seg', 'IDC-IDC_vestibular_schwannoma_seg'}	{'IDC', 'TCIA'}	4
-XR ABDOMEN 1 VW	{'DX'}	{'MIDRC-Open-R1'}	{'MIDRC'}	4
-CT_LSpine	{'CT', nan}	{'IDC-IDC_cmb_mel', 'IDC-IDC_cmb_mml', 'TCIA-cmb-mml', 'TCIA-cmb-mel'}	{'IDC', 'TCIA'}	4
-CT_LungBiopsy	{'CT', nan}	{'TCIA-cmb-crc', 'IDC-IDC_cmb_crc'}	{'IDC', 'TCIA'}	4
-CT_biopsybonemarrow	{'CT', nan}	{'IDC-IDC_cmb_mml', 'TCIA-cmb-mml'}	{'IDC', 'TCIA'}	4
-CT_biopsyliver	{'CT', nan}	{'IDC-IDC_cmb_mel', 'IDC-IDC_cmb_crc', 'TCIA-cmb-crc', 'TCIA-cmb-mel'}	{'IDC', 'TCIA'}	4
-Thyroid	{'US'}	{'ACRdart-ACRIN_6666'}	{'ACRdart'}	4
-TomoHD Unilateral Right	{'MG', nan}	{'TCIA-breast-cancer-screening-dbt', 'ACRdart-EA1141Restricted', 'IDC-IDC_breast_cancer_screening_dbt'}	{'IDC', 'TCIA', 'ACRdart'}	4
-Tomoscintigrafia PET t	{'SEG', 'PT', nan}	{'IDC-IDC_rider_lung_pet_ct', 'TCIA-rider-lung-pet-ct'}	{'IDC', 'TCIA'}	4
-Head^HEAD_Routine (Adult)	{'CT'}	{'MIDRC-Open-A1'}	{'MIDRC'}	4
-Head^CT_MAXILLOFACIAL_WITH (Adult)	{'CT'}	{'MIDRC-Open-A1'}	{'MIDRC'}	4
-Chest CT Routine	{'CT', nan}	{'IDC-IDC_stageii_colorectal_ct', 'TCIA-stageii-colorectal-ct'}	{'IDC', 'TCIA'}	4
-Chest Contrast	{'CT', nan}	{'TCIA-acrin-nsclc-fdg-pet', 'IDC-IDC_acrin_nsclc_fdg_pet'}	{'IDC', 'TCIA'}	4
-Chest PA+LAT	{'DX'}	{'MIDRC-Open-R1'}	{'MIDRC'}	4
-X-RAY SACRUM AND COCCYX MINIMUM 2 VIEWS	{'DX'}	{'MIDRC-Open-A1'}	{'MIDRC'}	4
-UNKNOWN	{'US'}	{'ACRdart-ACRIN_6666'}	{'ACRdart'}	4
-Chest With Contrast	{'CT', nan}	{'TCIA-acrin-nsclc-fdg-pet', 'IDC-IDC_acrin_nsclc_fdg_pet'}	{'IDC', 'TCIA'}	4
-Head^DE_CTA_NECK_Customized (Adult)	{'CT'}	{'MIDRC-Open-A1'}	{'MIDRC'}	4
-US Biopsy Liver	{'US', nan}	{'TCIA-cmb-lca', 'IDC-IDC_cmb_lca'}	{'IDC', 'TCIA'}	4
-MAMMO DIGITAL TOMOSYNTHESIS DIAGNOSTIC BILATERAL	{'MG'}	{'ACRdart-EA1141Restricted', 'IDC-IDC_ea1141'}	{'ACRdart', 'IDC'}	4
-XR RIGHT KNEE 3 VIEWS	{'CR', 'DX'}	{'MIDRC-Open-A1'}	{'MIDRC'}	4
-_t3of5MRI IAMS	{'MR', nan}	{'IDC-IDC_vestibular_schwannoma_mc_rc', 'TCIA-vestibular-schwannoma-mc-rc'}	{'IDC', 'TCIA'}	4
-CT THORAX WITH CONTRAS	{'RTSTRUCT', 'CT', nan}	{'TCIA-acrin-nsclc-fdg-pet', 'IDC-IDC_cptac_ucec', 'TCIA-cptac-ucec', 'IDC-IDC_acrin_nsclc_fdg_pet'}	{'IDC', 'TCIA'}	4
-SPINE PROTOCOLS^SMALL ANIMAL	{'MR', nan}	{'IDC-IDC_icdc_glioma', 'TCIA-icdc-glioma'}	{'IDC', 'TCIA'}	4
-SPINE^L-SPINE	{'MR'}	{'MIDRC-Open-A1'}	{'MIDRC'}	4
-SV	{'US'}	{'ACRdart-ACRIN_6666'}	{'ACRdart'}	4
-CT HEAD WWO CONTRAST	{'CT'}	{'MIDRC-Open-A1'}	{'MIDRC'}	4
-CT HEART FOR CONGENITAL HEART DISEASE	{'CT'}	{'MIDRC-Open-R1'}	{'MIDRC'}	4
-CT HI RES CHEST	{'CT', nan}	{'TCIA-tcga-lusc', 'IDC-IDC_tcga_lusc', 'TCIA-tcga-luad', 'IDC-IDC_tcga_luad'}	{'IDC', 'TCIA'}	4
-Scanner-Philips_Exp-100_Pitch-0.9_SlCol-16x0.75	{'CT', nan}	{'IDC-IDC_phantom_fda', 'TCIA-phantom-fda'}	{'IDC', 'TCIA'}	4
-Scanner-Philips_Exp-100_Pitch-0.9_SlCol-16x1.5	{'CT', nan}	{'IDC-IDC_phantom_fda', 'TCIA-phantom-fda'}	{'IDC', 'TCIA'}	4
-Scanner-Philips_Exp-100_Pitch-0.9_SlCol-16x1.5mm	{'CT', nan}	{'IDC-IDC_phantom_fda', 'TCIA-phantom-fda'}	{'IDC', 'TCIA'}	4
-Scanner-Philips_Exp-100_Pitch-1.2_SlCol-16x0.75	{'CT', nan}	{'IDC-IDC_phantom_fda', 'TCIA-phantom-fda'}	{'IDC', 'TCIA'}	4
-MR BREAST BI UE	{'MR', nan}	{'TCIA-breast-mri-nact-pilot', 'IDC-IDC_ispy1', 'IDC-IDC_breast_mri_nact_pilot'}	{'IDC', 'TCIA'}	4
-Scanner-Philips_Exp-100_Pitch-1.2_SlCol-16x1.5	{'CT', nan}	{'IDC-IDC_phantom_fda', 'TCIA-phantom-fda'}	{'IDC', 'TCIA'}	4
-Scanner-Philips_Exp-200_Pitch-0.9_SlCol-16x0.75	{'CT', nan}	{'IDC-IDC_phantom_fda', 'TCIA-phantom-fda'}	{'IDC', 'TCIA'}	4
-Scanner-Philips_Exp-200_Pitch-0.9_SlCol-16x1.5	{'CT', nan}	{'IDC-IDC_phantom_fda', 'TCIA-phantom-fda'}	{'IDC', 'TCIA'}	4
-Scanner-Philips_Exp-200_Pitch-0.9_SlCol-16x1.5mm	{'CT', nan}	{'IDC-IDC_phantom_fda', 'TCIA-phantom-fda'}	{'IDC', 'TCIA'}	4
-_t2of2  MRI IAMS	{'MR', nan}	{'IDC-IDC_vestibular_schwannoma_mc_rc', 'TCIA-vestibular-schwannoma-mc-rc'}	{'IDC', 'TCIA'}	4
-Scanner-Philips_Exp-200_Pitch-1.2_SlCol-16x0.75	{'CT', nan}	{'IDC-IDC_phantom_fda', 'TCIA-phantom-fda'}	{'IDC', 'TCIA'}	4
-_t2of2  External Images for PACS	{'MR', nan}	{'IDC-IDC_vestibular_schwannoma_mc_rc', 'TCIA-vestibular-schwannoma-mc-rc'}	{'IDC', 'TCIA'}	4
-CT LUNG BIOPSY	{'CT', nan}	{'TCIA-acrin-nsclc-fdg-pet', 'TCIA-tcga-luad', 'IDC-IDC_tcga_luad', 'IDC-IDC_acrin_nsclc_fdg_pet'}	{'IDC', 'TCIA'}	4
-SOFT TISSUE NECK	{'CR'}	{'MIDRC-Open-R1'}	{'MIDRC'}	4
-MR BREAST UNILATERAL W/WO CONT	{nan}	{'TCIA-tcga-brca'}	{'TCIA'}	4
-CT HEAD (BRAINLAB) WO CONTRAST PRE-OP	{'CT'}	{'MIDRC-Open-A1'}	{'MIDRC'}	4
-MR PELVIS W/WO CONTRAST	{'MR', nan}	{'IDC-IDC_tcga_kirp', 'IDC-IDC_tcga_blca', 'TCIA-tcga-kirp', 'TCIA-tcga-blca'}	{'IDC', 'TCIA'}	4
-_t3of5  External Images for PACS	{'MR', nan}	{'IDC-IDC_vestibular_schwannoma_mc_rc', 'TCIA-vestibular-schwannoma-mc-rc'}	{'IDC', 'TCIA'}	4
-Pelvic Cavity CT Routine	{'CT', nan}	{'IDC-IDC_stageii_colorectal_ct', 'TCIA-stageii-colorectal-ct'}	{'IDC', 'TCIA'}	4
-MR TOTAL SPINE WITH AND WITHOUT CONTRAST	{'MR'}	{'MIDRC-Open-R1'}	{'MIDRC'}	4
-Performed Desc	{'CR', 'DX'}	{'MIDRC-Open-A1', 'MIDRC-Open-R1'}	{'MIDRC'}	4
-CT Chest-w/Contrast	{'CT', nan}	{'TCIA-acrin-nsclc-fdg-pet', 'IDC-IDC_acrin_nsclc_fdg_pet'}	{'IDC', 'TCIA'}	4
-Port - CXR	{'DX'}	{'MIDRC-Open-R1'}	{'MIDRC'}	4
-_t3of3  MRI Stereo Gamma Knife	{'MR', nan}	{'IDC-IDC_vestibular_schwannoma_mc_rc', 'TCIA-vestibular-schwannoma-mc-rc'}	{'IDC', 'TCIA'}	4
-CT Chest/Abdomen	{'CT', nan}	{'TCIA-cmb-lca', 'IDC-IDC_cmb_lca'}	{'IDC', 'TCIA'}	4
-MR LT BREAST WO/W CONT 6667	{'MR', nan}	{'IDC-IDC_acrin_contralateral_breast_mr', 'TCIA-acrin-contralateral-breast-mr'}	{'IDC', 'TCIA'}	4
-SCREENING MAMMO/TOMO BIL W CAD	{'MG'}	{'ACRdart-EA1141Restricted', 'IDC-IDC_ea1141'}	{'ACRdart', 'IDC'}	4
-_t2of3External Images for PACS	{'MR', nan}	{'IDC-IDC_vestibular_schwannoma_mc_rc', 'TCIA-vestibular-schwannoma-mc-rc'}	{'IDC', 'TCIA'}	4
-MR LT BREAST WO/W CONT	{'MR', nan}	{'IDC-IDC_acrin_contralateral_breast_mr', 'TCIA-acrin-contralateral-breast-mr'}	{'IDC', 'TCIA'}	4
-RT BREAST BIOPSY	{'MR', nan}	{'IDC-IDC_acrin_contralateral_breast_mr', 'TCIA-acrin-contralateral-breast-mr'}	{'IDC', 'TCIA'}	4
-RT^RCCT_THORAX_8F (Adult)	{'RTSTRUCT', 'CT'}	{'IDC-IDC_lctsc'}	{'IDC'}	4
-MR DIAGNOSTIC BILAT BREAST WANDW/O CONTRAST	{'MR'}	{'ACRdart-EA1141Restricted', 'IDC-IDC_ea1141'}	{'ACRdart', 'IDC'}	4
-MR CHOLANGIOPANCREATOGRAPHY	{'MR'}	{'MIDRC-Open-R1'}	{'MIDRC'}	4
-CT GUIDED BIOPSY:  KIDNEY	{'CT', nan}	{'TCIA-cptac-ccrcc', 'IDC-IDC_cptac_ccrcc'}	{'IDC', 'TCIA'}	4
-RoutineImage Guidance	{'RTDOSE', 'RTSTRUCT', nan}	{'TCIA-vestibular-schwannoma-seg', 'IDC-IDC_vestibular_schwannoma_seg'}	{'IDC', 'TCIA'}	4
-CT LUNG BX	{'CT', nan}	{'TCIA-tcga-lusc', 'IDC-IDC_tcga_lusc', 'TCIA-tcga-luad', 'IDC-IDC_tcga_luad'}	{'IDC', 'TCIA'}	4
-Scanner-Philips_Exp-25_Pitch-0.9_SlCol-16x0.75	{'CT', nan}	{'IDC-IDC_phantom_fda', 'TCIA-phantom-fda'}	{'IDC', 'TCIA'}	4
-CT NECK SOFT TISSUE  W/ CONTR	{'CT', nan}	{'TCIA-tcga-lusc', 'IDC-IDC_tcga_lusc', 'TCIA-tcga-thca', 'IDC-IDC_tcga_thca'}	{'IDC', 'TCIA'}	4
-Thorax^13_0_Chest_Biphase_Liver (Adult)	{'SEG', nan}	{'TCIA-tcga-lihc', 'IDC-IDC_tcga_lihc'}	{'IDC', 'TCIA'}	4
-CT THORAX  WITH AND WI	{'CT', nan}	{'IDC-IDC_tcga_ov', 'TCIA-tcga-ov', 'TCIA-tcga-lusc', 'IDC-IDC_tcga_lusc'}	{'IDC', 'TCIA'}	4
-MC prostaat kliniek stadiering_mc MCPROSKL45	{'MR', nan}	{'IDC-IDC_prostate_3t', 'TCIA-prostate-3t'}	{'IDC', 'TCIA'}	4
-_t11of11_MRI IAMS WITH CONTRAST	{'MR', nan}	{'IDC-IDC_vestibular_schwannoma_mc_rc', 'TCIA-vestibular-schwannoma-mc-rc'}	{'IDC', 'TCIA'}	4
-Thorax^09_0_Chest_PE_Study (Adult)	{'CT', nan}	{'TCIA-tcga-kirc', 'IDC-IDC_tcga_kirc', 'TCIA-tcga-ucec', 'IDC-IDC_tcga_ucec'}	{'IDC', 'TCIA'}	4
-_t11of11_MRI IAMS	{'MR', nan}	{'IDC-IDC_vestibular_schwannoma_mc_rc', 'TCIA-vestibular-schwannoma-mc-rc'}	{'IDC', 'TCIA'}	4
-Thorax^1 Chest Routine	{'CT', nan}	{'TCIA-acrin-nsclc-fdg-pet', 'IDC-IDC_acrin_nsclc_fdg_pet'}	{'IDC', 'TCIA'}	4
-XR_biopsybonemarrow	{'XA', nan}	{'IDC-IDC_cmb_mml', 'TCIA-cmb-aml', 'TCIA-cmb-mml', 'IDC-IDC_cmb_aml'}	{'IDC', 'TCIA'}	4
-CT THORAX W CONT	{'CT', 'SEG', nan}	{'TCIA-tcga-lusc', 'IDC-IDC_tcga_lusc', 'TCIA-tcga-luad', 'IDC-IDC_tcga_luad'}	{'IDC', 'TCIA'}	4
-XR WRIST LEFT (ROUTINE: AP,LAT,OBL)	{'CR', 'DX'}	{'MIDRC-Open-A1'}	{'MIDRC'}	4
-CT STONE STUDY(Adult)	{'CT'}	{'MIDRC-Open-A1'}	{'MIDRC'}	4
-MAMMOGRAM/ULTRASOUND	{'US'}	{'ACRdart-ACRIN_6666'}	{'ACRdart'}	4
-CT THORAX W IV CONTRAS	{'SEG', nan}	{'TCIA-lidc-idri', 'IDC-IDC_lidc_idri'}	{'IDC', 'TCIA'}	4
-MAMMOGRAM SCREENING BILATERAL W/TOMO	{'MG'}	{'IDC-IDC_ea1141'}	{'IDC'}	4
-Thorax^CAP_WITHOUT_Customized (Adult)	{'CT'}	{'MIDRC-Open-A1'}	{'MIDRC'}	4
-Thorax^CHEST_ABD_PEL (Adult)	{'CT', nan}	{'IDC-IDC_cptac_ucec', 'TCIA-cptac-ucec'}	{'IDC', 'TCIA'}	4
-XR RIGHT WRIST 1-2 VIEWS	{'CR', 'DX'}	{'MIDRC-Open-A1'}	{'MIDRC'}	4
-XR RIGHT TIBIA FIBULA 2 VIEWS	{'CR', 'DX'}	{'MIDRC-Open-A1'}	{'MIDRC'}	4
-MAMMO TOMO SCREEENING BILATERAL	{'MG'}	{'ACRdart-EA1141Restricted', 'IDC-IDC_ea1141'}	{'ACRdart', 'IDC'}	4
-_t1of1  MRI IAMS	{'MR', nan}	{'IDC-IDC_vestibular_schwannoma_mc_rc', 'TCIA-vestibular-schwannoma-mc-rc'}	{'IDC', 'TCIA'}	4
-_t1of11  External Images for PACS	{'MR', nan}	{'IDC-IDC_vestibular_schwannoma_mc_rc', 'TCIA-vestibular-schwannoma-mc-rc'}	{'IDC', 'TCIA'}	4
-Scanner-Philips_Exp-25_Pitch-0.9_SlCol-16x1.5	{'CT', nan}	{'IDC-IDC_phantom_fda', 'TCIA-phantom-fda'}	{'IDC', 'TCIA'}	4
-_t1of5  External Images for PACS	{'MR', nan}	{'IDC-IDC_vestibular_schwannoma_mc_rc', 'TCIA-vestibular-schwannoma-mc-rc'}	{'IDC', 'TCIA'}	4
-Scanner-Philips_Exp-25_Pitch-0.9_SlCol-16x1.5mm	{'CT', nan}	{'IDC-IDC_phantom_fda', 'TCIA-phantom-fda'}	{'IDC', 'TCIA'}	4
-_t1of8  External Images for PACS	{'MR', nan}	{'IDC-IDC_vestibular_schwannoma_mc_rc', 'TCIA-vestibular-schwannoma-mc-rc'}	{'IDC', 'TCIA'}	4
-MR ABDOMEN/PELVIS WITH AND WITHOUT CONTRAST	{'MR'}	{'MIDRC-Open-R1'}	{'MIDRC'}	4
-MR ABDOMEN WITHOUT CONTRAST	{'MR', nan}	{'TCIA-cptac-ccrcc', 'IDC-IDC_cptac_ccrcc', 'MIDRC-Open-R1'}	{'IDC', 'TCIA', 'MIDRC'}	4
-CT OUTSIDE IMAGING, REFERENCE ONLY	{'CT', nan}	{'TCIA-cptac-lscc', 'IDC-IDC_cptac_lscc'}	{'IDC', 'TCIA'}	4
-CT Outside CD Import	{'SEG', nan}	{'IDC-IDC_qin_lung_ct', 'TCIA-qin-lung-ct'}	{'IDC', 'TCIA'}	4
-Scanner-Philips_Exp-25_Pitch-1.2_SlCol-16x1.5mm	{'CT', nan}	{'IDC-IDC_phantom_fda', 'TCIA-phantom-fda'}	{'IDC', 'TCIA'}	4
-CT P CHEST WO	{'CT'}	{'MIDRC-Open-A1', 'MIDRC-Open-R1'}	{'MIDRC'}	4
-MR 6667 BREAST WO/W CONT	{'MR', nan}	{'IDC-IDC_acrin_contralateral_breast_mr', 'TCIA-acrin-contralateral-breast-mr'}	{'IDC', 'TCIA'}	4
-TRIPLE RO	{'CT', nan}	{'IDC-IDC_rider_lung_pet_ct', 'TCIA-rider-lung-pet-ct'}	{'IDC', 'TCIA'}	4
-CT PELVIS W/ CONTRAST, CT ABDOMEN W/WO CONTRAST	{'CT', 'SEG', nan}	{'IDC-IDC_tcga_kirp', 'TCIA-tcga-kirp'}	{'IDC', 'TCIA'}	4
-TAP W/C	{'SEG', nan}	{'IDC-IDC_hcc_tace_seg', 'TCIA-hcc-tace-seg'}	{'IDC', 'TCIA'}	4
-TK JAMY BRZUSZNE	{'RTSTRUCT', nan}	{'TCIA-cptac-pda', 'TCIA-cptac-ccrcc', 'IDC-IDC_cptac_ccrcc', 'IDC-IDC_cptac_pda'}	{'IDC', 'TCIA'}	4
-_t1of4  External Images for PACS	{'MR', nan}	{'IDC-IDC_vestibular_schwannoma_mc_rc', 'TCIA-vestibular-schwannoma-mc-rc'}	{'IDC', 'TCIA'}	4
-TK jamy brzusznej	{'RTSTRUCT', nan}	{'TCIA-cptac-pda', 'IDC-IDC_cptac_pda'}	{'IDC', 'TCIA'}	4
-_t1of3_MRI External Films	{'MR', nan}	{'IDC-IDC_vestibular_schwannoma_mc_rc', 'TCIA-vestibular-schwannoma-mc-rc'}	{'IDC', 'TCIA'}	4
-CT Pelvis w/ Contrast	{'CT', nan}	{'IDC-IDC_tcga_blca', 'TCIA-tcga-blca'}	{'IDC', 'TCIA'}	4
-TOMOGRAFIA KLATKI PIER	{'CT', nan}	{'TCIA-cptac-lscc', 'IDC-IDC_cptac_lscc'}	{'IDC', 'TCIA'}	4
-Scanner-Philips_Exp-200_Pitch-1.2_SlCol-16x1.5	{'CT', nan}	{'IDC-IDC_phantom_fda', 'TCIA-phantom-fda'}	{'IDC', 'TCIA'}	4
-#NAME?	{'MR'}	{'ACRdart-EA1141Restricted'}	{'ACRdart'}	4
-CT ABDOMEN/PELVIS WITHOUT CONTRAST (S)	{'CT'}	{'MIDRC-Open-R1'}	{'MIDRC'}	4
-CT ANGIO KIDNEY WITH CH/PEL	{'CT', 'SEG', nan}	{'TCIA-tcga-kirc', 'IDC-IDC_tcga_kirc'}	{'IDC', 'TCIA'}	4
-CAP W	{'SEG', nan}	{'IDC-IDC_anti_pd_1_lung', 'TCIA-anti-pd-1_lung'}	{'IDC', 'TCIA'}	4
-CT Abd and Pelvis with cont	{'CT', nan}	{'TCIA-tcga-lusc', 'IDC-IDC_tcga_lusc', 'TCIA-tcga-ucec', 'IDC-IDC_tcga_ucec'}	{'IDC', 'TCIA'}	4
-A-P	{'CT', nan}	{'TCIA-tcga-kirc', 'TCIA-tcga-ov', 'IDC-IDC_tcga_kirc', 'IDC-IDC_tcga_ov'}	{'IDC', 'TCIA'}	4
-CAP IP	{'CT'}	{'MIDRC-Open-R1'}	{'MIDRC'}	4
-A/P	{'CT', nan}	{'TCIA-tcga-kirc', 'IDC-IDC_tcga_kirc'}	{'IDC', 'TCIA'}	4
-A/P LIVER	{'SEG', nan}	{'IDC-IDC_hcc_tace_seg', 'TCIA-hcc-tace-seg'}	{'IDC', 'TCIA'}	4
-CT C/A/P LIVER PROT	{'SEG', nan}	{'IDC-IDC_hcc_tace_seg', 'TCIA-hcc-tace-seg'}	{'IDC', 'TCIA'}	4
-ABD (ADRENAL SURG )	{'CT', 'SEG', nan}	{'TCIA-adrenal-acc-ki67-seg', 'IDC-IDC_adrenal_acc_ki67_seg'}	{'IDC', 'TCIA'}	4
-CT C/A/P W/O WITH	{'SEG', nan}	{'TCIA-tcga-kirc', 'IDC-IDC_tcga_kirc'}	{'IDC', 'TCIA'}	4
-Breast^Bilateral Tumor	{'MR', nan}	{'IDC-IDC_tcga_brca', 'TCIA-tcga-brca'}	{'IDC', 'TCIA'}	4
-CT ABDOMEN & PELVIS ENHANCED-BODY	{'CT', nan}	{'TCIA-tcga-lihc', 'IDC-IDC_tcga_lihc'}	{'IDC', 'TCIA'}	4
-ABD (ADRENAL)	{'CT', 'SEG', nan}	{'TCIA-adrenal-acc-ki67-seg', 'IDC-IDC_adrenal_acc_ki67_seg'}	{'IDC', 'TCIA'}	4
-ABD CT W&W/OC	{'CT', nan}	{'TCIA-tcga-kirc', 'IDC-IDC_tcga_kirc'}	{'IDC', 'TCIA'}	4
-Breast-Left	{'MR', 'SEG'}	{'IDC-IDC_ispy1'}	{'IDC'}	4
-Biopsy_Liver	{'CT', nan}	{'TCIA-cmb-crc', 'IDC-IDC_cmb_crc'}	{'IDC', 'TCIA'}	4
-CT ABDOMEN +/- AUGMENT=AB	{'RTSTRUCT', nan}	{'TCIA-cptac-pda', 'IDC-IDC_cptac_pda'}	{'IDC', 'TCIA'}	4
-BRZUCH	{'RTSTRUCT', nan}	{'IDC-IDC_cptac_ucec', 'TCIA-cptac-pda', 'IDC-IDC_cptac_pda', 'TCIA-cptac-ucec'}	{'IDC', 'TCIA'}	4
-ABD/PELVIS WITH	{'CT', nan}	{'TCIA-tcga-kirc', 'TCIA-tcga-ov', 'IDC-IDC_tcga_kirc', 'IDC-IDC_tcga_ov'}	{'IDC', 'TCIA'}	4
-CT ABDOMEN AND PELVIS WITH AND WITHOUT CONTRAST	{'RTSTRUCT', 'CT', nan}	{'IDC-IDC_cptac_ucec', 'IDC-IDC_cptac_sar', 'TCIA-cptac-sar', 'TCIA-cptac-ucec'}	{'IDC', 'TCIA'}	4
-BREAST^RESEARCH STUDY	{'MR'}	{'ACRdart-EA1141Restricted'}	{'ACRdart'}	4
-CT CAP LIVER PROTO	{'SEG', nan}	{'IDC-IDC_hcc_tace_seg', 'TCIA-hcc-tace-seg'}	{'IDC', 'TCIA'}	4
-CT ABDOMEN PELVIS WITH	{'RTSTRUCT', 'CT', nan}	{'IDC-IDC_cptac_ucec', 'TCIA-cptac-ccrcc', 'IDC-IDC_cptac_ccrcc', 'TCIA-cptac-ucec'}	{'IDC', 'TCIA'}	4
-CT CAP ROUTINE	{'CT', 'SEG', nan}	{'IDC-IDC_hcc_tace_seg', 'TCIA-hcc-tace-seg', 'TCIA-tcga-ucec', 'IDC-IDC_tcga_ucec'}	{'IDC', 'TCIA'}	4
-BREAST RIGHT	{'MR', nan}	{'IDC-IDC_acrin_contralateral_breast_mr', 'TCIA-acrin-contralateral-breast-mr'}	{'IDC', 'TCIA'}	4
-CT ABDOMEN PELVIS WWO CONTRAST	{'CT'}	{'MIDRC-Open-A1'}	{'MIDRC'}	4
-ABDOMEN W/WO	{'CT', nan}	{'TCIA-tcga-kirc', 'TCIA-tcga-ov', 'IDC-IDC_tcga_kirc', 'IDC-IDC_tcga_ov'}	{'IDC', 'TCIA'}	4
-BREAST (L)	{'MR', nan}	{'IDC-IDC_acrin_contralateral_breast_mr', 'TCIA-acrin-contralateral-breast-mr'}	{'IDC', 'TCIA'}	4
-ACRIN 6667	{'MR', nan}	{'IDC-IDC_acrin_contralateral_breast_mr', 'TCIA-acrin-contralateral-breast-mr'}	{'IDC', 'TCIA'}	4
-BR-BreastBwc MR	{'MR', nan}	{'IDC-IDC_acrin_contralateral_breast_mr', 'TCIA-acrin-contralateral-breast-mr'}	{'IDC', 'TCIA'}	4
-CAP W CONTRAST	{'SEG', nan}	{'IDC-IDC_anti_pd_1_lung', 'TCIA-anti-pd-1_lung'}	{'IDC', 'TCIA'}	4
-CAP(ADRENAL)	{'CT', nan}	{'TCIA-adrenal-acc-ki67-seg', 'IDC-IDC_adrenal_acc_ki67_seg'}	{'IDC', 'TCIA'}	4
-CAP/LIVER W.WO	{'CT', nan}	{'IDC-IDC_hcc_tace_seg', 'TCIA-hcc-tace-seg'}	{'IDC', 'TCIA'}	4
-CT BIOPSY	{'CT', nan}	{'TCIA-acrin-nsclc-fdg-pet', 'IDC-IDC_acrin_nsclc_fdg_pet'}	{'IDC', 'TCIA'}	4
-CT Abdomen and Pelvis W/ Contrast	{'CT'}	{'MIDRC-Open-A1_PETAL_BLUECORAL'}	{'MIDRC'}	4
-CONTRA BREAST LEFT	{'MR', nan}	{'IDC-IDC_acrin_contralateral_breast_mr', 'TCIA-acrin-contralateral-breast-mr'}	{'IDC', 'TCIA'}	4
-CHEST/ABDOMEN/PELVIS CT	{'CT', nan}	{'TCIA-acrin-nsclc-fdg-pet', 'IDC-IDC_acrin_nsclc_fdg_pet'}	{'IDC', 'TCIA'}	4
-CONTRABREAST  LEFT	{'MR', nan}	{'IDC-IDC_acrin_contralateral_breast_mr', 'TCIA-acrin-contralateral-breast-mr'}	{'IDC', 'TCIA'}	4
-CONTRABREAST LEFT	{'MR', nan}	{'IDC-IDC_acrin_contralateral_breast_mr', 'TCIA-acrin-contralateral-breast-mr'}	{'IDC', 'TCIA'}	4
-CHEST+C	{'CT', 'SEG', nan}	{'IDC-IDC_lung_pet_ct_dx', 'TCIA-lung-pet-ct-dx'}	{'IDC', 'TCIA'}	4
-CHEST WO OP	{'CT'}	{'MIDRC-Open-R1'}	{'MIDRC'}	4
-CHEST WO - nodule or mass with ion(Adult)	{'CT'}	{'MIDRC-Open-A1'}	{'MIDRC'}	4
-CT Abdomen, Pelvis, w/contrast	{'SEG', nan}	{'TCIA-tcga-lihc', 'IDC-IDC_tcga_lihc'}	{'IDC', 'TCIA'}	4
-CHEST W/WO CONTRAST (CT)-CS	{'CT'}	{'MIDRC-Open-A1'}	{'MIDRC'}	4
-5AFOV LUNGS	{'PT', nan}	{'IDC-IDC_rider_lung_pet_ct', 'TCIA-rider-lung-pet-ct'}	{'IDC', 'TCIA'}	4
-CT A/P	{'CT', 'SEG', nan}	{'IDC-IDC_hcc_tace_seg', 'TCIA-tcga-ov', 'TCIA-hcc-tace-seg', 'IDC-IDC_tcga_ov'}	{'IDC', 'TCIA'}	4
-6667 CONTRA LATERAL	{'MR', nan}	{'IDC-IDC_acrin_contralateral_breast_mr', 'TCIA-acrin-contralateral-breast-mr'}	{'IDC', 'TCIA'}	4
-6667 CONTRA-LATERAL	{'MR', nan}	{'IDC-IDC_acrin_contralateral_breast_mr', 'TCIA-acrin-contralateral-breast-mr'}	{'IDC', 'TCIA'}	4
-CT Biopsy Retroperitoneal	{'CT', nan}	{'TCIA-cmb-lca', 'TCIA-cmb-crc', 'IDC-IDC_cmb_lca', 'IDC-IDC_cmb_crc'}	{'IDC', 'TCIA'}	4
-CT BIOPSY LUNG OR MEDI	{'CT', nan}	{'TCIA-tcga-lusc', 'IDC-IDC_tcga_lusc', 'TCIA-tcga-luad', 'IDC-IDC_tcga_luad'}	{'IDC', 'TCIA'}	4
-6667CONTRALAT. BREAST	{'MR', nan}	{'IDC-IDC_acrin_contralateral_breast_mr', 'TCIA-acrin-contralateral-breast-mr'}	{'IDC', 'TCIA'}	4
-CT A/P LIVER PROT	{'SEG', nan}	{'IDC-IDC_hcc_tace_seg', 'TCIA-hcc-tace-seg'}	{'IDC', 'TCIA'}	4
-CT ABD & PELVIS W/ + W/O CONTRAST	{'CT', nan}	{'IDC-IDC_tcga_blca', 'TCIA-tcga-blca'}	{'IDC', 'TCIA'}	4
-CHEST 1 VIEW PA/AP	{'CR'}	{'MIDRC-Open-A1_PETAL_BLUECORAL'}	{'MIDRC'}	4
-CHEST (THORAX) WITHOUT	{'CT', nan}	{'TCIA-acrin-nsclc-fdg-pet', 'IDC-IDC_acrin_nsclc_fdg_pet'}	{'IDC', 'TCIA'}	4
-CT ABD PELVIS W/ CONTRAST, CT ABD PELVIS W/O CONTRAST	{'CT', nan}	{'TCIA-tcga-coad', 'IDC-IDC_tcga_coad'}	{'IDC', 'TCIA'}	4
-CT BRAIN W+WO CNTRST	{'CT', nan}	{'TCIA-acrin-nsclc-fdg-pet', 'IDC-IDC_acrin_nsclc_fdg_pet'}	{'IDC', 'TCIA'}	4
-CH	{'CT', 'SEG', nan}	{'IDC-IDC_lung_pet_ct_dx', 'TCIA-lung-pet-ct-dx'}	{'IDC', 'TCIA'}	4
-CBCC	{'CT', nan}	{'TCIA-acrin-nsclc-fdg-pet', 'IDC-IDC_acrin_nsclc_fdg_pet'}	{'IDC', 'TCIA'}	4
-CARDIAG GATING	{'CT', nan}	{'IDC-IDC_rider_lung_pet_ct', 'TCIA-rider-lung-pet-ct'}	{'IDC', 'TCIA'}	4
-CT ABD&PELVIS W/O C COLON TECHNIQUE	{'CT', nan}	{'TCIA-ct-colonography', 'IDC-IDC_ct_colonography'}	{'IDC', 'TCIA'}	4
-CT Biopsy Lung	{'CT', nan}	{'IDC-IDC_cmb_mml', 'TCIA-cmb-crc', 'TCIA-cmb-mml', 'IDC-IDC_cmb_crc'}	{'IDC', 'TCIA'}	4
-ACRIN 6667-RESEARCH	{'MR', nan}	{'IDC-IDC_acrin_contralateral_breast_mr', 'TCIA-acrin-contralateral-breast-mr'}	{'IDC', 'TCIA'}	4
-CT ABDOMEN PELVIS ENHANCED	{'CT', nan}	{'TCIA-tcga-ucec', 'IDC-IDC_tcga_ucec'}	{'IDC', 'TCIA'}	4
-COLOGRAPHY SCREENING	{'CT', nan}	{'TCIA-ct-colonography', 'IDC-IDC_ct_colonography'}	{'IDC', 'TCIA'}	4
-Abdomen^02_CAP_ONERUN (Adult)	{'CT', nan}	{'TCIA-tcga-ov', 'TCIA-acrin-nsclc-fdg-pet', 'IDC-IDC_acrin_nsclc_fdg_pet', 'IDC-IDC_tcga_ov'}	{'IDC', 'TCIA'}	4
-Abdomen^01ACRIN_Colonography _Prone	{'CT', nan}	{'TCIA-ct-colonography', 'IDC-IDC_ct_colonography'}	{'IDC', 'TCIA'}	4
-CT CARD W/CON PULMNARY VEIN	{'CT'}	{'MIDRC-Open-A1'}	{'MIDRC'}	4
-Abdomen^01APRoutine (Adult)	{'CT', nan}	{'TCIA-tcga-ov', 'IDC-IDC_tcga_ov'}	{'IDC', 'TCIA'}	4
-CT ABDOMEN/PELVIS  (RENAL COLIC)	{'CT', nan}	{'TCIA-tcga-kirc', 'IDC-IDC_tcga_kirc'}	{'IDC', 'TCIA'}	4
-CT ABDOMEN WITHOUT CONTRAST	{'CT'}	{'MIDRC-Open-R1'}	{'MIDRC'}	4
-B MRI-RT THIGH	{'RTSTRUCT', 'MR', nan}	{'IDC-IDC_soft_tissue_sarcoma', 'TCIA-soft-tissue-sarcoma'}	{'IDC', 'TCIA'}	4
-Abdomen^02 Chest-Abd-Pelvis 2	{'CT', nan}	{'TCIA-acrin-nsclc-fdg-pet', 'IDC-IDC_acrin_nsclc_fdg_pet'}	{'IDC', 'TCIA'}	4
-CT CH/ABD/PEL(LIVER)	{'SEG', nan}	{'IDC-IDC_hcc_tace_seg', 'TCIA-hcc-tace-seg'}	{'IDC', 'TCIA'}	4
-CT CH/ABD/PEL (LIVER)	{'CT', 'SEG', nan}	{'IDC-IDC_hcc_tace_seg', 'TCIA-hcc-tace-seg'}	{'IDC', 'TCIA'}	4
-CT ABDOMEN wo	{'CT', nan}	{'IDC-IDC_tcga_ov', 'TCIA-tcga-ov', 'TCIA-tcga-ucec', 'IDC-IDC_tcga_ucec'}	{'IDC', 'TCIA'}	4
-Abdomen^1_ABD-PELV	{'CT', nan}	{'TCIA-tcga-ucec', 'IDC-IDC_tcga_ucec'}	{'IDC', 'TCIA'}	4
-Abdomen^1CAP_WO_WC (Adult)	{'CT', nan}	{'TCIA-acrin-nsclc-fdg-pet', 'IDC-IDC_acrin_nsclc_fdg_pet'}	{'IDC', 'TCIA'}	4
-Abdomen^01 ABD-PEL	{'CT', nan}	{'TCIA-tcga-ov', 'IDC-IDC_tcga_ov'}	{'IDC', 'TCIA'}	4
-Abdomen^02_Chest_Abd (Adult)	{'CT', nan}	{'TCIA-tcga-lusc', 'IDC-IDC_tcga_lusc', 'TCIA-acrin-nsclc-fdg-pet', 'IDC-IDC_acrin_nsclc_fdg_pet'}	{'IDC', 'TCIA'}	4
-B LT THIGH	{'RTSTRUCT', nan}	{'IDC-IDC_soft_tissue_sarcoma', 'TCIA-soft-tissue-sarcoma'}	{'IDC', 'TCIA'}	4
-Abdomen^04_CA (Adult)	{'CT', nan}	{'TCIA-acrin-nsclc-fdg-pet', 'IDC-IDC_acrin_nsclc_fdg_pet'}	{'IDC', 'TCIA'}	4
-Abdomen^05_CAP (Adult)	{'CT', nan}	{'TCIA-tcga-prad', 'IDC-IDC_tcga_prad', 'TCIA-tcga-ov', 'IDC-IDC_tcga_ov'}	{'IDC', 'TCIA'}	4
-Abdomen^07_2_ACRIN COLONOGRAPHY (Adult)	{'CT', nan}	{'TCIA-ct-colonography', 'IDC-IDC_ct_colonography'}	{'IDC', 'TCIA'}	4
-CT CH/AB/PEL	{'CT', 'SEG', nan}	{'TCIA-tcga-kirc', 'IDC-IDC_pseudo_phi_dicom_data', 'IDC-IDC_tcga_kirc', 'TCIA-pseudo-phi-dicom-data'}	{'IDC', 'TCIA'}	4
-CT CH/AB/PEL W/O CONTRAST	{'CT', nan}	{'TCIA-tcga-kirc', 'IDC-IDC_tcga_kirc'}	{'IDC', 'TCIA'}	4
-Abdomen^urogram_STONE_gr (Adult)	{'CT'}	{'MIDRC-Open-A1'}	{'MIDRC'}	4
-Abdomen^12_9_Liver_HCC_Hepatoma_Triphase (Adult)	{'SEG', nan}	{'TCIA-tcga-lihc', 'IDC-IDC_tcga_lihc'}	{'IDC', 'TCIA'}	4
-CT CH/AB/PELVIS	{'CT', 'SEG', nan}	{'TCIA-lidc-idri', 'IDC-IDC_lidc_idri'}	{'IDC', 'TCIA'}	4
-Abdomen^UROGRAM_2 (Adult)	{'RTSTRUCT', 'CT', nan}	{'IDC-IDC_tcga_blca', 'TCIA-cptac-ccrcc', 'IDC-IDC_cptac_ccrcc', 'TCIA-tcga-blca'}	{'IDC', 'TCIA'}	4
-Abdomen^1_CA	{'CT', nan}	{'TCIA-acrin-nsclc-fdg-pet', 'IDC-IDC_acrin_nsclc_fdg_pet'}	{'IDC', 'TCIA'}	4
-CT ABDOMEN WITHOUT CON	{'CT', nan}	{'TCIA-tcga-kirc', 'IDC-IDC_tcga_kirc'}	{'IDC', 'TCIA'}	4
-CT CAP W/WO	{'CT', 'SEG', nan}	{'IDC-IDC_hcc_tace_seg', 'IDC-IDC_tcga_blca', 'TCIA-hcc-tace-seg', 'TCIA-tcga-blca'}	{'IDC', 'TCIA'}	4
-Abdomen^2 BIPHASE LIVER_PANC	{'SEG', nan}	{'TCIA-tcga-lihc', 'IDC-IDC_tcga_lihc'}	{'IDC', 'TCIA'}	4
-CT ABDOMEN W/WO CONTRA	{'CT', nan}	{'TCIA-tcga-kirc', 'IDC-IDC_tcga_kirc'}	{'IDC', 'TCIA'}	4
-3607 MR BREAST WO/W CONT	{'MR', 'SEG'}	{'IDC-IDC_ispy1'}	{'IDC'}	4
-/PRO/BD   Pelvis w&w/oCon	{'SEG', nan}	{'IDC-IDC_qin_prostate_repeatability', 'TCIA-qin-prostate-repeatability'}	{'IDC', 'TCIA'}	4
-*MRI - PELVIS	{'MR', nan}	{'TCIA-tcga-kirc', 'IDC-IDC_tcga_kirc', 'TCIA-tcga-ucec', 'IDC-IDC_tcga_ucec'}	{'IDC', 'TCIA'}	4
-CT ABDOMEN/PELVIS W AND W/O IV CONTRAST	{'RTSTRUCT', nan}	{'TCIA-cptac-ccrcc', 'IDC-IDC_cptac_ccrcc'}	{'IDC', 'TCIA'}	4
-ACRIN6667/CONTRALAT BR	{'MR', nan}	{'IDC-IDC_acrin_contralateral_breast_mr', 'TCIA-acrin-contralateral-breast-mr'}	{'IDC', 'TCIA'}	4
-ACRIN 6701 MRT Prostata Follow UP	{'PR', 'MR'}	{'ACRdart-ACRIN_6701'}	{'ACRdart'}	4
-ANKLE LEFT MIN 3 VIEWS	{'CR', 'DX'}	{'MIDRC-Open-R1'}	{'MIDRC'}	4
-CT ABD AND PELVIS WWO IV CONT	{'CT', nan}	{'MIDRC-TCIA-COVID-19-NY-SBU', 'IDC-IDC_covid_19_ny_sbu', 'TCIA-covid-19-ny-sbu'}	{'IDC', 'TCIA', 'MIDRC'}	3
-CT HEAD (BRAINLAB) W CONTRAST PRE-OP	{'CT'}	{'MIDRC-Open-A1'}	{'MIDRC'}	3
-DUAL ABDOMEN(Adult)	{'CT'}	{'MIDRC-Open-A1'}	{'MIDRC'}	3
-DX	{'DX'}	{'MIDRC-Open-A1_PETAL_BLUECORAL'}	{'MIDRC'}	3
-XR PELVIS 1-2 VIEWS	{'CR', 'DX'}	{'MIDRC-Open-A1', 'MIDRC-Open-A1_PETAL_REDCORAL'}	{'MIDRC'}	3
-Cardiac^TAVR_BOLUSTRACKAdult (Adult)	{'CT'}	{'MIDRC-Open-A1'}	{'MIDRC'}	3
-XR SCOLIOSIS STUDY 2 OR 3 VIEWS	{'DX'}	{'MIDRC-Open-R1'}	{'MIDRC'}	3
-Thorax^LARGE_CHEST_WITHOUT_IV_CONTRAST (Adult)	{nan}	{'TCIA-varepop-apollo'}	{'TCIA'}	3
-CR XR PORTABLE FEEDING TUBE X-RAY	{'CR'}	{'MIDRC-Open-A1_PETAL_REDCORAL'}	{'MIDRC'}	3
-CTA Chest W Embolus	{'CT'}	{'MIDRC-Open-A1_PETAL_BLUECORAL', 'MIDRC-Open-A1_PETAL_REDCORAL'}	{'MIDRC'}	3
-XR SPINE CERVICAL (AP + LAT)	{'CR', 'DX'}	{'MIDRC-Open-A1'}	{'MIDRC'}	3
-CT FACE/SINUSES (BRAINLAB) WO CONTRAST	{'CT'}	{'MIDRC-Open-A1'}	{'MIDRC'}	3
-CTA CHEST(Adult)	{'CT'}	{'MIDRC-Open-A1'}	{'MIDRC'}	3
-Thorax^LOW_DOSE_CHEST_OVER_30_BMI (Adult)	{'CT'}	{'MIDRC-Open-A1'}	{'MIDRC'}	3
-XR RIBS LEFT - 2 VIEWS	{'CR'}	{'MIDRC-Open-A1'}	{'MIDRC'}	3
-CT ABD AND PELVIS WO IV CONTRAST	{'CT', nan}	{'MIDRC-TCIA-COVID-19-NY-SBU', 'IDC-IDC_covid_19_ny_sbu', 'TCIA-covid-19-ny-sbu'}	{'IDC', 'TCIA', 'MIDRC'}	3
-XR RIGHT HIP 2+ VIEWS ORTHOPEDICS PRE OPERATIVE	{'CR', 'DX'}	{'MIDRC-Open-A1'}	{'MIDRC'}	3
-Cardiac^DANIELS_ROUTINE (Adult)	{'CT'}	{'MIDRC-Open-A1'}	{'MIDRC'}	3
-Cardiac^COR_HR_LESS_THAN_65 (Adult)	{'CT'}	{'MIDRC-Open-A1'}	{'MIDRC'}	3
-Thorax^CTA_CHEST_Adult_Customized (Adult)	{'CT'}	{'MIDRC-Open-A1'}	{'MIDRC'}	3
-XR LUMBAR SPINE 4+ VIEWS	{'DX'}	{'MIDRC-Open-A1'}	{'MIDRC'}	3
-DCUABDNGPL	{'DX'}	{'MIDRC-Open-A1_PETAL_BLUECORAL'}	{'MIDRC'}	3
-CT HEART WITH CONTRAST	{'CT'}	{'MIDRC-Open-R1'}	{'MIDRC'}	3
-XR RIGHT HUMERUS	{'CR', 'DX'}	{'MIDRC-Open-A1'}	{'MIDRC'}	3
-Chest Post Line/Tube/ETT Init	{'CR'}	{'MIDRC-Open-A1_PETAL_BLUECORAL'}	{'MIDRC'}	3
-Cardiac^COR_HR_65to75 (Adult)	{'CT'}	{'MIDRC-Open-A1'}	{'MIDRC'}	3
-Cardiac^CORONARY_PROSPECTIVE_MORE_PAD (Adult)	{'CT'}	{'MIDRC-Open-A1'}	{'MIDRC'}	3
-DE ABDOMEN PELVIS(Adult)	{'CT'}	{'MIDRC-Open-A1'}	{'MIDRC'}	3
-CT HEAD (PERFUSION ONLY)	{'CT'}	{'MIDRC-Open-A1'}	{'MIDRC'}	3
-DG CHEST 1V	{'CR'}	{'MIDRC-Open-A1'}	{'MIDRC'}	3
-Thorax^HI_RESOLUTION_CHEST (Adult)	{'CT'}	{'MIDRC-Open-A1'}	{'MIDRC'}	3
-XR PELVIS 1 VIEW	{'CR', 'DX'}	{'MIDRC-Open-A1'}	{'MIDRC'}	3
-X-RAY SHOULDER 1 VIEW - RIGHT	{'DX'}	{'MIDRC-Open-A1'}	{'MIDRC'}	3
-CTA CHEST WITH CONTRAST - PE PROTOCOL	{'CT'}	{'MIDRC-Open-A1_PETAL_BLUECORAL'}	{'MIDRC'}	3
-Vascular^CTA_HEAD (Adult)	{'CT'}	{'MIDRC-Open-A1'}	{'MIDRC'}	3
-XR HIP RIGHT 2-3 VIEWS WWO PELVIS	{'CR', 'DX'}	{'MIDRC-Open-A1'}	{'MIDRC'}	3
-TUMOR LOCALWHOLE BODY SINGLE	{'NM', nan}	{'MIDRC-TCIA-COVID-19-NY-SBU', 'IDC-IDC_covid_19_ny_sbu', 'TCIA-covid-19-ny-sbu'}	{'IDC', 'TCIA', 'MIDRC'}	3
-Vascular^Pre_AAA_STENT_ (Adult)	{'CT'}	{'MIDRC-Open-A1'}	{'MIDRC'}	3
-CT THORAX W CONTRAST	{'CT'}	{'MIDRC-Open-R1'}	{'MIDRC'}	3
-CT ABDOMEN PELVIS W CONTRAST (ENTEROGRAPHY)	{'CT'}	{'MIDRC-Open-A1'}	{'MIDRC'}	3
-CT P ANGIO CHEST WWO	{'CT'}	{'MIDRC-Open-A1', 'MIDRC-Open-R1'}	{'MIDRC'}	3
-X-RAY ABDOMEN POST TUBE PLACEMENT	{'DX'}	{'MIDRC-Open-A1'}	{'MIDRC'}	3
-X-RAY BONE LENGTH STUDIES	{'DX'}	{'MIDRC-Open-A1'}	{'MIDRC'}	3
-CT SPINE CERVICAL WO CONTRAST	{'CT'}	{'MIDRC-Open-A1'}	{'MIDRC'}	3
-XR FOOT LEFT (ROUTINE: AP,LAT,OBL)	{'CR', 'DX'}	{'MIDRC-Open-A1'}	{'MIDRC'}	3
-XR CERVICAL SPINE 4-5 VIEWS	{'CR', 'DX'}	{'MIDRC-Open-A1'}	{'MIDRC'}	3
-X-RAY ELBOW 2 VIEWS - RIGHT	{'DX'}	{'MIDRC-Open-A1'}	{'MIDRC'}	3
-X-RAY ELBOW COMPLETE MIN 3 VWS - RIGHT	{'DX'}	{'MIDRC-Open-A1'}	{'MIDRC'}	3
-X-RAY ENTIRE SPINE SCOLIOSIS 2 OR 3 VIEWS	{'DX'}	{'MIDRC-Open-A1'}	{'MIDRC'}	3
-X-RAY FEMUR MINIMUM 2 VIEWS - LEFT	{'DX'}	{'MIDRC-Open-A1'}	{'MIDRC'}	3
-CT ABDOMEN W AND WO IV CONTRAST	{'CT'}	{'MIDRC-Open-A1'}	{'MIDRC'}	3
-CT ABDOMEN W CONTRAST (CIRRHOSIS)	{'CT'}	{'MIDRC-Open-A1'}	{'MIDRC'}	3
-X-RAY HIPS BILATERAL WITH PELVIS 2 VIEWS	{'DX'}	{'MIDRC-Open-A1'}	{'MIDRC'}	3
-3607 MR RT BREAST WO/W CONT	{'MR', 'SEG'}	{'IDC-IDC_ispy1'}	{'IDC'}	3
-Vascular^CTA_PE (Adult)	{'CT'}	{'MIDRC-Open-A1'}	{'MIDRC'}	3
-Vascular^CTA_CHEST_GR (Adult)	{'CT'}	{'MIDRC-Open-A1'}	{'MIDRC'}	3
-CTA CHEST WITH CONTRAS	{'CT'}	{'MIDRC-Open-A1_PETAL_BLUECORAL'}	{'MIDRC'}	3
-CT Thorax w/Cont	{'SEG', nan}	{'IDC-IDC_qin_lung_ct', 'TCIA-qin-lung-ct'}	{'IDC', 'TCIA'}	3
-XR LOWER LEG (TIBIA/FIBULA) LEFT	{'CR', 'DX'}	{'MIDRC-Open-A1'}	{'MIDRC'}	3
-XR LEFT TIBIA FIBULA 2 VIEWS	{'CR', 'DX'}	{'MIDRC-Open-A1'}	{'MIDRC'}	3
-CT ABD-PELV W/O CM	{'CT'}	{'MIDRC-Open-A1'}	{'MIDRC'}	3
-CTA CHEST AND CT ABDOMEN AND PELVIS W CONT	{'CT'}	{'MIDRC-Open-A1_PETAL_BLUECORAL', 'MIDRC-Open-A1_PETAL_REDCORAL'}	{'MIDRC'}	3
-Thorax^TRAUMA_CHEST_ABD_PEL_WITH (Adult)	{'CT'}	{'MIDRC-Open-A1'}	{'MIDRC'}	3
-CTA CERVICAL CAROTIDS-CS	{'CT'}	{'MIDRC-Open-A1'}	{'MIDRC'}	3
-X-RAY TOE(S) MINIMUM 2 VIEWS - LEFT	{'CR', 'DX'}	{'MIDRC-Open-A1'}	{'MIDRC'}	3
-XR LEFT KNEE 3 VIEWS	{'CR', 'DX'}	{'MIDRC-Open-A1'}	{'MIDRC'}	3
-Thorax^XL_CTA_CHEST (Adult)	{'CT'}	{'MIDRC-Open-A1'}	{'MIDRC'}	3
-CTA ABDOMEN AND PELVIS	{'CT'}	{'MIDRC-Open-A1', 'MIDRC-Open-A1_PETAL_BLUECORAL'}	{'MIDRC'}	3
-ULTRASOUND T1 F/U 1	{'US'}	{'ACRdart-ACRIN_6666'}	{'ACRdart'}	3
-US ABDOMEN LIMITED	{'US'}	{'MIDRC-Open-A1'}	{'MIDRC'}	3
-US LOWER EXTREMITY VENOUS DUPLEX LTD	{'US'}	{'MIDRC-Open-A1'}	{'MIDRC'}	3
-US SOFT TISSUE HEAD/NECK	{'US'}	{'MIDRC-Open-A1'}	{'MIDRC'}	3
-CT UROGRAPHY	{'CT'}	{'MIDRC-Open-A1'}	{'MIDRC'}	3
-Ultrasound Guided Core Biopsy	{'US'}	{'ACRdart-ACRIN_6666'}	{'ACRdart'}	3
-CT LUNG NODULE F/U	{'CT'}	{'MIDRC-Open-R1'}	{'MIDRC'}	3
-CT ABDOMEN WO CONTRAST (ROUTINE)	{'CT'}	{'MIDRC-Open-A1'}	{'MIDRC'}	3
-XR LEFT ELBOW 1-2 VIEWS	{'CR', 'DX'}	{'MIDRC-Open-A1'}	{'MIDRC'}	3
-XR LEFT KNEE 4+ VIEWS (TRAUMA)	{'CR', 'DX'}	{'MIDRC-Open-A1'}	{'MIDRC'}	3
-MRI MRCP	{'MR', nan}	{'MIDRC-TCIA-COVID-19-NY-SBU', 'IDC-IDC_covid_19_ny_sbu', 'TCIA-covid-19-ny-sbu'}	{'IDC', 'TCIA', 'MIDRC'}	3
-TRAUMA CHEST AP PORTABLE	{'CR', nan}	{'MIDRC-TCIA-COVID-19-NY-SBU', 'IDC-IDC_covid_19_ny_sbu', 'TCIA-covid-19-ny-sbu'}	{'IDC', 'TCIA', 'MIDRC'}	3
-Mg. Mammo Digital Screening Bilateral	{'MG'}	{'ACRdart-EA1141Restricted'}	{'ACRdart'}	3
-MRI THORACIC SPINE W/O CONTRAST	{'MR'}	{'MIDRC-Open-A1'}	{'MIDRC'}	3
-MRI THORACIC SPINE WO/W IV CONTRAST	{'MR'}	{'MIDRC-Open-A1'}	{'MIDRC'}	3
-BR SV	{'US'}	{'ACRdart-ACRIN_6666'}	{'ACRdart'}	3
-ACRIN 6701 MRT Prostata Baseline	{'PR', 'MR'}	{'ACRdart-ACRIN_6701'}	{'ACRdart'}	3
-BR-BX BrstCoreL	{'US'}	{'ACRdart-ACRIN_6666'}	{'ACRdart'}	3
-BR-BX BrstCoreR	{'US'}	{'ACRdart-ACRIN_6666'}	{'ACRdart'}	3
-BR-Breast US_RT	{'US'}	{'ACRdart-ACRIN_6666'}	{'ACRdart'}	3
-ABOVE 30 BMI LUNG LOW DOSE(Adult)	{'CT'}	{'MIDRC-Open-A1'}	{'MIDRC'}	3
-MR BREAST BI W O W CONTRAST	{'MR'}	{'ACRdart-EA1141Restricted', 'IDC-IDC_ea1141'}	{'ACRdart', 'IDC'}	3
-Mammo-Digital Screening Employee w/ Tomo	{'MG'}	{'ACRdart-EA1141Restricted', 'IDC-IDC_ea1141'}	{'ACRdart', 'IDC'}	3
-MR BRAIN WITHOUT CONTRAST (S)	{'MR'}	{'MIDRC-Open-R1'}	{'MIDRC'}	3
-MRI SHOULDER WO CONTRAST - LEFT	{'MR'}	{'MIDRC-Open-A1'}	{'MIDRC'}	3
-MR BRAIN WITH AND WITHOUT CONTRAST (S)	{'MR'}	{'MIDRC-Open-R1'}	{'MIDRC'}	3
-NM LUNG VENTILATION/PERFUSION SCAN	{'NM'}	{'MIDRC-Open-R1'}	{'MIDRC'}	3
-NM MYOCARDIAL EXERCISE TREADMILL STRESS ECG	{'NM', 'NM,CT'}	{'MIDRC-Open-R1'}	{'MIDRC'}	3
-ABDOMEN SERIES FLAT AND ERECT PORTABLE	{'CR', nan}	{'MIDRC-TCIA-COVID-19-NY-SBU', 'IDC-IDC_covid_19_ny_sbu', 'TCIA-covid-19-ny-sbu'}	{'IDC', 'TCIA', 'MIDRC'}	3
-MR ABDOMEN WITH AND WITHOUT CONTRAST	{'MR'}	{'MIDRC-Open-R1'}	{'MIDRC'}	3
-BREAST-LEFT	{'MR', nan}	{'IDC-IDC_acrin_contralateral_breast_mr', 'IDC-IDC_ispy1', 'TCIA-acrin-contralateral-breast-mr'}	{'IDC', 'TCIA'}	3
-NUC MED BONE/JOINT IMAGING WHOLE BODY	{'NM'}	{'MIDRC-Open-A1'}	{'MIDRC'}	3
-Normal	{'CT'}	{'IDC-IDC_nlm_visible_human_project'}	{'IDC'}	3
-ABDOMEN 1 VIEW KUB	{'CR'}	{'MIDRC-Open-R1'}	{'MIDRC'}	3
-MMSCRCOMBO	{'MG'}	{'ACRdart-EA1141Restricted', 'IDC-IDC_ea1141'}	{'ACRdart', 'IDC'}	3
-MRI SPINE SURVEY WO/W IV CONTRAST	{'MR'}	{'MIDRC-Open-A1'}	{'MIDRC'}	3
-MRI PROSTATE WO/W CONTRAST	{'MR'}	{'MIDRC-Open-A1'}	{'MIDRC'}	3
-BRST TOMO BILAT MAMMO	{'MG'}	{'ACRdart-EA1141Restricted'}	{'ACRdart'}	3
-Abdomen^ROUTINE_AP_WITH_UNDER_50_OVER_250 (Adult)	{'CT'}	{'MIDRC-Open-A1'}	{'MIDRC'}	3
-MRI ABDOMEN WO/W CONTRAST	{'MR'}	{'MIDRC-Open-A1'}	{'MIDRC'}	3
-MRI BREAST BILAT COMPLETE O/P	{'MR'}	{'ACRdart-EA1141Restricted', 'IDC-IDC_ea1141'}	{'ACRdart', 'IDC'}	3
-MRI BREAST BILAT PRE&POST INF	{'MR'}	{'IDC-IDC_ispy1'}	{'IDC'}	3
-MRI ABD WO IV CONT	{'MR', nan}	{'MIDRC-TCIA-COVID-19-NY-SBU', 'IDC-IDC_covid_19_ny_sbu', 'TCIA-covid-19-ny-sbu'}	{'IDC', 'TCIA', 'MIDRC'}	3
-MRI BREAST BILATERAL WO/W CONTRAST	{'MR'}	{'MIDRC-Open-A1'}	{'MIDRC'}	3
-Abdomen^ABD_PELVIS_WITHOUT (Adult)	{'CT'}	{'MIDRC-Open-A1'}	{'MIDRC'}	3
-Abdomen^AB20_LOWER_GIB (Adult)	{'CT'}	{'MIDRC-Open-A1_PETAL_BLUECORAL'}	{'MIDRC'}	3
-Abdomen^6_DUAL_PHASE (Adult)	{'CT'}	{'MIDRC-Open-A1'}	{'MIDRC'}	3
-MR THORACIC SPINE WITH AND WITHOUT CONTRAST (S)	{'MR'}	{'MIDRC-Open-R1'}	{'MIDRC'}	3
-MR THORACIC SPINE WITH AND WITHOUT CONTRAST	{'MR'}	{'MIDRC-Open-R1'}	{'MIDRC'}	3
-Abdomen^ROUTINE_AP_WO (Adult)	{'CT'}	{'MIDRC-Open-A1'}	{'MIDRC'}	3
-BI BREAST SCREENING BILATERAL	{'MG'}	{'ACRdart-EA1141Restricted', 'IDC-IDC_ea1141'}	{'ACRdart', 'IDC'}	3
-MR Research Grant Stu?	{'MR', 'SEG'}	{'IDC-IDC_ispy1'}	{'IDC'}	3
-MRI CARDIAC WO/W CONTRAST	{'MR'}	{'MIDRC-Open-A1'}	{'MIDRC'}	3
-Abdomen^11_ADRENAL (Adult)	{'CT'}	{'MIDRC-Open-A1'}	{'MIDRC'}	3
-MR PROSTATE WITH AND WITHOUT CONTRAST	{'MR'}	{'MIDRC-Open-R1'}	{'MIDRC'}	3
-Abdomen^XL_AP_WITH (Adult)	{'CT'}	{'MIDRC-Open-A1'}	{'MIDRC'}	3
-MRI HIP WITHOUT CONTRAST-LEFT	{'MR'}	{'MIDRC-Open-A1'}	{'MIDRC'}	3
-MRI LUMBAR SPINE WO/W IV CONTRAST	{'MR'}	{'MIDRC-Open-A1'}	{'MIDRC'}	3
-MRI PELVIS BONE W/O CONTRAST	{'MR'}	{'MIDRC-Open-A1'}	{'MIDRC'}	3
-BD/PRO Pelvis w	{'SEG', nan}	{'IDC-IDC_qin_prostate_repeatability', 'TCIA-qin-prostate-repeatability'}	{'IDC', 'TCIA'}	3
-BELOW 30 BMI LUNG LW DOSE_LUNG SCREEN(Adult)	{'CT'}	{'MIDRC-Open-A1'}	{'MIDRC'}	3
-BREAST^SENTINELLE  COIL	{'MR'}	{'ACRdart-EA1141Restricted', 'IDC-IDC_ea1141'}	{'ACRdart', 'IDC'}	3
-MG MAMMO+3D SCREEN	{'MG'}	{'ACRdart-EA1141Restricted', 'IDC-IDC_ea1141'}	{'ACRdart', 'IDC'}	3
-TRANSESOPHAGEAL ECHO	{'US'}	{'MIDRC-Open-R1'}	{'MIDRC'}	3
-HIP RIGHT 2 VIEWS LATERAL AND AP PELVIS (ROUTINE)	{'CR'}	{'MIDRC-Open-R1'}	{'MIDRC'}	3
-JCCI CT CHEST/PELVIS	{'CT'}	{'MIDRC-Open-R1'}	{'MIDRC'}	3
-CHEST 1 VIEW PORTABLE	{'CR', 'DX'}	{'MIDRC-Open-R1'}	{'MIDRC'}	3
-RIGHT MAMMO DIGITAL DIAGNOSTIC	{'MG'}	{'ACRdart-EA1141Restricted', 'IDC-IDC_ea1141'}	{'ACRdart', 'IDC'}	3
-CHEST AP INFANT PORTABLE	{'CR', nan}	{'MIDRC-TCIA-COVID-19-NY-SBU', 'IDC-IDC_covid_19_ny_sbu', 'TCIA-covid-19-ny-sbu'}	{'IDC', 'TCIA', 'MIDRC'}	3
-Head^Maxillofacial (Adult)	{'CT'}	{'MIDRC-Open-A1'}	{'MIDRC'}	3
-CHEST OP	{'CT'}	{'MIDRC-Open-R1'}	{'MIDRC'}	3
-CHEST OVER PENETRATED PA AP PORTABLE	{'CR', nan}	{'MIDRC-TCIA-COVID-19-NY-SBU', 'IDC-IDC_covid_19_ny_sbu', 'TCIA-covid-19-ny-sbu'}	{'IDC', 'TCIA', 'MIDRC'}	3
-Head^CTA_HEAD (Adult)	{'CT'}	{'MIDRC-Open-A1'}	{'MIDRC'}	3
-CHEST PORT LINE PLACEMENT	{'CR'}	{'MIDRC-Open-A1_PETAL_REDCORAL'}	{'MIDRC'}	3
-Head	{'CT'}	{'MIDRC-Open-A1'}	{'MIDRC'}	3
-HIP LEFT 2 VIEWS LATERAL AND AP PELVIS (ROUTINE)	{'CR'}	{'MIDRC-Open-R1'}	{'MIDRC'}	3
-JHN CAP OP	{'CT'}	{'MIDRC-Open-R1'}	{'MIDRC'}	3
-HIP COMPLETE RIGHT MIN 2 VWS	{'CR', 'DX'}	{'MIDRC-Open-R1'}	{'MIDRC'}	3
-CHEST ROUTINE PA/AP AND LATERAL	{'CR', nan}	{'MIDRC-TCIA-COVID-19-NY-SBU', 'IDC-IDC_covid_19_ny_sbu', 'TCIA-covid-19-ny-sbu'}	{'IDC', 'TCIA', 'MIDRC'}	3
-HAND LEFT 3 VIEWS MIN	{'CR', 'DX'}	{'MIDRC-Open-R1'}	{'MIDRC'}	3
-CHEST WO IP	{'CT'}	{'MIDRC-Open-R1'}	{'MIDRC'}	3
-Screen digital breast tomosynthesis bil	{'MG'}	{'ACRdart-EA1141Restricted'}	{'ACRdart'}	3
-T0 - Ultra	{'US'}	{'ACRdart-ACRIN_6666'}	{'ACRdart'}	3
-THORAX LOW DOSE	{'CT', nan}	{'TCIA-midrc-ricord-1a', 'IDC-IDC_midrc_ricord_1a', 'MIDRC-TCIA-RICORD_1a'}	{'IDC', 'TCIA', 'MIDRC'}	3
-CHEST-PA AND LATERAL VIEWS	{'CR', 'DX'}	{'MIDRC-Open-A1_PETAL_REDCORAL'}	{'MIDRC'}	3
-CHEST-PA ONLY	{'CR', 'DX'}	{'MIDRC-Open-A1_PETAL_REDCORAL'}	{'MIDRC'}	3
-FOOT	{'CR', 'MR'}	{'MIDRC-Open-A1', 'MIDRC-Open-R1'}	{'MIDRC'}	3
-XR SPINE LUMBAR (AP+LAT+OBLIQUES)	{'CR', 'DX'}	{'MIDRC-Open-A1'}	{'MIDRC'}	3
-JHN CHEST W/ OP	{'CT'}	{'MIDRC-Open-R1'}	{'MIDRC'}	3
-MG 3D TOMO HD DX LT	{'MG'}	{'ACRdart-EA1141Restricted', 'IDC-IDC_ea1141'}	{'ACRdart', 'IDC'}	3
-MAMMO DIAGNOSTIC W OR WO CAD WITH TOMOSYNTHESIS - BI	{'MG'}	{'ACRdart-EA1141Restricted'}	{'ACRdart'}	3
-BX MRI RT	{'MR'}	{'ACRdart-EA1141Restricted', 'IDC-IDC_ea1141'}	{'ACRdart', 'IDC'}	3
-ABD SUPINE LATERAL	{'CR', nan}	{'MIDRC-TCIA-COVID-19-NY-SBU', 'IDC-IDC_covid_19_ny_sbu', 'TCIA-covid-19-ny-sbu'}	{'IDC', 'TCIA', 'MIDRC'}	3
-MAMMO-DIGITAL SCREENING EMPLOYEE W/ TOMO	{'MG'}	{'ACRdart-EA1141Restricted', 'IDC-IDC_ea1141'}	{'ACRdart', 'IDC'}	3
-BlueCoral	{'DX', 'CT'}	{'MIDRC-Open-A1_PETAL_BLUECORAL'}	{'MIDRC'}	3
-Breast-Right	{'MR'}	{'IDC-IDC_ispy1'}	{'IDC'}	3
-C-ARM FLUOROSCOPY UP TO 1 HOUR	{'RF', 'XA'}	{'MIDRC-Open-R1'}	{'MIDRC'}	3
-C-ARM FLUOROSCOPY UP TO 2 HOURS	{'RF', 'XA'}	{'MIDRC-Open-R1'}	{'MIDRC'}	3
-C/A/P IP	{'CT'}	{'MIDRC-Open-R1'}	{'MIDRC'}	3
-MAMMO DIGITAL DIAGNOSTIC RIGHT	{'MG'}	{'ACRdart-EA1141Restricted', 'IDC-IDC_ea1141'}	{'ACRdart', 'IDC'}	3
-MAMMO DIAGNOSTIC W OR WO CAD WITH TOMOSYNTHESIS - LT	{'MG'}	{'ACRdart-EA1141Restricted', 'IDC-IDC_ea1141'}	{'ACRdart', 'IDC'}	3
-MAMMO DIAGNOSTIC LT RETURNEE	{'MG'}	{'ACRdart-EA1141Restricted', 'IDC-IDC_ea1141'}	{'ACRdart', 'IDC'}	3
-PULMONARY PERFU SION	{'CT', 'NM', nan}	{'MIDRC-TCIA-COVID-19-NY-SBU', 'IDC-IDC_covid_19_ny_sbu', 'TCIA-covid-19-ny-sbu'}	{'IDC', 'TCIA', 'MIDRC'}	3
-PET LUNG	{nan}	{'TCIA-varepop-apollo'}	{'TCIA'}	3
-CAP IV OP	{'CT'}	{'MIDRC-Open-R1'}	{'MIDRC'}	3
-LUMBAR SACRAL SPINE 2 OR 3 VIEWS (ROUTINE)	{'CR'}	{'MIDRC-Open-R1'}	{'MIDRC'}	3
-CAP_WO(Adult)	{'CT'}	{'MIDRC-Open-A1'}	{'MIDRC'}	3
-CARDIAC CORONARY CTA	{'CT', nan}	{'TCIA-midrc-ricord-1a', 'IDC-IDC_midrc_ricord_1a', 'MIDRC-TCIA-RICORD_1a'}	{'IDC', 'TCIA', 'MIDRC'}	3
-LEFT MAMMO DIGITAL TOMOSYNTHESIS DIAGNOSTIC	{'MG'}	{'ACRdart-EA1141Restricted', 'IDC-IDC_ea1141'}	{'ACRdart', 'IDC'}	3
-L-SPINE	{'MR', nan}	{'MIDRC-Open-A1', 'IDC-IDC_soft_tissue_sarcoma', 'TCIA-soft-tissue-sarcoma'}	{'IDC', 'TCIA', 'MIDRC'}	3
-KIDNEY PROTOCOL(Adult)	{'CT'}	{'MIDRC-Open-A1'}	{'MIDRC'}	3
-JOINY CT CHEST LUNG SCREEN	{'CT'}	{'MIDRC-Open-R1'}	{'MIDRC'}	3
-JOIEN CT C/A/P	{'CT'}	{'MIDRC-Open-R1'}	{'MIDRC'}	3
-Physics^EFJ NCI	{nan}	{'TCIA-rider-phantom-mri'}	{'TCIA'}	3
-Abdomen^GH_AbdomenPlain (Adult)	{'CT'}	{'MIDRC-Open-A1_SCCM_VIRUS'}	{'MIDRC'}	3
-XR SPINE LUMBAR (AP+LAT, SUPINE+UPRIGHT)	{'CR', 'DX'}	{'MIDRC-Open-A1'}	{'MIDRC'}	3
-CT ER Chest w IV Contrast	{'CT'}	{'MIDRC-Open-R1'}	{'MIDRC'}	3
-CT Abd/Pelvis W/ IV + Oral Contrast	{'CT'}	{'MIDRC-Open-A1_PETAL_BLUECORAL'}	{'MIDRC'}	3
-CT CAP W DYE	{nan}	{'TCIA-varepop-apollo'}	{'TCIA'}	3
-CT CHEST NO IVCON	{'CT'}	{'MIDRC-Open-A1_PETAL_BLUECORAL'}	{'MIDRC'}	3
-CT CHEST, ABDOMEN & PELVIS W CONTRAST	{'CT'}	{'MIDRC-Open-A1_PETAL_BLUECORAL'}	{'MIDRC'}	3
-CT CHEST ILD	{'CT'}	{'MIDRC-Open-A1_PETAL_BLUECORAL'}	{'MIDRC'}	3
-CT CHEST(SEE AB/PEL) W IV CON	{'CT', nan}	{'MIDRC-TCIA-COVID-19-NY-SBU', 'IDC-IDC_covid_19_ny_sbu', 'TCIA-covid-19-ny-sbu'}	{'IDC', 'TCIA', 'MIDRC'}	3
-CT CHEST DYNAMIC AIRWAY	{'CT'}	{'AIMI-COCA'}	{'AIMI'}	3
-CT CHEST ANGIOGRAPHY W IV CONTRAST PULMONARY EMBOLISM	{'CT'}	{'MIDRC-Open-A1_PETAL_REDCORAL'}	{'MIDRC'}	3
-CT CARDIAC CHEST W/ (ROBOTIC & CORONARY)	{'CT'}	{'MIDRC-Open-A1', 'MIDRC-Open-R1'}	{'MIDRC'}	3
-CT Chest/Abd/Pelvis W/Contrast	{'CT'}	{'MIDRC-Open-A1_PETAL_BLUECORAL'}	{'MIDRC'}	3
-CT CHEST ABDOMEN AND PELVIS W CONTRAST	{'CT'}	{'MIDRC-Open-A1_PETAL_BLUECORAL', 'MIDRC-Open-A1_PETAL_REDCORAL'}	{'MIDRC'}	3
-CT CHEST WO CONT	{'CT'}	{'MIDRC-Open-A1_PETAL_BLUECORAL', 'MIDRC-Open-A1_PETAL_REDCORAL'}	{'MIDRC'}	3
-CT CHEST WO AND W CONTRAST	{'CT'}	{'MIDRC-Open-R1'}	{'MIDRC'}	3
-CT CHEST WITH AND WITHOUT CONTRAST (S)	{'CT'}	{'MIDRC-Open-R1'}	{'MIDRC'}	3
-CT ANGIOGRAM HEART CORONARY ARTERIES WITH CONTRAST	{'CT'}	{'MIDRC-Open-R1'}	{'MIDRC'}	3
-6V2E-2	{'SR', nan}	{'IDC-IDC_qiba_ct_1c', 'TCIA-qiba-ct-1c'}	{'IDC', 'TCIA'}	2
-PET/CT LUNG CA STAGING FD	{'SEG', nan}	{'TCIA-acrin-nsclc-fdg-pet', 'IDC-IDC_acrin_nsclc_fdg_pet'}	{'IDC', 'TCIA'}	2
-_t8of8EXTERNAL IMAGES	{'MR', nan}	{'IDC-IDC_vestibular_schwannoma_mc_rc', 'TCIA-vestibular-schwannoma-mc-rc'}	{'IDC', 'TCIA'}	2
-7V6A-2	{'SR', nan}	{'IDC-IDC_qiba_ct_1c', 'TCIA-qiba-ct-1c'}	{'IDC', 'TCIA'}	2
-7V6A-1	{'SR', nan}	{'IDC-IDC_qiba_ct_1c', 'TCIA-qiba-ct-1c'}	{'IDC', 'TCIA'}	2
-7V5F-2	{'SR', nan}	{'IDC-IDC_qiba_ct_1c', 'TCIA-qiba-ct-1c'}	{'IDC', 'TCIA'}	2
-7V5E-2	{'SR', nan}	{'IDC-IDC_qiba_ct_1c', 'TCIA-qiba-ct-1c'}	{'IDC', 'TCIA'}	2
-7V5E-1	{'SR', nan}	{'IDC-IDC_qiba_ct_1c', 'TCIA-qiba-ct-1c'}	{'IDC', 'TCIA'}	2
-_t8of8  MRI IAMS post Gad	{'MR', nan}	{'IDC-IDC_vestibular_schwannoma_mc_rc', 'TCIA-vestibular-schwannoma-mc-rc'}	{'IDC', 'TCIA'}	2
-_t8of8  MRI IAMS	{'MR', nan}	{'IDC-IDC_vestibular_schwannoma_mc_rc', 'TCIA-vestibular-schwannoma-mc-rc'}	{'IDC', 'TCIA'}	2
-PET/CT Lung Nodu	{'SEG', nan}	{'IDC-IDC_nsclc_radiogenomics', 'TCIA-nsclc-radiogenomics'}	{'IDC', 'TCIA'}	2
-7V5D-2	{'SR', nan}	{'IDC-IDC_qiba_ct_1c', 'TCIA-qiba-ct-1c'}	{'IDC', 'TCIA'}	2
-7V5D-1	{'SR', nan}	{'IDC-IDC_qiba_ct_1c', 'TCIA-qiba-ct-1c'}	{'IDC', 'TCIA'}	2
-7V5C-2	{'SR', nan}	{'IDC-IDC_qiba_ct_1c', 'TCIA-qiba-ct-1c'}	{'IDC', 'TCIA'}	2
-7V5C-1	{'SR', nan}	{'IDC-IDC_qiba_ct_1c', 'TCIA-qiba-ct-1c'}	{'IDC', 'TCIA'}	2
-PET/CT RAD TX	{'SEG', nan}	{'TCIA-acrin-nsclc-fdg-pet', 'IDC-IDC_acrin_nsclc_fdg_pet'}	{'IDC', 'TCIA'}	2
-7V5B-2	{'SR', nan}	{'IDC-IDC_qiba_ct_1c', 'TCIA-qiba-ct-1c'}	{'IDC', 'TCIA'}	2
-7V6B-1	{'SR', nan}	{'IDC-IDC_qiba_ct_1c', 'TCIA-qiba-ct-1c'}	{'IDC', 'TCIA'}	2
-7V6B-2	{'SR', nan}	{'IDC-IDC_qiba_ct_1c', 'TCIA-qiba-ct-1c'}	{'IDC', 'TCIA'}	2
-7V6E-1	{'SR', nan}	{'IDC-IDC_qiba_ct_1c', 'TCIA-qiba-ct-1c'}	{'IDC', 'TCIA'}	2
-S.KOZAK	{'CT', nan}	{'TCIA-ct-colonography', 'IDC-IDC_ct_colonography'}	{'IDC', 'TCIA'}	2
-1V4A-2	{'SR', nan}	{'IDC-IDC_qiba_ct_1c', 'TCIA-qiba-ct-1c'}	{'IDC', 'TCIA'}	2
-PET-CT STUDY for Shelly Wallace	{'PT', nan}	{'IDC-IDC_pseudo_phi_dicom_data', 'TCIA-pseudo-phi-dicom-data'}	{'IDC', 'TCIA'}	2
-PET-CT WATROBA	{'CT', nan}	{'TCIA-cptac-pda', 'IDC-IDC_cptac_pda'}	{'IDC', 'TCIA'}	2
-PET-CT WB ST	{'CT', nan}	{'TCIA-cptac-pda', 'IDC-IDC_cptac_pda'}	{'IDC', 'TCIA'}	2
-_t8of8MRI Head	{'MR', nan}	{'IDC-IDC_vestibular_schwannoma_mc_rc', 'TCIA-vestibular-schwannoma-mc-rc'}	{'IDC', 'TCIA'}	2
-PET-TK ONKOLOGIC	{'PT', nan}	{'TCIA-cptac-lscc', 'IDC-IDC_cptac_lscc'}	{'IDC', 'TCIA'}	2
-SBRT PELVIS	{'CT', nan}	{'IDC-IDC_pelvic_reference_data', 'TCIA-pelvic-reference-data'}	{'IDC', 'TCIA'}	2
-7V6D-1	{'SR', nan}	{'IDC-IDC_qiba_ct_1c', 'TCIA-qiba-ct-1c'}	{'IDC', 'TCIA'}	2
-PET/CT ATTN ONLY NCAP	{'SEG', nan}	{'TCIA-tcga-lusc', 'IDC-IDC_tcga_lusc'}	{'IDC', 'TCIA'}	2
-7V6C-2	{'SR', nan}	{'IDC-IDC_qiba_ct_1c', 'TCIA-qiba-ct-1c'}	{'IDC', 'TCIA'}	2
-7V6C-1	{'SR', nan}	{'IDC-IDC_qiba_ct_1c', 'TCIA-qiba-ct-1c'}	{'IDC', 'TCIA'}	2
-PET/CT DELAY	{'SEG', nan}	{'TCIA-acrin-nsclc-fdg-pet', 'IDC-IDC_acrin_nsclc_fdg_pet'}	{'IDC', 'TCIA'}	2
-PET/CT Head Neck Reference Only	{'SEG', nan}	{'IDC-IDC_nsclc_radiogenomics', 'TCIA-nsclc-radiogenomics'}	{'IDC', 'TCIA'}	2
-PET/CT Imaging - Skull Base to Mid-Thigh=W	{'PT', nan}	{'IDC-IDC_cc_tumor_heterogeneity', 'TCIA-cc-tumor-heterogeneity'}	{'IDC', 'TCIA'}	2
-PET/CT LUNG	{'SEG', nan}	{'IDC-IDC_nsclc_radiogenomics', 'TCIA-nsclc-radiogenomics'}	{'IDC', 'TCIA'}	2
-7V5B-1	{'SR', nan}	{'IDC-IDC_qiba_ct_1c', 'TCIA-qiba-ct-1c'}	{'IDC', 'TCIA'}	2
-1V4B-1	{'SR', nan}	{'IDC-IDC_qiba_ct_1c', 'TCIA-qiba-ct-1c'}	{'IDC', 'TCIA'}	2
-1V4B-2	{'SR', nan}	{'IDC-IDC_qiba_ct_1c', 'TCIA-qiba-ct-1c'}	{'IDC', 'TCIA'}	2
-7V5A-2	{'SR', nan}	{'IDC-IDC_qiba_ct_1c', 'TCIA-qiba-ct-1c'}	{'IDC', 'TCIA'}	2
-7V4B-2	{'SR', nan}	{'IDC-IDC_qiba_ct_1c', 'TCIA-qiba-ct-1c'}	{'IDC', 'TCIA'}	2
-1V4C-1	{'SR', nan}	{'IDC-IDC_qiba_ct_1c', 'TCIA-qiba-ct-1c'}	{'IDC', 'TCIA'}	2
-PETCT CONTRASTED SUBSQ TX 78815	{'SEG', nan}	{'IDC-IDC_anti_pd_1_lung', 'TCIA-anti-pd-1_lung'}	{'IDC', 'TCIA'}	2
-7V4B-1	{'SR', nan}	{'IDC-IDC_qiba_ct_1c', 'TCIA-qiba-ct-1c'}	{'IDC', 'TCIA'}	2
-7V4A-2	{'SR', nan}	{'IDC-IDC_qiba_ct_1c', 'TCIA-qiba-ct-1c'}	{'IDC', 'TCIA'}	2
-7V4A-1	{'SR', nan}	{'IDC-IDC_qiba_ct_1c', 'TCIA-qiba-ct-1c'}	{'IDC', 'TCIA'}	2
-7V3F-2	{'SR', nan}	{'IDC-IDC_qiba_ct_1c', 'TCIA-qiba-ct-1c'}	{'IDC', 'TCIA'}	2
-PETCT LIMITED WHOLE BODY VERTEX TO MID THIGH (S)	{'PT'}	{'MIDRC-Open-R1'}	{'MIDRC'}	2
-PETCT LUNG CA	{'SEG', nan}	{'IDC-IDC_nsclc_radiogenomics', 'TCIA-nsclc-radiogenomics'}	{'IDC', 'TCIA'}	2
-7V3E-2	{'SR', nan}	{'IDC-IDC_qiba_ct_1c', 'TCIA-qiba-ct-1c'}	{'IDC', 'TCIA'}	2
-PETCT LUNG NODULE	{'SEG', nan}	{'IDC-IDC_nsclc_radiogenomics', 'TCIA-nsclc-radiogenomics'}	{'IDC', 'TCIA'}	2
-7V3E-1	{'SR', nan}	{'IDC-IDC_qiba_ct_1c', 'TCIA-qiba-ct-1c'}	{'IDC', 'TCIA'}	2
-7V3D-2	{'SR', nan}	{'IDC-IDC_qiba_ct_1c', 'TCIA-qiba-ct-1c'}	{'IDC', 'TCIA'}	2
-7V3D-1	{'SR', nan}	{'IDC-IDC_qiba_ct_1c', 'TCIA-qiba-ct-1c'}	{'IDC', 'TCIA'}	2
-7V3C-2	{'SR', nan}	{'IDC-IDC_qiba_ct_1c', 'TCIA-qiba-ct-1c'}	{'IDC', 'TCIA'}	2
-6V2B-1	{'SR', nan}	{'IDC-IDC_qiba_ct_1c', 'TCIA-qiba-ct-1c'}	{'IDC', 'TCIA'}	2
-PETCT COLON CA	{'SEG', nan}	{'IDC-IDC_nsclc_radiogenomics', 'TCIA-nsclc-radiogenomics'}	{'IDC', 'TCIA'}	2
-7V4C-1	{'SR', nan}	{'IDC-IDC_qiba_ct_1c', 'TCIA-qiba-ct-1c'}	{'IDC', 'TCIA'}	2
-PET/CT W/CON LUNG SPN	{'SEG', nan}	{'IDC-IDC_nsclc_radiogenomics', 'TCIA-nsclc-radiogenomics'}	{'IDC', 'TCIA'}	2
-Rtg Klatki Piersiowej	{'CT', nan}	{'TCIA-cptac-luad', 'IDC-IDC_cptac_luad'}	{'IDC', 'TCIA'}	2
-7V5A-1	{'SR', nan}	{'IDC-IDC_qiba_ct_1c', 'TCIA-qiba-ct-1c'}	{'IDC', 'TCIA'}	2
-PET/CT Skull Base to M	{'SEG', nan}	{'TCIA-acrin-nsclc-fdg-pet', 'IDC-IDC_acrin_nsclc_fdg_pet'}	{'IDC', 'TCIA'}	2
-7V4F-2	{'SR', nan}	{'IDC-IDC_qiba_ct_1c', 'TCIA-qiba-ct-1c'}	{'IDC', 'TCIA'}	2
-6V2A-1	{'SR', nan}	{'IDC-IDC_qiba_ct_1c', 'TCIA-qiba-ct-1c'}	{'IDC', 'TCIA'}	2
-PET/CT Uncovered Diagn	{'SEG', nan}	{'IDC-IDC_nsclc_radiogenomics', 'TCIA-nsclc-radiogenomics'}	{'IDC', 'TCIA'}	2
-7V4E-2	{'SR', nan}	{'IDC-IDC_qiba_ct_1c', 'TCIA-qiba-ct-1c'}	{'IDC', 'TCIA'}	2
-7V4C-2	{'SR', nan}	{'IDC-IDC_qiba_ct_1c', 'TCIA-qiba-ct-1c'}	{'IDC', 'TCIA'}	2
-7V4E-1	{'SR', nan}	{'IDC-IDC_qiba_ct_1c', 'TCIA-qiba-ct-1c'}	{'IDC', 'TCIA'}	2
-PET/CT with added MR	{'MR', nan}	{'IDC-IDC_soft_tissue_sarcoma', 'TCIA-soft-tissue-sarcoma'}	{'IDC', 'TCIA'}	2
-7V4D-2	{'SR', nan}	{'IDC-IDC_qiba_ct_1c', 'TCIA-qiba-ct-1c'}	{'IDC', 'TCIA'}	2
-7V4D-1	{'SR', nan}	{'IDC-IDC_qiba_ct_1c', 'TCIA-qiba-ct-1c'}	{'IDC', 'TCIA'}	2
-PET1A	{'CT', nan}	{'IDC-IDC_cc_tumor_heterogeneity', 'TCIA-cc-tumor-heterogeneity'}	{'IDC', 'TCIA'}	2
-6V2A-2	{'SR', nan}	{'IDC-IDC_qiba_ct_1c', 'TCIA-qiba-ct-1c'}	{'IDC', 'TCIA'}	2
-7V6D-2	{'SR', nan}	{'IDC-IDC_qiba_ct_1c', 'TCIA-qiba-ct-1c'}	{'IDC', 'TCIA'}	2
-PET WB OR REG RESTAG HEAD+NECK	{'SEG', nan}	{'TCIA-tcga-lusc', 'IDC-IDC_tcga_lusc'}	{'IDC', 'TCIA'}	2
-_t5of9MRI IAMS post Gad	{'MR', nan}	{'IDC-IDC_vestibular_schwannoma_mc_rc', 'TCIA-vestibular-schwannoma-mc-rc'}	{'IDC', 'TCIA'}	2
-PET CT TUMOR IMG SKULL THIGH	{'CT', nan}	{'IDC-IDC_tcga_kirp', 'TCIA-tcga-kirp'}	{'IDC', 'TCIA'}	2
-abd/pelvis	{'SEG', nan}	{'IDC-IDC_hcc_tace_seg', 'TCIA-hcc-tace-seg'}	{'IDC', 'TCIA'}	2
-PET CT TUMOR WHOLE BO	{nan}	{'TCIA-breast-diagnosis'}	{'TCIA'}	2
-AB PEL/	{'CT', nan}	{'TCIA-ct-colonography', 'IDC-IDC_ct_colonography'}	{'IDC', 'TCIA'}	2
-AABD/PELVIS	{'SEG', nan}	{'IDC-IDC_hcc_tace_seg', 'TCIA-hcc-tace-seg'}	{'IDC', 'TCIA'}	2
-PET CT WHOLE BODY NON REGISTRY INITIAL STAGING	{'PT', nan}	{'TCIA-cptac-pda', 'IDC-IDC_cptac_pda'}	{'IDC', 'TCIA'}	2
-AABD (ADRENAL)	{'CT', nan}	{'TCIA-adrenal-acc-ki67-seg', 'IDC-IDC_adrenal_acc_ki67_seg'}	{'IDC', 'TCIA'}	2
-ab/5589	{'MR', nan}	{'TCIA-tcga-kirc', 'IDC-IDC_tcga_kirc'}	{'IDC', 'TCIA'}	2
-AA/P LIVER	{'SEG', nan}	{'IDC-IDC_hcc_tace_seg', 'TCIA-hcc-tace-seg'}	{'IDC', 'TCIA'}	2
-PET DEDICATED RUBIDIUM REST/STRESS MYOCARDIAL PERFUSION	{'CT', 'PT'}	{'MIDRC-Open-R1'}	{'MIDRC'}	2
-A/P-PRE/POST	{'CT', nan}	{'TCIA-tcga-ov', 'IDC-IDC_tcga_ov'}	{'IDC', 'TCIA'}	2
-1V3D-1	{'SR', nan}	{'IDC-IDC_qiba_ct_1c', 'TCIA-qiba-ct-1c'}	{'IDC', 'TCIA'}	2
-1V3D-2	{'SR', nan}	{'IDC-IDC_qiba_ct_1c', 'TCIA-qiba-ct-1c'}	{'IDC', 'TCIA'}	2
-A/P-LIVER	{'SEG', nan}	{'IDC-IDC_hcc_tace_seg', 'TCIA-hcc-tace-seg'}	{'IDC', 'TCIA'}	2
-1V3E-1	{'SR', nan}	{'IDC-IDC_qiba_ct_1c', 'TCIA-qiba-ct-1c'}	{'IDC', 'TCIA'}	2
-A/P WO	{'CT', nan}	{'IDC-IDC_tcga_blca', 'TCIA-tcga-blca'}	{'IDC', 'TCIA'}	2
-SCAN ABDOMINO-PELVIEN C+ -ABD	{'CT', nan}	{'TCIA-tcga-lihc', 'IDC-IDC_tcga_lihc'}	{'IDC', 'TCIA'}	2
-PET CT Skull To Mid Th	{'SEG', nan}	{'IDC-IDC_anti_pd_1_lung', 'TCIA-anti-pd-1_lung'}	{'IDC', 'TCIA'}	2
-7V6E-2	{'SR', nan}	{'IDC-IDC_qiba_ct_1c', 'TCIA-qiba-ct-1c'}	{'IDC', 'TCIA'}	2
-PET CT Sarcoma Initial	{'SEG', nan}	{'IDC-IDC_nsclc_radiogenomics', 'TCIA-nsclc-radiogenomics'}	{'IDC', 'TCIA'}	2
-1V3A-1	{'SR', nan}	{'IDC-IDC_qiba_ct_1c', 'TCIA-qiba-ct-1c'}	{'IDC', 'TCIA'}	2
-PET CT IMAGING SKULL BASE TO THIGH	{'CT', nan}	{'TCIA-acrin-flt-breast', 'IDC-IDC_acrin_flt_breast'}	{'IDC', 'TCIA'}	2
-1V3A-2	{'SR', nan}	{'IDC-IDC_qiba_ct_1c', 'TCIA-qiba-ct-1c'}	{'IDC', 'TCIA'}	2
-1V3B-1	{'SR', nan}	{'IDC-IDC_qiba_ct_1c', 'TCIA-qiba-ct-1c'}	{'IDC', 'TCIA'}	2
-PET CT LIMITED AREA	{'CT', nan}	{'IDC-IDC_rider_lung_pet_ct', 'TCIA-rider-lung-pet-ct'}	{'IDC', 'TCIA'}	2
-1V3B-2	{'SR', nan}	{'IDC-IDC_qiba_ct_1c', 'TCIA-qiba-ct-1c'}	{'IDC', 'TCIA'}	2
-ABD	{'CT', nan}	{'IDC-IDC_tcga_kich', 'TCIA-tcga-kich'}	{'IDC', 'TCIA'}	2
-PET CT SCAN ONCOLOGY DIAGNOSTIC	{'CT', nan}	{'TCIA-cptac-lscc', 'IDC-IDC_cptac_lscc'}	{'IDC', 'TCIA'}	2
-PET CT SCAN ONCOLOGY INITIAL STAGING	{'CT', nan}	{'TCIA-cptac-luad', 'IDC-IDC_cptac_luad'}	{'IDC', 'TCIA'}	2
-1V3C-1	{'SR', nan}	{'IDC-IDC_qiba_ct_1c', 'TCIA-qiba-ct-1c'}	{'IDC', 'TCIA'}	2
-1V3C-2	{'SR', nan}	{'IDC-IDC_qiba_ct_1c', 'TCIA-qiba-ct-1c'}	{'IDC', 'TCIA'}	2
-AB/6514	{'MR', nan}	{'TCIA-tcga-kirc', 'IDC-IDC_tcga_kirc'}	{'IDC', 'TCIA'}	2
-AB+C	{'SEG', nan}	{'IDC-IDC_lung_pet_ct_dx', 'TCIA-lung-pet-ct-dx'}	{'IDC', 'TCIA'}	2
-PET CT SKULL TO MID-TH	{'SEG', nan}	{'TCIA-acrin-nsclc-fdg-pet', 'IDC-IDC_acrin_nsclc_fdg_pet'}	{'IDC', 'TCIA'}	2
-PET CT SKULL TO MID-THIGH	{'PT', nan}	{'TCIA-acrin-nsclc-fdg-pet', 'IDC-IDC_acrin_nsclc_fdg_pet'}	{'IDC', 'TCIA'}	2
-PET IMAGE W/CT, LMTD	{'SEG', nan}	{'IDC-IDC_nsclc_radiogenomics', 'TCIA-nsclc-radiogenomics'}	{'IDC', 'TCIA'}	2
-A/P WITH	{'CT', nan}	{'IDC-IDC_tcga_blca', 'TCIA-tcga-blca'}	{'IDC', 'TCIA'}	2
-PET Imaging Outside Consultation With Formal Dictation	{'CT', nan}	{'TCIA-cptac-lscc', 'IDC-IDC_cptac_lscc'}	{'IDC', 'TCIA'}	2
-1V3E-2	{'SR', nan}	{'IDC-IDC_qiba_ct_1c', 'TCIA-qiba-ct-1c'}	{'IDC', 'TCIA'}	2
-PET OVARIAN CANCER	{'SEG', nan}	{'TCIA-acrin-nsclc-fdg-pet', 'IDC-IDC_acrin_nsclc_fdg_pet'}	{'IDC', 'TCIA'}	2
-A/P - LIVER	{'SEG', nan}	{'IDC-IDC_hcc_tace_seg', 'TCIA-hcc-tace-seg'}	{'IDC', 'TCIA'}	2
-_t8of9MRI Head	{'MR', nan}	{'IDC-IDC_vestibular_schwannoma_mc_rc', 'TCIA-vestibular-schwannoma-mc-rc'}	{'IDC', 'TCIA'}	2
-A-P W/WO	{'CT', nan}	{'IDC-IDC_tcga_blca', 'TCIA-tcga-blca'}	{'IDC', 'TCIA'}	2
-_t8of8_MRI IAMS WITH CONTRAST	{'MR', nan}	{'IDC-IDC_vestibular_schwannoma_mc_rc', 'TCIA-vestibular-schwannoma-mc-rc'}	{'IDC', 'TCIA'}	2
-A-P W	{'CT', nan}	{'TCIA-tcga-ov', 'IDC-IDC_tcga_ov'}	{'IDC', 'TCIA'}	2
-1V3F-2	{'SR', nan}	{'IDC-IDC_qiba_ct_1c', 'TCIA-qiba-ct-1c'}	{'IDC', 'TCIA'}	2
-PET TUM SKULL/MID-THIGH-CT	{'SEG', nan}	{'TCIA-acrin-nsclc-fdg-pet', 'IDC-IDC_acrin_nsclc_fdg_pet'}	{'IDC', 'TCIA'}	2
-PET TUM SKULL/MID-THIGH-CT ANA	{'SEG', nan}	{'TCIA-acrin-nsclc-fdg-pet', 'IDC-IDC_acrin_nsclc_fdg_pet'}	{'IDC', 'TCIA'}	2
-1V4A-1	{'SR', nan}	{'IDC-IDC_qiba_ct_1c', 'TCIA-qiba-ct-1c'}	{'IDC', 'TCIA'}	2
-88.011 TK jamy brzuszn	{'CT', nan}	{'TCIA-cptac-pda', 'IDC-IDC_cptac_pda'}	{'IDC', 'TCIA'}	2
-PET TUMOR IMAGING	{'PT', nan}	{'IDC-IDC_tcga_blca', 'TCIA-tcga-blca'}	{'IDC', 'TCIA'}	2
-PET TUMOR IMAGING WITH DOTATATE	{'PT,CT'}	{'MIDRC-Open-A1'}	{'MIDRC'}	2
-PET TUMOR METAB	{'SEG', nan}	{'IDC-IDC_rider_lung_pet_ct', 'TCIA-rider-lung-pet-ct'}	{'IDC', 'TCIA'}	2
-7V6F-2	{'SR', nan}	{'IDC-IDC_qiba_ct_1c', 'TCIA-qiba-ct-1c'}	{'IDC', 'TCIA'}	2
-A/P -CLONOGRAPHY	{'CT', nan}	{'TCIA-ct-colonography', 'IDC-IDC_ct_colonography'}	{'IDC', 'TCIA'}	2
-A/P -LIVER	{'SEG', nan}	{'IDC-IDC_hcc_tace_seg', 'TCIA-hcc-tace-seg'}	{'IDC', 'TCIA'}	2
-A/P -UROGRAM	{'CT', nan}	{'IDC-IDC_tcga_blca', 'TCIA-tcga-blca'}	{'IDC', 'TCIA'}	2
-PET Lung	{'SEG', nan}	{'TCIA-acrin-nsclc-fdg-pet', 'IDC-IDC_acrin_nsclc_fdg_pet'}	{'IDC', 'TCIA'}	2
-A/P W/W/O	{'CT', nan}	{'TCIA-tcga-kirc', 'IDC-IDC_tcga_kirc'}	{'IDC', 'TCIA'}	2
-A/P W WO	{'CT', nan}	{'IDC-IDC_tcga_blca', 'TCIA-tcga-blca'}	{'IDC', 'TCIA'}	2
-PET LYMPHOMA HODGKINS	{'PT,CT'}	{'MIDRC-Open-A1'}	{'MIDRC'}	2
-A/P RENAL W/WO	{'SEG', nan}	{'TCIA-tcga-kirc', 'IDC-IDC_tcga_kirc'}	{'IDC', 'TCIA'}	2
-A/P RENAL PRT W/WO	{'SEG', nan}	{'TCIA-tcga-kirc', 'IDC-IDC_tcga_kirc'}	{'IDC', 'TCIA'}	2
-A/P RENAL	{'SEG', nan}	{'TCIA-tcga-kirc', 'IDC-IDC_tcga_kirc'}	{'IDC', 'TCIA'}	2
-PET Lung Cancer Initial I	{'SEG', nan}	{'TCIA-acrin-nsclc-fdg-pet', 'IDC-IDC_acrin_nsclc_fdg_pet'}	{'IDC', 'TCIA'}	2
-_t9of17  External Images for PACS	{'MR', nan}	{'IDC-IDC_vestibular_schwannoma_mc_rc', 'TCIA-vestibular-schwannoma-mc-rc'}	{'IDC', 'TCIA'}	2
-PET Lung Cancer Restag	{'SEG', nan}	{'TCIA-acrin-nsclc-fdg-pet', 'IDC-IDC_acrin_nsclc_fdg_pet'}	{'IDC', 'TCIA'}	2
-A/P LIVER W/WO	{'SEG', nan}	{'IDC-IDC_hcc_tace_seg', 'TCIA-hcc-tace-seg'}	{'IDC', 'TCIA'}	2
-A/P LIVER PRT W/WO	{'SEG', nan}	{'IDC-IDC_hcc_tace_seg', 'TCIA-hcc-tace-seg'}	{'IDC', 'TCIA'}	2
-A/P LIVER PROTOCOL	{'SEG', nan}	{'IDC-IDC_hcc_tace_seg', 'TCIA-hcc-tace-seg'}	{'IDC', 'TCIA'}	2
-PET NCAP ATTN ONLY	{'RTSTRUCT', nan}	{'IDC-IDC_cptac_ucec', 'TCIA-cptac-ucec'}	{'IDC', 'TCIA'}	2
-PET NON-SMALL CELL LUN	{'SEG', nan}	{'TCIA-acrin-nsclc-fdg-pet', 'IDC-IDC_acrin_nsclc_fdg_pet'}	{'IDC', 'TCIA'}	2
-7V3C-1	{'SR', nan}	{'IDC-IDC_qiba_ct_1c', 'TCIA-qiba-ct-1c'}	{'IDC', 'TCIA'}	2
-7V3B-2	{'SR', nan}	{'IDC-IDC_qiba_ct_1c', 'TCIA-qiba-ct-1c'}	{'IDC', 'TCIA'}	2
-PETCT_NCAP	{'PT', nan}	{'TCIA-cmb-lca', 'IDC-IDC_cmb_lca'}	{'IDC', 'TCIA'}	2
-6V4D-2	{'SR', nan}	{'IDC-IDC_qiba_ct_1c', 'TCIA-qiba-ct-1c'}	{'IDC', 'TCIA'}	2
-Post Treatment- Specials 1PETCT_WholeBody	{'SEG', nan}	{'TCIA-acrin-nsclc-fdg-pet', 'IDC-IDC_acrin_nsclc_fdg_pet'}	{'IDC', 'TCIA'}	2
-Post treatment- Abdomen 2_CHEST-ABD-PEL	{'CT', nan}	{'TCIA-acrin-nsclc-fdg-pet', 'IDC-IDC_acrin_nsclc_fdg_pet'}	{'IDC', 'TCIA'}	2
-6V4D-1	{'SR', nan}	{'IDC-IDC_qiba_ct_1c', 'TCIA-qiba-ct-1c'}	{'IDC', 'TCIA'}	2
-6V4C-2	{'SR', nan}	{'IDC-IDC_qiba_ct_1c', 'TCIA-qiba-ct-1c'}	{'IDC', 'TCIA'}	2
-Private^WBHPELVIS (Adult)	{'CT', nan}	{'IDC-IDC_pelvic_reference_data', 'TCIA-pelvic-reference-data'}	{'IDC', 'TCIA'}	2
-_t6of10MRI IAMS	{'MR', nan}	{'IDC-IDC_vestibular_schwannoma_mc_rc', 'TCIA-vestibular-schwannoma-mc-rc'}	{'IDC', 'TCIA'}	2
-Prostate CA PET	{'PT', nan}	{'IDC-IDC_tcga_prad', 'TCIA-tcga-prad'}	{'IDC', 'TCIA'}	2
-QIN-PET-Phantom-UI	{nan}	{'TCIA-qin-pet-phantom'}	{'TCIA'}	2
-6V2C-2	{'SR', nan}	{'IDC-IDC_qiba_ct_1c', 'TCIA-qiba-ct-1c'}	{'IDC', 'TCIA'}	2
-QIN-PET-Phantom-UW	{nan}	{'TCIA-qin-pet-phantom'}	{'TCIA'}	2
-6V4C-1	{'SR', nan}	{'IDC-IDC_qiba_ct_1c', 'TCIA-qiba-ct-1c'}	{'IDC', 'TCIA'}	2
-RAD Chest 2 V Pa and Lat 71020	{'CR', nan}	{'TCIA-acrin-nsclc-fdg-pet', 'IDC-IDC_acrin_nsclc_fdg_pet'}	{'IDC', 'TCIA'}	2
-6V4B-2	{'SR', nan}	{'IDC-IDC_qiba_ct_1c', 'TCIA-qiba-ct-1c'}	{'IDC', 'TCIA'}	2
-RCC S/P PARTIAL RT NEP	{'CT', nan}	{'TCIA-tcga-kirc', 'IDC-IDC_tcga_kirc'}	{'IDC', 'TCIA'}	2
-RECALL FOR ADDITIONAL IMAGING	{'MR'}	{'ACRdart-EA1141Restricted'}	{'ACRdart'}	2
-1V4D-2	{'SR', nan}	{'IDC-IDC_qiba_ct_1c', 'TCIA-qiba-ct-1c'}	{'IDC', 'TCIA'}	2
-Renal	{'US'}	{'ACRdart-ACRIN_6666'}	{'ACRdart'}	2
-7V3B-1	{'SR', nan}	{'IDC-IDC_qiba_ct_1c', 'TCIA-qiba-ct-1c'}	{'IDC', 'TCIA'}	2
-Port Chest	{'CR', nan}	{'TCIA-acrin-nsclc-fdg-pet', 'IDC-IDC_acrin_nsclc_fdg_pet'}	{'IDC', 'TCIA'}	2
-Pelvis	{'MR', nan}	{'IDC-IDC_tcga_blca', 'TCIA-tcga-blca'}	{'IDC', 'TCIA'}	2
-Pelvis^01_Pelvis_Routine (Adult)	{'CT', nan}	{'TCIA-tcga-ucec', 'IDC-IDC_tcga_ucec'}	{'IDC', 'TCIA'}	2
-6V5A-2	{'SR', nan}	{'IDC-IDC_qiba_ct_1c', 'TCIA-qiba-ct-1c'}	{'IDC', 'TCIA'}	2
-Pelvis^MIEDNICA (Adult)	{'CT', nan}	{'IDC-IDC_cptac_cm', 'TCIA-cptac-cm'}	{'IDC', 'TCIA'}	2
-1V4D-1	{'SR', nan}	{'IDC-IDC_qiba_ct_1c', 'TCIA-qiba-ct-1c'}	{'IDC', 'TCIA'}	2
-6V5A-1	{'SR', nan}	{'IDC-IDC_qiba_ct_1c', 'TCIA-qiba-ct-1c'}	{'IDC', 'TCIA'}	2
-Pelvis^PELVIS_SUPINE (Adult)	{'CT', nan}	{'TCIA-spine-mets-ct-seg', 'IDC-IDC_spine_mets_ct_seg'}	{'IDC', 'TCIA'}	2
-Pelvis^PELVIS_TRAUMA_Customized (Adult)	{'CT'}	{'MIDRC-Open-A1'}	{'MIDRC'}	2
-6V4F-2	{'SR', nan}	{'IDC-IDC_qiba_ct_1c', 'TCIA-qiba-ct-1c'}	{'IDC', 'TCIA'}	2
-Pet CUPS Acrin	{'SEG', nan}	{'TCIA-acrin-nsclc-fdg-pet', 'IDC-IDC_acrin_nsclc_fdg_pet'}	{'IDC', 'TCIA'}	2
-Pet/Ct WB	{'SEG', nan}	{'TCIA-acrin-nsclc-fdg-pet', 'IDC-IDC_acrin_nsclc_fdg_pet'}	{'IDC', 'TCIA'}	2
-_t6of11MRI Stereo Gamma Knife gad	{'MR', nan}	{'IDC-IDC_vestibular_schwannoma_mc_rc', 'TCIA-vestibular-schwannoma-mc-rc'}	{'IDC', 'TCIA'}	2
-PinSourceImg	{'CT', nan}	{'IDC-IDC_rider_lung_pet_ct', 'TCIA-rider-lung-pet-ct'}	{'IDC', 'TCIA'}	2
-6V4E-2	{'SR', nan}	{'IDC-IDC_qiba_ct_1c', 'TCIA-qiba-ct-1c'}	{'IDC', 'TCIA'}	2
-6V4E-1	{'SR', nan}	{'IDC-IDC_qiba_ct_1c', 'TCIA-qiba-ct-1c'}	{'IDC', 'TCIA'}	2
-6V2D-1	{'SR', nan}	{'IDC-IDC_qiba_ct_1c', 'TCIA-qiba-ct-1c'}	{'IDC', 'TCIA'}	2
-6V4B-1	{'SR', nan}	{'IDC-IDC_qiba_ct_1c', 'TCIA-qiba-ct-1c'}	{'IDC', 'TCIA'}	2
-RECTUM/ANUS	{'CT', nan}	{'IDC-IDC_pelvic_reference_data', 'TCIA-pelvic-reference-data'}	{'IDC', 'TCIA'}	2
-RENAL// C A P	{'SEG', nan}	{'TCIA-tcga-kirc', 'IDC-IDC_tcga_kirc'}	{'IDC', 'TCIA'}	2
-6V3C-2	{'SR', nan}	{'IDC-IDC_qiba_ct_1c', 'TCIA-qiba-ct-1c'}	{'IDC', 'TCIA'}	2
-6V3C-1	{'SR', nan}	{'IDC-IDC_qiba_ct_1c', 'TCIA-qiba-ct-1c'}	{'IDC', 'TCIA'}	2
-6V3B-2	{'SR', nan}	{'IDC-IDC_qiba_ct_1c', 'TCIA-qiba-ct-1c'}	{'IDC', 'TCIA'}	2
-RM PELVE - EXT	{'MR', nan}	{'IDC-IDC_tcga_cesc', 'TCIA-tcga-cesc'}	{'IDC', 'TCIA'}	2
-ROUTINE BRAIN	{'MR', nan}	{'IDC-IDC_icdc_glioma', 'TCIA-icdc-glioma'}	{'IDC', 'TCIA'}	2
-6V3B-1	{'SR', nan}	{'IDC-IDC_qiba_ct_1c', 'TCIA-qiba-ct-1c'}	{'IDC', 'TCIA'}	2
-6V3A-2	{'SR', nan}	{'IDC-IDC_qiba_ct_1c', 'TCIA-qiba-ct-1c'}	{'IDC', 'TCIA'}	2
-6V3A-1	{'SR', nan}	{'IDC-IDC_qiba_ct_1c', 'TCIA-qiba-ct-1c'}	{'IDC', 'TCIA'}	2
-6V2F-2	{'SR', nan}	{'IDC-IDC_qiba_ct_1c', 'TCIA-qiba-ct-1c'}	{'IDC', 'TCIA'}	2
-RT BREAST/GAD	{'MR', nan}	{'IDC-IDC_acrin_contralateral_breast_mr', 'TCIA-acrin-contralateral-breast-mr'}	{'IDC', 'TCIA'}	2
-RT Breast Study	{'MR', nan}	{'IDC-IDC_acrin_contralateral_breast_mr', 'TCIA-acrin-contralateral-breast-mr'}	{'IDC', 'TCIA'}	2
-RT HIP & L3 SBRT	{'CT', nan}	{'TCIA-spine-mets-ct-seg', 'IDC-IDC_spine_mets_ct_seg'}	{'IDC', 'TCIA'}	2
-RT LUNG	{'RTSTRUCT', 'CT'}	{'IDC-IDC_lctsc'}	{'IDC'}	2
-RT LUNG BX	{'CT', nan}	{'TCIA-tcga-luad', 'IDC-IDC_tcga_luad'}	{'IDC', 'TCIA'}	2
-RT-BREAST	{'MR', nan}	{'IDC-IDC_acrin_contralateral_breast_mr', 'TCIA-acrin-contralateral-breast-mr'}	{'IDC', 'TCIA'}	2
-RIGHT THIGH C+	{'RTSTRUCT', nan}	{'IDC-IDC_soft_tissue_sarcoma', 'TCIA-soft-tissue-sarcoma'}	{'IDC', 'TCIA'}	2
-RIGHT MAMMO DIGITAL TOMOSYNTHESIS DIAGNOSTIC	{'MG'}	{'ACRdart-EA1141Restricted'}	{'ACRdart'}	2
-1V4E-2	{'SR', nan}	{'IDC-IDC_qiba_ct_1c', 'TCIA-qiba-ct-1c'}	{'IDC', 'TCIA'}	2
-6V2D-2	{'SR', nan}	{'IDC-IDC_qiba_ct_1c', 'TCIA-qiba-ct-1c'}	{'IDC', 'TCIA'}	2
-RESEARCH BREAST	{'MR', nan}	{'IDC-IDC_acrin_contralateral_breast_mr', 'TCIA-acrin-contralateral-breast-mr'}	{'IDC', 'TCIA'}	2
-6V4A-2	{'SR', nan}	{'IDC-IDC_qiba_ct_1c', 'TCIA-qiba-ct-1c'}	{'IDC', 'TCIA'}	2
-6V4A-1	{'SR', nan}	{'IDC-IDC_qiba_ct_1c', 'TCIA-qiba-ct-1c'}	{'IDC', 'TCIA'}	2
-RESEARCH-ACRIN6667	{'MR', nan}	{'IDC-IDC_acrin_contralateral_breast_mr', 'TCIA-acrin-contralateral-breast-mr'}	{'IDC', 'TCIA'}	2
-6V3F-2	{'SR', nan}	{'IDC-IDC_qiba_ct_1c', 'TCIA-qiba-ct-1c'}	{'IDC', 'TCIA'}	2
-6V3E-2	{'SR', nan}	{'IDC-IDC_qiba_ct_1c', 'TCIA-qiba-ct-1c'}	{'IDC', 'TCIA'}	2
-RESSONANCIA MAGNETICA ABDOME INFERIOR	{'MR', nan}	{'IDC-IDC_tcga_cesc', 'TCIA-tcga-cesc'}	{'IDC', 'TCIA'}	2
-RIGHT LUNG	{'RTSTRUCT', 'CT'}	{'IDC-IDC_lctsc'}	{'IDC'}	2
-6V3E-1	{'SR', nan}	{'IDC-IDC_qiba_ct_1c', 'TCIA-qiba-ct-1c'}	{'IDC', 'TCIA'}	2
-6V3D-2	{'SR', nan}	{'IDC-IDC_qiba_ct_1c', 'TCIA-qiba-ct-1c'}	{'IDC', 'TCIA'}	2
-1V4E-1	{'SR', nan}	{'IDC-IDC_qiba_ct_1c', 'TCIA-qiba-ct-1c'}	{'IDC', 'TCIA'}	2
-RIBS - UNILATERAL NO CHEST-CS	{'DX'}	{'MIDRC-Open-A1'}	{'MIDRC'}	2
-6V2E-1	{'SR', nan}	{'IDC-IDC_qiba_ct_1c', 'TCIA-qiba-ct-1c'}	{'IDC', 'TCIA'}	2
-6V3D-1	{'SR', nan}	{'IDC-IDC_qiba_ct_1c', 'TCIA-qiba-ct-1c'}	{'IDC', 'TCIA'}	2
-6V5B-1	{'SR', nan}	{'IDC-IDC_qiba_ct_1c', 'TCIA-qiba-ct-1c'}	{'IDC', 'TCIA'}	2
-6V5B-2	{'SR', nan}	{'IDC-IDC_qiba_ct_1c', 'TCIA-qiba-ct-1c'}	{'IDC', 'TCIA'}	2
-6V5C-1	{'SR', nan}	{'IDC-IDC_qiba_ct_1c', 'TCIA-qiba-ct-1c'}	{'IDC', 'TCIA'}	2
-7V1A-1	{'SR', nan}	{'IDC-IDC_qiba_ct_1c', 'TCIA-qiba-ct-1c'}	{'IDC', 'TCIA'}	2
-7V1F-2	{'SR', nan}	{'IDC-IDC_qiba_ct_1c', 'TCIA-qiba-ct-1c'}	{'IDC', 'TCIA'}	2
-7V1E-2	{'SR', nan}	{'IDC-IDC_qiba_ct_1c', 'TCIA-qiba-ct-1c'}	{'IDC', 'TCIA'}	2
-PET^1PETCT_LUNG_RTP (Adult)	{'SEG', nan}	{'TCIA-acrin-nsclc-fdg-pet', 'IDC-IDC_acrin_nsclc_fdg_pet'}	{'IDC', 'TCIA'}	2
-7V1E-1	{'SR', nan}	{'IDC-IDC_qiba_ct_1c', 'TCIA-qiba-ct-1c'}	{'IDC', 'TCIA'}	2
-7V1D-2	{'SR', nan}	{'IDC-IDC_qiba_ct_1c', 'TCIA-qiba-ct-1c'}	{'IDC', 'TCIA'}	2
-PET^1_PETCT_cerv_WB_CAUDCRAN (Adult)	{'PT', nan}	{'IDC-IDC_cc_tumor_heterogeneity', 'TCIA-cc-tumor-heterogeneity'}	{'IDC', 'TCIA'}	2
-6V2C-1	{'SR', nan}	{'IDC-IDC_qiba_ct_1c', 'TCIA-qiba-ct-1c'}	{'IDC', 'TCIA'}	2
-7V1D-1	{'SR', nan}	{'IDC-IDC_qiba_ct_1c', 'TCIA-qiba-ct-1c'}	{'IDC', 'TCIA'}	2
-7V1C-2	{'SR', nan}	{'IDC-IDC_qiba_ct_1c', 'TCIA-qiba-ct-1c'}	{'IDC', 'TCIA'}	2
-1V4C-2	{'SR', nan}	{'IDC-IDC_qiba_ct_1c', 'TCIA-qiba-ct-1c'}	{'IDC', 'TCIA'}	2
-7V1C-1	{'SR', nan}	{'IDC-IDC_qiba_ct_1c', 'TCIA-qiba-ct-1c'}	{'IDC', 'TCIA'}	2
-7V1B-2	{'SR', nan}	{'IDC-IDC_qiba_ct_1c', 'TCIA-qiba-ct-1c'}	{'IDC', 'TCIA'}	2
-7V1B-1	{'SR', nan}	{'IDC-IDC_qiba_ct_1c', 'TCIA-qiba-ct-1c'}	{'IDC', 'TCIA'}	2
-7V1A-2	{'SR', nan}	{'IDC-IDC_qiba_ct_1c', 'TCIA-qiba-ct-1c'}	{'IDC', 'TCIA'}	2
-PET^PETCT_AC_WB_VEN_LHR (Adult)	{'CT', nan}	{'IDC-IDC_cptac_sar', 'TCIA-cptac-sar'}	{'IDC', 'TCIA'}	2
-7V2A-1	{'SR', nan}	{'IDC-IDC_qiba_ct_1c', 'TCIA-qiba-ct-1c'}	{'IDC', 'TCIA'}	2
-7V2A-2	{'SR', nan}	{'IDC-IDC_qiba_ct_1c', 'TCIA-qiba-ct-1c'}	{'IDC', 'TCIA'}	2
-7V2B-1	{'SR', nan}	{'IDC-IDC_qiba_ct_1c', 'TCIA-qiba-ct-1c'}	{'IDC', 'TCIA'}	2
-ABD LIVER PROTOCOL	{'SEG', nan}	{'IDC-IDC_hcc_tace_seg', 'TCIA-hcc-tace-seg'}	{'IDC', 'TCIA'}	2
-7V3A-2	{'SR', nan}	{'IDC-IDC_qiba_ct_1c', 'TCIA-qiba-ct-1c'}	{'IDC', 'TCIA'}	2
-6V2B-2	{'SR', nan}	{'IDC-IDC_qiba_ct_1c', 'TCIA-qiba-ct-1c'}	{'IDC', 'TCIA'}	2
-_t7of7External Images for PACS	{'MR', nan}	{'IDC-IDC_vestibular_schwannoma_mc_rc', 'TCIA-vestibular-schwannoma-mc-rc'}	{'IDC', 'TCIA'}	2
-7V3A-1	{'SR', nan}	{'IDC-IDC_qiba_ct_1c', 'TCIA-qiba-ct-1c'}	{'IDC', 'TCIA'}	2
-7V2F-2	{'SR', nan}	{'IDC-IDC_qiba_ct_1c', 'TCIA-qiba-ct-1c'}	{'IDC', 'TCIA'}	2
-7V2E-2	{'SR', nan}	{'IDC-IDC_qiba_ct_1c', 'TCIA-qiba-ct-1c'}	{'IDC', 'TCIA'}	2
-7V2E-1	{'SR', nan}	{'IDC-IDC_qiba_ct_1c', 'TCIA-qiba-ct-1c'}	{'IDC', 'TCIA'}	2
-7V2B-2	{'SR', nan}	{'IDC-IDC_qiba_ct_1c', 'TCIA-qiba-ct-1c'}	{'IDC', 'TCIA'}	2
-7V2D-2	{'SR', nan}	{'IDC-IDC_qiba_ct_1c', 'TCIA-qiba-ct-1c'}	{'IDC', 'TCIA'}	2
-_t7of7 MRI IAMS	{'MR', nan}	{'IDC-IDC_vestibular_schwannoma_mc_rc', 'TCIA-vestibular-schwannoma-mc-rc'}	{'IDC', 'TCIA'}	2
-7V2D-1	{'SR', nan}	{'IDC-IDC_qiba_ct_1c', 'TCIA-qiba-ct-1c'}	{'IDC', 'TCIA'}	2
-_t7of7  MRI Stereo Gamma Knife	{'MR', nan}	{'IDC-IDC_vestibular_schwannoma_mc_rc', 'TCIA-vestibular-schwannoma-mc-rc'}	{'IDC', 'TCIA'}	2
-7V2C-2	{'SR', nan}	{'IDC-IDC_qiba_ct_1c', 'TCIA-qiba-ct-1c'}	{'IDC', 'TCIA'}	2
-7V2C-1	{'SR', nan}	{'IDC-IDC_qiba_ct_1c', 'TCIA-qiba-ct-1c'}	{'IDC', 'TCIA'}	2
-PET^PETCT_WholeBody (Adult)	{'SEG', nan}	{'TCIA-acrin-nsclc-fdg-pet', 'IDC-IDC_acrin_nsclc_fdg_pet'}	{'IDC', 'TCIA'}	2
-74160 CT ABDOMEN W	{'CT', nan}	{'TCIA-tcga-ucec', 'IDC-IDC_tcga_ucec'}	{'IDC', 'TCIA'}	2
-Pancreas/Liver DIBH 2mm	{'CT', nan}	{'IDC-IDC_pancreatic_ct_cbct_seg', 'TCIA-pancreatic-ct-cbct-seg'}	{'IDC', 'TCIA'}	2
-6V6F-2	{'SR', nan}	{'IDC-IDC_qiba_ct_1c', 'TCIA-qiba-ct-1c'}	{'IDC', 'TCIA'}	2
-PROSTATE FOSSA	{'CT', nan}	{'IDC-IDC_pelvic_reference_data', 'TCIA-pelvic-reference-data'}	{'IDC', 'TCIA'}	2
-PROSTATE RE-SIM	{'CT', nan}	{'IDC-IDC_pelvic_reference_data', 'TCIA-pelvic-reference-data'}	{'IDC', 'TCIA'}	2
-PROSTATE W/URETHRO	{'CT', nan}	{'IDC-IDC_pelvic_reference_data', 'TCIA-pelvic-reference-data'}	{'IDC', 'TCIA'}	2
-6V6A-2	{'SR', nan}	{'IDC-IDC_qiba_ct_1c', 'TCIA-qiba-ct-1c'}	{'IDC', 'TCIA'}	2
-PROSTATE/PELVIS	{'CT', nan}	{'IDC-IDC_pelvic_reference_data', 'TCIA-pelvic-reference-data'}	{'IDC', 'TCIA'}	2
-6V6A-1	{'SR', nan}	{'IDC-IDC_qiba_ct_1c', 'TCIA-qiba-ct-1c'}	{'IDC', 'TCIA'}	2
-6V5F-2	{'SR', nan}	{'IDC-IDC_qiba_ct_1c', 'TCIA-qiba-ct-1c'}	{'IDC', 'TCIA'}	2
-6V5E-2	{'SR', nan}	{'IDC-IDC_qiba_ct_1c', 'TCIA-qiba-ct-1c'}	{'IDC', 'TCIA'}	2
-6V5E-1	{'SR', nan}	{'IDC-IDC_qiba_ct_1c', 'TCIA-qiba-ct-1c'}	{'IDC', 'TCIA'}	2
-6V5D-2	{'SR', nan}	{'IDC-IDC_qiba_ct_1c', 'TCIA-qiba-ct-1c'}	{'IDC', 'TCIA'}	2
-_t6of6_MRI HEAD	{'MR', nan}	{'IDC-IDC_vestibular_schwannoma_mc_rc', 'TCIA-vestibular-schwannoma-mc-rc'}	{'IDC', 'TCIA'}	2
-PYELOGRAM, IV W/TOMO	{'DX', nan}	{'IDC-IDC_tcga_blca', 'TCIA-tcga-blca'}	{'IDC', 'TCIA'}	2
-_t6of6MRI IAMS	{'MR', nan}	{'IDC-IDC_vestibular_schwannoma_mc_rc', 'TCIA-vestibular-schwannoma-mc-rc'}	{'IDC', 'TCIA'}	2
-6V5D-1	{'SR', nan}	{'IDC-IDC_qiba_ct_1c', 'TCIA-qiba-ct-1c'}	{'IDC', 'TCIA'}	2
-6V5C-2	{'SR', nan}	{'IDC-IDC_qiba_ct_1c', 'TCIA-qiba-ct-1c'}	{'IDC', 'TCIA'}	2
-6V6B-1	{'SR', nan}	{'IDC-IDC_qiba_ct_1c', 'TCIA-qiba-ct-1c'}	{'IDC', 'TCIA'}	2
-6V6B-2	{'SR', nan}	{'IDC-IDC_qiba_ct_1c', 'TCIA-qiba-ct-1c'}	{'IDC', 'TCIA'}	2
-6V6C-1	{'SR', nan}	{'IDC-IDC_qiba_ct_1c', 'TCIA-qiba-ct-1c'}	{'IDC', 'TCIA'}	2
-PP CT CHEST WITH CONTR	{'CT', nan}	{'TCIA-acrin-nsclc-fdg-pet', 'IDC-IDC_acrin_nsclc_fdg_pet'}	{'IDC', 'TCIA'}	2
-_t7of7  External Images for PACS	{'MR', nan}	{'IDC-IDC_vestibular_schwannoma_mc_rc', 'TCIA-vestibular-schwannoma-mc-rc'}	{'IDC', 'TCIA'}	2
-PORTABLE CHEST 1 VIEW	{'DX'}	{'MIDRC-Open-A1_SCCM_VIRUS', 'MIDRC-Open-R1'}	{'MIDRC'}	2
-PORTABLE CXR PICC PLMT	{'CR'}	{'MIDRC-Open-R1'}	{'MIDRC'}	2
-6V6E-2	{'SR', nan}	{'IDC-IDC_qiba_ct_1c', 'TCIA-qiba-ct-1c'}	{'IDC', 'TCIA'}	2
-6V6E-1	{'SR', nan}	{'IDC-IDC_qiba_ct_1c', 'TCIA-qiba-ct-1c'}	{'IDC', 'TCIA'}	2
-PP CT CHEST ABDOMEN W	{'CT', nan}	{'TCIA-acrin-nsclc-fdg-pet', 'IDC-IDC_acrin_nsclc_fdg_pet'}	{'IDC', 'TCIA'}	2
-6V6D-2	{'SR', nan}	{'IDC-IDC_qiba_ct_1c', 'TCIA-qiba-ct-1c'}	{'IDC', 'TCIA'}	2
-6V6C-2	{'SR', nan}	{'IDC-IDC_qiba_ct_1c', 'TCIA-qiba-ct-1c'}	{'IDC', 'TCIA'}	2
-PRE CHEST	{'SEG', nan}	{'TCIA-lidc-idri', 'IDC-IDC_lidc_idri'}	{'IDC', 'TCIA'}	2
-_t6of6_MRI IAMS	{'MR', nan}	{'IDC-IDC_vestibular_schwannoma_mc_rc', 'TCIA-vestibular-schwannoma-mc-rc'}	{'IDC', 'TCIA'}	2
-_t6of6_MRI HEAD WITH CONTRAST	{'MR', nan}	{'IDC-IDC_vestibular_schwannoma_mc_rc', 'TCIA-vestibular-schwannoma-mc-rc'}	{'IDC', 'TCIA'}	2
-6V6D-1	{'SR', nan}	{'IDC-IDC_qiba_ct_1c', 'TCIA-qiba-ct-1c'}	{'IDC', 'TCIA'}	2
-PRONE	{'SEG', nan}	{'IDC-IDC_qin_breast', 'TCIA-qin-breast'}	{'IDC', 'TCIA'}	2
-PRONE ANUS	{'CT', nan}	{'IDC-IDC_pelvic_reference_data', 'TCIA-pelvic-reference-data'}	{'IDC', 'TCIA'}	2
-ascities	{'CT', nan}	{'TCIA-tcga-ov', 'IDC-IDC_tcga_ov'}	{'IDC', 'TCIA'}	2
-ABD PEL NO IV	{'CT', nan}	{'IDC-IDC_tcga_blca', 'TCIA-tcga-blca'}	{'IDC', 'TCIA'}	2
-brain	{'MR', nan}	{'IDC-IDC_icdc_glioma', 'TCIA-icdc-glioma'}	{'IDC', 'TCIA'}	2
-MRI LT LEG +C	{'MR', nan}	{'IDC-IDC_soft_tissue_sarcoma', 'TCIA-soft-tissue-sarcoma'}	{'IDC', 'TCIA'}	2
-MRI LIVER ELASTOGRAPHY W/O	{'MR', nan}	{'TCIA-tcga-lihc', 'IDC-IDC_tcga_lihc'}	{'IDC', 'TCIA'}	2
-MRI LOWER EXTREMITY NOT JOINT WITH CONTRAST LEFT	{'MR', nan}	{'IDC-IDC_cptac_sar', 'TCIA-cptac-sar'}	{'IDC', 'TCIA'}	2
-hot spheres with water	{'PT', nan}	{'IDC-IDC_rider_lung_pet_ct', 'TCIA-rider-lung-pet-ct'}	{'IDC', 'TCIA'}	2
-MRI LOWER EXTREMITY NOT JOINT WITH CONTRAST RIGHT	{'MR', nan}	{'IDC-IDC_cptac_sar', 'TCIA-cptac-sar'}	{'IDC', 'TCIA'}	2
-Abdomen^03_7_Kidney_Biphase_Post_Nephrectomy (Adult)	{'CT', nan}	{'TCIA-tcga-kirc', 'IDC-IDC_tcga_kirc'}	{'IDC', 'TCIA'}	2
-MRI LOWER EXTREMITY W/WO CONT	{'MR', nan}	{'IDC-IDC_tcga_sarc', 'TCIA-tcga-sarc'}	{'IDC', 'TCIA'}	2
-MRI LT BREAST	{'MR', nan}	{'IDC-IDC_acrin_contralateral_breast_mr', 'TCIA-acrin-contralateral-breast-mr'}	{'IDC', 'TCIA'}	2
-Abdomen^03_7_Kidney_Biphase (Adult)	{'CT', nan}	{'TCIA-tcga-kirc', 'IDC-IDC_tcga_kirc'}	{'IDC', 'TCIA'}	2
-PET CT	{'RTSTRUCT', nan}	{'IDC-IDC_soft_tissue_sarcoma', 'TCIA-soft-tissue-sarcoma'}	{'IDC', 'TCIA'}	2
-hernia	{'CT', nan}	{'TCIA-tcga-kirc', 'IDC-IDC_tcga_kirc'}	{'IDC', 'TCIA'}	2
-head^general	{'MR', nan}	{'IDC-IDC_icdc_glioma', 'TCIA-icdc-glioma'}	{'IDC', 'TCIA'}	2
-he/37280	{'MR', nan}	{'TCIA-tcga-lihc', 'IDC-IDC_tcga_lihc'}	{'IDC', 'TCIA'}	2
-CT CHEST  NO IV	{'SEG', nan}	{'TCIA-lidc-idri', 'IDC-IDC_lidc_idri'}	{'IDC', 'TCIA'}	2
-MRI OF BLADDER	{'MR', nan}	{'IDC-IDC_tcga_blca', 'TCIA-tcga-blca'}	{'IDC', 'TCIA'}	2
-Abdomen^02_0_Abdomen_Pelvis (Adult)	{'CT', nan}	{'TCIA-tcga-ucec', 'IDC-IDC_tcga_ucec'}	{'IDC', 'TCIA'}	2
-1V1E-1	{'SR', nan}	{'IDC-IDC_qiba_ct_1c', 'TCIA-qiba-ct-1c'}	{'IDC', 'TCIA'}	2
-Abdomen^03_LARGE_ABD_PELVIS (Adult)	{'CT', nan}	{'TCIA-tcga-ov', 'IDC-IDC_tcga_ov'}	{'IDC', 'TCIA'}	2
-kidney ca	{'CT', nan}	{'TCIA-tcga-kirc', 'IDC-IDC_tcga_kirc'}	{'IDC', 'TCIA'}	2
-lt hemorrahagic cyst	{'CT', nan}	{'TCIA-tcga-ucec', 'IDC-IDC_tcga_ucec'}	{'IDC', 'TCIA'}	2
-Abdomen^06CTAAbdomenPostEVT (Adult)	{'CT', nan}	{'TCIA-tcga-kirc', 'IDC-IDC_tcga_kirc'}	{'IDC', 'TCIA'}	2
-Abdomen^12_9_Liver_HCC (Adult)	{'SEG', nan}	{'TCIA-tcga-lihc', 'IDC-IDC_tcga_lihc'}	{'IDC', 'TCIA'}	2
-Abdomen^12_5_Liver_Post_Ablation (Adult)	{'CT', nan}	{'TCIA-tcga-lihc', 'IDC-IDC_tcga_lihc'}	{'IDC', 'TCIA'}	2
-1V1C-2	{'SR', nan}	{'IDC-IDC_qiba_ct_1c', 'TCIA-qiba-ct-1c'}	{'IDC', 'TCIA'}	2
-Abdomen^10_LOW_DOSE_STONE_STUDY (Adult)	{'CT'}	{'MIDRC-Open-A1'}	{'MIDRC'}	2
-MRI ELBOW W/O CONTRAST-RIGHT	{'MR'}	{'MIDRC-Open-A1'}	{'MIDRC'}	2
-1V1D-1	{'SR', nan}	{'IDC-IDC_qiba_ct_1c', 'TCIA-qiba-ct-1c'}	{'IDC', 'TCIA'}	2
-lung+C	{'CT', nan}	{'IDC-IDC_lung_pet_ct_dx', 'TCIA-lung-pet-ct-dx'}	{'IDC', 'TCIA'}	2
-lung bx	{'CT', nan}	{'TCIA-tcga-luad', 'IDC-IDC_tcga_luad'}	{'IDC', 'TCIA'}	2
-MRI EXTREMITIES WITHOU AND WITH CONTRAST - LEFT	{'RTSTRUCT', nan}	{'IDC-IDC_soft_tissue_sarcoma', 'TCIA-soft-tissue-sarcoma'}	{'IDC', 'TCIA'}	2
-lung biopsy	{'CT', nan}	{'TCIA-tcga-luad', 'IDC-IDC_tcga_luad'}	{'IDC', 'TCIA'}	2
-Abdomen^08_Kidney_MultiPhase (Adult)	{'SEG', nan}	{'TCIA-cptac-ccrcc', 'IDC-IDC_cptac_ccrcc'}	{'IDC', 'TCIA'}	2
-Abdomen^08_3_Type_I_Dose_Saving (Adult)	{'CT', nan}	{'TCIA-tcga-ucec', 'IDC-IDC_tcga_ucec'}	{'IDC', 'TCIA'}	2
-1V1D-2	{'SR', nan}	{'IDC-IDC_qiba_ct_1c', 'TCIA-qiba-ct-1c'}	{'IDC', 'TCIA'}	2
-Abdomen^08_3_Type_I_CTU_Dose_Saving (Adult)	{'CT', nan}	{'TCIA-tcga-kirc', 'IDC-IDC_tcga_kirc'}	{'IDC', 'TCIA'}	2
-lt. renal mass,? bleed	{'CT', nan}	{'TCIA-tcga-ucec', 'IDC-IDC_tcga_ucec'}	{'IDC', 'TCIA'}	2
-MRI PELVIS C- C	{'RTSTRUCT', nan}	{'IDC-IDC_soft_tissue_sarcoma', 'TCIA-soft-tissue-sarcoma'}	{'IDC', 'TCIA'}	2
-MRI PELVIS SOFT TISSUE WO/W CONTRAST	{'MR'}	{'MIDRC-Open-A1'}	{'MIDRC'}	2
-e-1 PET/CT CHEST	{'SEG', nan}	{'TCIA-tcga-luad', 'IDC-IDC_tcga_luad'}	{'IDC', 'TCIA'}	2
-e+1 PET IMAGE W/CT, SKULL-	{'SEG', nan}	{'IDC-IDC_nsclc_radiogenomics', 'TCIA-nsclc-radiogenomics'}	{'IDC', 'TCIA'}	2
-e+1 MRI BREAST BILAT W-WO-RH	{'SEG', nan}	{'TCIA-duke-breast-cancer-mri', 'IDC-IDC_duke_breast_cancer_mri'}	{'IDC', 'TCIA'}	2
-MRI Pelvis w/ + w/o Contrast	{'MR'}	{'ACRdart-ACRIN_6701'}	{'ACRdart'}	2
-e+1 MRI BREAST ABBREVIATED BILATERAL W/WO CONTRAST	{'MR'}	{'ACRdart-EA1141Restricted', 'IDC-IDC_ea1141'}	{'ACRdart', 'IDC'}	2
-Abdomen^004 Chest-Abd-Pelvis	{'CT', nan}	{'TCIA-tcga-ov', 'IDC-IDC_tcga_ov'}	{'IDC', 'TCIA'}	2
-Abdomen^0 ABDOMEN	{'CT', nan}	{'TCIA-acrin-nsclc-fdg-pet', 'IDC-IDC_acrin_nsclc_fdg_pet'}	{'IDC', 'TCIA'}	2
-Abdomen/Pelvis W/WO	{'CT', nan}	{'IDC-IDC_tcga_blca', 'TCIA-tcga-blca'}	{'IDC', 'TCIA'}	2
-MRI Prostate w+wo	{'MR'}	{'ACRdart-ACRIN_6701'}	{'ACRdart'}	2
-MRI RENAL W/WO CONTRAST	{'MR', nan}	{'IDC-IDC_tcga_kirp', 'TCIA-tcga-kirp'}	{'IDC', 'TCIA'}	2
-Abdomen 3 phase	{'RTSTRUCT', nan}	{'IDC-IDC_cptac_ucec', 'TCIA-cptac-ucec'}	{'IDC', 'TCIA'}	2
-MRI RT THIGH	{'RTSTRUCT', nan}	{'IDC-IDC_soft_tissue_sarcoma', 'TCIA-soft-tissue-sarcoma'}	{'IDC', 'TCIA'}	2
-MRI RT THIGH +C	{'MR', nan}	{'IDC-IDC_soft_tissue_sarcoma', 'TCIA-soft-tissue-sarcoma'}	{'IDC', 'TCIA'}	2
-ANONYMIZED	{'CT', nan}	{'TCIA-spine-mets-ct-seg', 'IDC-IDC_spine_mets_ct_seg'}	{'IDC', 'TCIA'}	2
-ANKLE RIGHT MIN 3 VIEWS	{'CR', 'DX'}	{'MIDRC-Open-R1'}	{'MIDRC'}	2
-e+1 MRI 3D REFORMATION NON INDEPENDENT WORKSTATION	{'SEG', nan}	{'TCIA-duke-breast-cancer-mri', 'IDC-IDC_duke_breast_cancer_mri'}	{'IDC', 'TCIA'}	2
-ANKLE RIGHT 3 VIEWS (WEIGHT BEARING)	{'CR'}	{'MIDRC-Open-R1'}	{'MIDRC'}	2
-Abdomen^01AP_Routine (Adult)	{'CT', nan}	{'TCIA-tcga-ov', 'IDC-IDC_tcga_ov'}	{'IDC', 'TCIA'}	2
-MRI PROSTATE WO CONTRAST	{'SEG'}	{'IDC-IDC_prostate_mri_us_biopsy'}	{'IDC'}	2
-MRI PELVIS W&W/O CONTR	{'MR', nan}	{'TCIA-tcga-ucec', 'IDC-IDC_tcga_ucec'}	{'IDC', 'TCIA'}	2
-MRI PROSTATE WITHOUT CONTRAST	{'MR', nan}	{'IDC-IDC_prostate_diagnosis', 'TCIA-prostate-diagnosis'}	{'IDC', 'TCIA'}	2
-Abdomen^02 Chest-Abd-Pelvis 1	{'CT', nan}	{'TCIA-tcga-ov', 'IDC-IDC_tcga_ov'}	{'IDC', 'TCIA'}	2
-e-1	{'PT', nan}	{'IDC-IDC_rider_lung_pet_ct', 'TCIA-rider-lung-pet-ct'}	{'IDC', 'TCIA'}	2
-MRI PELVIS WO CONT	{'MR', nan}	{'TCIA-tcga-kirc', 'IDC-IDC_tcga_kirc'}	{'IDC', 'TCIA'}	2
-MRI PELVIS WO/W	{'MR', nan}	{'TCIA-tcga-ucec', 'IDC-IDC_tcga_ucec'}	{'IDC', 'TCIA'}	2
-Abdomen^02 Chest-Abd 1	{'CT', nan}	{'TCIA-acrin-nsclc-fdg-pet', 'IDC-IDC_acrin_nsclc_fdg_pet'}	{'IDC', 'TCIA'}	2
-MRI PELVIS WW CON	{'SEG'}	{'IDC-IDC_prostate_mri_us_biopsy'}	{'IDC'}	2
-e+1 lung biopsy	{'CT', nan}	{'TCIA-tcga-luad', 'IDC-IDC_tcga_luad'}	{'IDC', 'TCIA'}	2
-e+1 lung	{'SEG', nan}	{'IDC-IDC_lung_pet_ct_dx', 'TCIA-lung-pet-ct-dx'}	{'IDC', 'TCIA'}	2
-Abdomen^01_LARGE_WB_PETCT	{'SEG', nan}	{'TCIA-acrin-nsclc-fdg-pet', 'IDC-IDC_acrin_nsclc_fdg_pet'}	{'IDC', 'TCIA'}	2
-e+1 PET/CT LUNG NODULE	{'CT', nan}	{'IDC-IDC_nsclc_radiogenomics', 'TCIA-nsclc-radiogenomics'}	{'IDC', 'TCIA'}	2
-MRI PERIANAL FISTULA WO/W CONTRAST	{'MR'}	{'MIDRC-Open-A1'}	{'MIDRC'}	2
-Abdomen^01_Abdomen_Pelvis (Adult)	{'CT', nan}	{'TCIA-tcga-ucec', 'IDC-IDC_tcga_ucec'}	{'IDC', 'TCIA'}	2
-Abdomen^01_AbdNative_and_Contrast (Adult)	{'SEG', nan}	{'TCIA-cptac-ccrcc', 'IDC-IDC_cptac_ccrcc'}	{'IDC', 'TCIA'}	2
-MRI PROSTATE WITH + WITHOUT IV CONTRAST	{'MR'}	{'ACRdart-ACRIN_6701'}	{'ACRdart'}	2
-Abdomen^01_ABDOMENBIOPSY (Adult)	{'CT', nan}	{'IDC-IDC_tcga_blca', 'TCIA-tcga-blca'}	{'IDC', 'TCIA'}	2
-lung+ccc	{'SEG', nan}	{'IDC-IDC_lung_pet_ct_dx', 'TCIA-lung-pet-ct-dx'}	{'IDC', 'TCIA'}	2
-1V1C-1	{'SR', nan}	{'IDC-IDC_qiba_ct_1c', 'TCIA-qiba-ct-1c'}	{'IDC', 'TCIA'}	2
-Abdomen^12_9_Liver_HCC_Triphase (Adult)	{'SEG', nan}	{'TCIA-tcga-lihc', 'IDC-IDC_tcga_lihc'}	{'IDC', 'TCIA'}	2
-*CT CHEST	{'CT', nan}	{'TCIA-tcga-ov', 'IDC-IDC_tcga_ov'}	{'IDC', 'TCIA'}	2
-Abdomen^CTA_ILLIOFEMORAL_RUN_OFF (Adult)	{'CT'}	{'MIDRC-Open-A1'}	{'MIDRC'}	2
-Abdomen^CTA_ABD_PELVIS_ (Adult)	{'CT'}	{'MIDRC-Open-A1'}	{'MIDRC'}	2
-Abdomen^BRZUCH_MIEDNICA (Adult)	{'RTSTRUCT', nan}	{'TCIA-cptac-pda', 'IDC-IDC_cptac_pda'}	{'IDC', 'TCIA'}	2
-Abdomen^BRZUCH_BOLUS_FAZA_TRZUSTKA (Adult)	{'RTSTRUCT', nan}	{'TCIA-cptac-pda', 'IDC-IDC_cptac_pda'}	{'IDC', 'TCIA'}	2
-Abdomen^BRZUCH_BOLUS (Adult)	{'RTSTRUCT', nan}	{'TCIA-cptac-pda', 'IDC-IDC_cptac_pda'}	{'IDC', 'TCIA'}	2
-MRI BREAST BILATERAL W & W/O	{'SEG', nan}	{'TCIA-duke-breast-cancer-mri', 'IDC-IDC_duke_breast_cancer_mri'}	{'IDC', 'TCIA'}	2
-MRI BREAST BILATERAL W & WO	{'MR', nan}	{'TCIA-duke-breast-cancer-mri', 'IDC-IDC_duke_breast_cancer_mri'}	{'IDC', 'TCIA'}	2
-Abdomen^AVERAGE_ABD_PELVIS_WITHOUT_IV_CONTRAST (Adult)	{nan}	{'TCIA-varepop-apollo'}	{'TCIA'}	2
-Abdomen^ACRIN_COLON_12 (Adult)	{'CT', nan}	{'TCIA-ct-colonography', 'IDC-IDC_ct_colonography'}	{'IDC', 'TCIA'}	2
-testCTACw75ccContrast	{'CT', nan}	{'IDC-IDC_rider_lung_pet_ct', 'TCIA-rider-lung-pet-ct'}	{'IDC', 'TCIA'}	2
-MRI BREAST BILATERAL W/ & WO	{'SEG', nan}	{'TCIA-duke-breast-cancer-mri', 'IDC-IDC_duke_breast_cancer_mri'}	{'IDC', 'TCIA'}	2
-Abdomen^ACRIN COLON (Adult)	{'CT', nan}	{'TCIA-ct-colonography', 'IDC-IDC_ct_colonography'}	{'IDC', 'TCIA'}	2
-Abdomen^ABD_WO_W (Adult)	{'SEG', nan}	{'TCIA-adrenal-acc-ki67-seg', 'IDC-IDC_adrenal_acc_ki67_seg'}	{'IDC', 'TCIA'}	2
-testCTACw35ccContrast	{'PT', nan}	{'IDC-IDC_rider_lung_pet_ct', 'TCIA-rider-lung-pet-ct'}	{'IDC', 'TCIA'}	2
-Abdomen^ABD_TRIPHASIC_KIDNEYS (Adult)	{'CT', nan}	{'IDC-IDC_tcga_blca', 'TCIA-tcga-blca'}	{'IDC', 'TCIA'}	2
-MRI BREAST BILAT W-WO	{'SEG', nan}	{'TCIA-duke-breast-cancer-mri', 'IDC-IDC_duke_breast_cancer_mri'}	{'IDC', 'TCIA'}	2
-MRI BREAST BILAT PRE&POMR	{'MR'}	{'IDC-IDC_ispy1'}	{'IDC'}	2
-MRI BREAST BIOPSY UNILATERAL WITH CONTRAST	{'MR', nan}	{'TCIA-breast-diagnosis', 'IDC-IDC_breast_diagnosis'}	{'IDC', 'TCIA'}	2
-two_phase__chest_abdomen	{'SEG', nan}	{'TCIA-c4kc-kits', 'IDC-IDC_c4kc_kits'}	{'IDC', 'TCIA'}	2
-Abdomen^ENTEROGRAPHY_GR (Adult)	{'CT'}	{'MIDRC-Open-A1'}	{'MIDRC'}	2
-Abdomen^ENTEROGRAPHY (Adult)	{'CT'}	{'MIDRC-Open-A1'}	{'MIDRC'}	2
-MRI BR BI W/INJ/MBBI	{'MR'}	{'IDC-IDC_ispy1'}	{'IDC'}	2
-Abdomen^DUAL_PHASE_PANC (Adult)	{'RTSTRUCT', nan}	{'TCIA-cptac-pda', 'IDC-IDC_cptac_pda'}	{'IDC', 'TCIA'}	2
-MRI BR UNILAT W&WO CONT LEFT	{'MR', 'SEG'}	{'IDC-IDC_ispy1'}	{'IDC'}	2
-MRI BRAIN	{'MR', nan}	{'TCIA-cmb-lca', 'IDC-IDC_cmb_lca'}	{'IDC', 'TCIA'}	2
-two_phase__chest_abdomen_pelvis	{'SEG', nan}	{'TCIA-c4kc-kits', 'IDC-IDC_c4kc_kits'}	{'IDC', 'TCIA'}	2
-Abdomen^Chest-Abd-Pelvis 1	{'CT', nan}	{'TCIA-tcga-ov', 'IDC-IDC_tcga_ov'}	{'IDC', 'TCIA'}	2
-MRI BRAIN, MRA BRAIN, MRA NECK - WITHOUT AND WITH CONTRAST	{'MR'}	{'MIDRC-Open-R1'}	{'MIDRC'}	2
-Abdomen^CYSTOGRAM (Adult)	{'CT'}	{'MIDRC-Open-A1'}	{'MIDRC'}	2
-Abdomen^CT_MARKS_CAILLAT_AP (Adult)	{'CT'}	{'MIDRC-Open-A1'}	{'MIDRC'}	2
-Abdomen^CT_CHST_ABD_PELVIS_WO_W_IVCON (Adult)	{'SEG', nan}	{'IDC-IDC_anti_pd_1_lung', 'TCIA-anti-pd-1_lung'}	{'IDC', 'TCIA'}	2
-MRI BREAST BIL ABBREVIATED W WO CONTRAST WO CAD	{'MR'}	{'IDC-IDC_ea1141'}	{'IDC'}	2
-MRI BREAST BIL WO W CONTRAST	{'MR', nan}	{'IDC-IDC_tcga_brca', 'TCIA-tcga-brca'}	{'IDC', 'TCIA'}	2
-MRI BREAST BIL WO/W CON	{'MR', nan}	{'IDC-IDC_tcga_brca', 'TCIA-tcga-brca'}	{'IDC', 'TCIA'}	2
-MRI BREAST BIOPSY RIGHT  1ST LESION	{'MR'}	{'ACRdart-EA1141Restricted', 'IDC-IDC_ea1141'}	{'ACRdart', 'IDC'}	2
-MRI BREAST BIOPSY UNILATERAL WITH WITHOUT CONTRAST	{'MR', nan}	{'TCIA-breast-diagnosis', 'IDC-IDC_breast_diagnosis'}	{'IDC', 'TCIA'}	2
-Abdomen^12_DE_ABD_N_CE_(Adult)	{'CT', nan}	{'IDC-IDC_ctpred_sunitinib_pannet', 'TCIA-ctpred-sunitinib-pannet'}	{'IDC', 'TCIA'}	2
-MRI BREAST, BILATERAL WITHOUT CONTRAST	{'MR', nan}	{'TCIA-breast-diagnosis', 'IDC-IDC_breast_diagnosis'}	{'IDC', 'TCIA'}	2
-pe/6516	{'MR', nan}	{'TCIA-tcga-kirc', 'IDC-IDC_tcga_kirc'}	{'IDC', 'TCIA'}	2
-MRI BREAST, UNILATERAL, WITH WITHOUT CONTRAST	{'MR'}	{'IDC-IDC_breast_diagnosis'}	{'IDC'}	2
-1V1A-1	{'SR', nan}	{'IDC-IDC_qiba_ct_1c', 'TCIA-qiba-ct-1c'}	{'IDC', 'TCIA'}	2
-1V1A-2	{'SR', nan}	{'IDC-IDC_qiba_ct_1c', 'TCIA-qiba-ct-1c'}	{'IDC', 'TCIA'}	2
-Abdomen^1VIRT_COLON_SUPINE (Adult)	{'CT', nan}	{'TCIA-ct-colonography', 'IDC-IDC_ct_colonography'}	{'IDC', 'TCIA'}	2
-Abdomen^1VIRT_COLON (Adult)	{'CT', nan}	{'TCIA-ct-colonography', 'IDC-IDC_ct_colonography'}	{'IDC', 'TCIA'}	2
-MRI Brain	{'MR', nan}	{'TCIA-cmb-lca', 'IDC-IDC_cmb_lca'}	{'IDC', 'TCIA'}	2
-MRI Breast Bilat W WO IV Contrast	{'MR'}	{'ACRdart-EA1141Restricted'}	{'ACRdart'}	2
-MRI Breast Bilateral	{'SEG', nan}	{'TCIA-duke-breast-cancer-mri', 'IDC-IDC_duke_breast_cancer_mri'}	{'IDC', 'TCIA'}	2
-Abdomen^1CA_AP_WC (Adult)	{'CT', nan}	{'TCIA-acrin-nsclc-fdg-pet', 'IDC-IDC_acrin_nsclc_fdg_pet'}	{'IDC', 'TCIA'}	2
-MRI Breast Bilateral without Contrast	{'MR', nan}	{'TCIA-breast-diagnosis', 'IDC-IDC_breast_diagnosis'}	{'IDC', 'TCIA'}	2
-1V1B-1	{'SR', nan}	{'IDC-IDC_qiba_ct_1c', 'TCIA-qiba-ct-1c'}	{'IDC', 'TCIA'}	2
-MRI Breast Biopsy	{'MR', nan}	{'IDC-IDC_tcga_brca', 'TCIA-tcga-brca'}	{'IDC', 'TCIA'}	2
-1V1B-2	{'SR', nan}	{'IDC-IDC_qiba_ct_1c', 'TCIA-qiba-ct-1c'}	{'IDC', 'TCIA'}	2
-MRI Breast w  wo Contrast Bilateral	{'MR'}	{'ACRdart-EA1141Restricted', 'IDC-IDC_ea1141'}	{'ACRdart', 'IDC'}	2
-pelvis^Pelvis (Y)	{'MR', nan}	{'IDC-IDC_cptac_sar', 'TCIA-cptac-sar'}	{'IDC', 'TCIA'}	2
-Abdomen^1_ABDOMEN_PELVIS_WITH (Adult)	{'CT', nan}	{'TCIA-tcga-ucec', 'IDC-IDC_tcga_ucec'}	{'IDC', 'TCIA'}	2
-MRI BREAST BX VAC CLIP 2 LSN RT WPPM SI	{'MR', nan}	{'IDC-IDC_tcga_brca', 'TCIA-tcga-brca'}	{'IDC', 'TCIA'}	2
-Abdomen^1_ABD_BMI_UNDER_30 (Adult)	{'RTSTRUCT', nan}	{'TCIA-cptac-ccrcc', 'IDC-IDC_cptac_ccrcc'}	{'IDC', 'TCIA'}	2
-MRI BREAST CORE BIOPSY	{'MR', nan}	{'IDC-IDC_acrin_contralateral_breast_mr', 'TCIA-acrin-contralateral-breast-mr'}	{'IDC', 'TCIA'}	2
-test CTAC radial trunc	{'PT', nan}	{'IDC-IDC_rider_lung_pet_ct', 'TCIA-rider-lung-pet-ct'}	{'IDC', 'TCIA'}	2
-Abdomen^ABDOME_4_FASES (Adult)	{'CT', nan}	{'IDC-IDC_tcga_blca', 'TCIA-tcga-blca'}	{'IDC', 'TCIA'}	2
-Abdomen^ABDOMEN_PELVIS_WO_WC (Adult)	{'CT', nan}	{'IDC-IDC_tcga_blca', 'TCIA-tcga-blca'}	{'IDC', 'TCIA'}	2
-Abdomen^ABDOMEN_4D (Adult)	{'CT', nan}	{'TCIA-spine-mets-ct-seg', 'IDC-IDC_spine_mets_ct_seg'}	{'IDC', 'TCIA'}	2
-post	{'PT', nan}	{'TCIA-acrin-nsclc-fdg-pet', 'IDC-IDC_acrin_nsclc_fdg_pet'}	{'IDC', 'TCIA'}	2
-06.Chest, Abdomen contrast	{'SEG', nan}	{'TCIA-cptac-ccrcc', 'IDC-IDC_cptac_ccrcc'}	{'IDC', 'TCIA'}	2
-Abdomen^23 COLON PRONE	{'CT', nan}	{'TCIA-ct-colonography', 'IDC-IDC_ct_colonography'}	{'IDC', 'TCIA'}	2
-MRI BREAST UNILA	{'MR', nan}	{'IDC-IDC_acrin_contralateral_breast_mr', 'TCIA-acrin-contralateral-breast-mr'}	{'IDC', 'TCIA'}	2
-MRI BREAST UNILATERAL W/WO	{'SEG', nan}	{'TCIA-duke-breast-cancer-mri', 'IDC-IDC_duke_breast_cancer_mri'}	{'IDC', 'TCIA'}	2
-MRI BREAST UNILATERAL WITH WITHOUT CONTRAST	{nan}	{'TCIA-breast-diagnosis'}	{'TCIA'}	2
-penqct	{'CT', nan}	{'IDC-IDC_stageii_colorectal_ct', 'TCIA-stageii-colorectal-ct'}	{'IDC', 'TCIA'}	2
-Abdomen^1_RENAL_WITH_IV (Adult)	{'CT', nan}	{'TCIA-tcga-ucec', 'IDC-IDC_tcga_ucec'}	{'IDC', 'TCIA'}	2
-pelvis_0001^MALYI TAZ	{'MR', nan}	{'IDC-IDC_cptac_sar', 'TCIA-cptac-sar'}	{'IDC', 'TCIA'}	2
-MRI BREAST W/WO + SUB + RECON	{'MR', nan}	{'IDC-IDC_tcga_brca', 'TCIA-tcga-brca'}	{'IDC', 'TCIA'}	2
-MRI SPINAL CANAL, LUMBAR WITHOUT CONTRAST	{'MR', nan}	{'TCIA-cptac-luad', 'IDC-IDC_cptac_luad'}	{'IDC', 'TCIA'}	2
-e+1 MR BREAST BILAT W AND W/O CONT-DR	{'SEG', nan}	{'TCIA-duke-breast-cancer-mri', 'IDC-IDC_duke_breast_cancer_mri'}	{'IDC', 'TCIA'}	2
-e+1 LEFT BREAST	{'MR', nan}	{'IDC-IDC_acrin_contralateral_breast_mr', 'TCIA-acrin-contralateral-breast-mr'}	{'IDC', 'TCIA'}	2
-OSF CT CHEST	{'CT', nan}	{'TCIA-tcga-kirc', 'IDC-IDC_tcga_kirc'}	{'IDC', 'TCIA'}	2
-OSI CT CHEST	{'SEG', nan}	{'IDC-IDC_anti_pd_1_lung', 'TCIA-anti-pd-1_lung'}	{'IDC', 'TCIA'}	2
-1V2C-2	{'SR', nan}	{'IDC-IDC_qiba_ct_1c', 'TCIA-qiba-ct-1c'}	{'IDC', 'TCIA'}	2
-ch.3d ao.cta	{'SEG', nan}	{'IDC-IDC_lung_pet_ct_dx', 'TCIA-lung-pet-ct-dx'}	{'IDC', 'TCIA'}	2
-ABDOMEN   PELVIS WITH CONTRAST	{'CT', nan}	{'TCIA-tcga-ucec', 'IDC-IDC_tcga_ucec'}	{'IDC', 'TCIA'}	2
-ABDOMEN   PELVIS W/O CONTRAST	{'CT', nan}	{'TCIA-tcga-ucec', 'IDC-IDC_tcga_ucec'}	{'IDC', 'TCIA'}	2
-OUTSIDE FILM CONSULTATION MAM	{'CR', nan}	{'IDC-IDC_acrin_contralateral_breast_mr', 'TCIA-acrin-contralateral-breast-mr'}	{'IDC', 'TCIA'}	2
-OVARIAN CA RESTAGING	{'CT', nan}	{'TCIA-tcga-ov', 'IDC-IDC_tcga_ov'}	{'IDC', 'TCIA'}	2
-OVARY CA,FATIGUE ?MASS	{'CT', nan}	{'TCIA-tcga-ov', 'IDC-IDC_tcga_ov'}	{'IDC', 'TCIA'}	2
-ABDOMEN   PELVIS W/CON	{'CT', nan}	{'TCIA-tcga-ucec', 'IDC-IDC_tcga_ucec'}	{'IDC', 'TCIA'}	2
-ABD/RENAL	{'SEG', nan}	{'TCIA-tcga-kirc', 'IDC-IDC_tcga_kirc'}	{'IDC', 'TCIA'}	2
-ch.3d	{'CT', nan}	{'IDC-IDC_lung_pet_ct_dx', 'TCIA-lung-pet-ct-dx'}	{'IDC', 'TCIA'}	2
-1V2D-1	{'SR', nan}	{'IDC-IDC_qiba_ct_1c', 'TCIA-qiba-ct-1c'}	{'IDC', 'TCIA'}	2
-Outside Read or Comparison BREAST MRI	{'MR', nan}	{'IDC-IDC_tcga_brca', 'TCIA-tcga-brca'}	{'IDC', 'TCIA'}	2
-ABD/PELVIS/ RENAL	{'SEG', nan}	{'TCIA-tcga-kirc', 'IDC-IDC_tcga_kirc'}	{'IDC', 'TCIA'}	2
-ABD/PELVIS/  LIVER	{'SEG', nan}	{'IDC-IDC_hcc_tace_seg', 'TCIA-hcc-tace-seg'}	{'IDC', 'TCIA'}	2
-OSI CT BRAIN	{'SEG', nan}	{'IDC-IDC_anti_pd_1_lung', 'TCIA-anti-pd-1_lung'}	{'IDC', 'TCIA'}	2
-OSF CT C/A/P	{'CT', nan}	{'IDC-IDC_tcga_kich', 'TCIA-tcga-kich'}	{'IDC', 'TCIA'}	2
-1V2E-1	{'SR', nan}	{'IDC-IDC_qiba_ct_1c', 'TCIA-qiba-ct-1c'}	{'IDC', 'TCIA'}	2
-chest.3d	{'CT', nan}	{'IDC-IDC_lung_pet_ct_dx', 'TCIA-lung-pet-ct-dx'}	{'IDC', 'TCIA'}	2
-NSCLC INIT STG	{'SEG', nan}	{'TCIA-acrin-nsclc-fdg-pet', 'IDC-IDC_acrin_nsclc_fdg_pet'}	{'IDC', 'TCIA'}	2
-NSCLC LUNG RESTAGING	{'SEG', nan}	{'TCIA-acrin-nsclc-fdg-pet', 'IDC-IDC_acrin_nsclc_fdg_pet'}	{'IDC', 'TCIA'}	2
-NSCLC RESTAGING	{'SEG', nan}	{'TCIA-acrin-nsclc-fdg-pet', 'IDC-IDC_acrin_nsclc_fdg_pet'}	{'IDC', 'TCIA'}	2
-chest_abdomen_pelvis__w_and_wo	{'SEG', nan}	{'TCIA-c4kc-kits', 'IDC-IDC_c4kc_kits'}	{'IDC', 'TCIA'}	2
-NSCLC RESTG	{'SEG', nan}	{'TCIA-acrin-nsclc-fdg-pet', 'IDC-IDC_acrin_nsclc_fdg_pet'}	{'IDC', 'TCIA'}	2
-1V2B-2	{'SR', nan}	{'IDC-IDC_qiba_ct_1c', 'TCIA-qiba-ct-1c'}	{'IDC', 'TCIA'}	2
-NUC MED LUNG VENTILATION + PERFUSION	{'NM'}	{'MIDRC-Open-A1'}	{'MIDRC'}	2
-Needle Loc Mammo Guidance 1st Right PRIM	{'MG'}	{'ACRdart-EA1141Restricted', 'IDC-IDC_ea1141'}	{'ACRdart', 'IDC'}	2
-No study description	{'SEG', nan}	{'TCIA-spine-mets-ct-seg', 'IDC-IDC_spine_mets_ct_seg'}	{'IDC', 'TCIA'}	2
-1V2C-1	{'SR', nan}	{'IDC-IDC_qiba_ct_1c', 'TCIA-qiba-ct-1c'}	{'IDC', 'TCIA'}	2
-ORTHO CHUS^OS LONGS	{'MR', nan}	{'IDC-IDC_soft_tissue_sarcoma', 'TCIA-soft-tissue-sarcoma'}	{'IDC', 'TCIA'}	2
-ORTHO THORAX	{'MR', nan}	{'IDC-IDC_soft_tissue_sarcoma', 'TCIA-soft-tissue-sarcoma'}	{'IDC', 'TCIA'}	2
-chest/abd with	{'CT', nan}	{'TCIA-tcga-lusc', 'IDC-IDC_tcga_lusc'}	{'IDC', 'TCIA'}	2
-ABDOMEN +/-CONT	{'MR', nan}	{'TCIA-tcga-kirc', 'IDC-IDC_tcga_kirc'}	{'IDC', 'TCIA'}	2
-ABDOMEN (CT)-BODY	{'SEG', nan}	{'TCIA-tcga-lihc', 'IDC-IDC_tcga_lihc'}	{'IDC', 'TCIA'}	2
-1V2D-2	{'SR', nan}	{'IDC-IDC_qiba_ct_1c', 'TCIA-qiba-ct-1c'}	{'IDC', 'TCIA'}	2
-P/P A/P	{'SEG', nan}	{'IDC-IDC_hcc_tace_seg', 'TCIA-hcc-tace-seg'}	{'IDC', 'TCIA'}	2
-ABDOMEN KIDNEY CHEST PELVIS WITH(Adult)	{'CT'}	{'MIDRC-Open-A1'}	{'MIDRC'}	2
-PELVIS SBRT	{'CT', nan}	{'IDC-IDC_pelvic_reference_data', 'TCIA-pelvic-reference-data'}	{'IDC', 'TCIA'}	2
-PELVIS W/O CONTRAST	{'CT', nan}	{'TCIA-tcga-ucec', 'IDC-IDC_tcga_ucec'}	{'IDC', 'TCIA'}	2
-PELVIS.1:PELVIS:Private^WBHPELVIS (Adult)	{'CT', nan}	{'IDC-IDC_pelvic_reference_data', 'TCIA-pelvic-reference-data'}	{'IDC', 'TCIA'}	2
-ABD. AND PELVIS	{'CT', nan}	{'TCIA-tcga-kirc', 'IDC-IDC_tcga_kirc'}	{'IDC', 'TCIA'}	2
-breast^lesion evaluation	{'SEG', nan}	{'TCIA-duke-breast-cancer-mri', 'IDC-IDC_duke_breast_cancer_mri'}	{'IDC', 'TCIA'}	2
-PENGQIANG	{'CT', nan}	{'IDC-IDC_stageii_colorectal_ct', 'TCIA-stageii-colorectal-ct'}	{'IDC', 'TCIA'}	2
-ABD RENAL W/WO	{'SEG', nan}	{'TCIA-tcga-kirc', 'IDC-IDC_tcga_kirc'}	{'IDC', 'TCIA'}	2
-1V2F-2	{'SR', nan}	{'IDC-IDC_qiba_ct_1c', 'TCIA-qiba-ct-1c'}	{'IDC', 'TCIA'}	2
-PET / CT F-18 FDG TUMOR SKULL BASE TO MID-THIGH	{'SEG', nan}	{'TCIA-acrin-nsclc-fdg-pet', 'IDC-IDC_acrin_nsclc_fdg_pet'}	{'IDC', 'TCIA'}	2
-breast research	{'MR', nan}	{'IDC-IDC_acrin_contralateral_breast_mr', 'TCIA-acrin-contralateral-breast-mr'}	{'IDC', 'TCIA'}	2
-ABD RENAL STONE	{'CT', nan}	{'TCIA-tcga-kirc', 'IDC-IDC_tcga_kirc'}	{'IDC', 'TCIA'}	2
-PET BREAST CANCER (W/L	{'PT,CT'}	{'MIDRC-Open-A1'}	{'MIDRC'}	2
-6V1F-2	{'SR', nan}	{'IDC-IDC_qiba_ct_1c', 'TCIA-qiba-ct-1c'}	{'IDC', 'TCIA'}	2
-ABD PEL LIVER	{'SEG', nan}	{'IDC-IDC_hcc_tace_seg', 'TCIA-hcc-tace-seg'}	{'IDC', 'TCIA'}	2
-PET COLON OR RECTAL CA	{'PT,CT'}	{'MIDRC-Open-A1'}	{'MIDRC'}	2
-PET COLON OR RECTAL CANCER (W/LOW DOSE CT)	{'PT,CT'}	{'MIDRC-Open-A1'}	{'MIDRC'}	2
-1V2E-2	{'SR', nan}	{'IDC-IDC_qiba_ct_1c', 'TCIA-qiba-ct-1c'}	{'IDC', 'TCIA'}	2
-PELVIS RECTUM	{'CT', nan}	{'IDC-IDC_pelvic_reference_data', 'TCIA-pelvic-reference-data'}	{'IDC', 'TCIA'}	2
-P/P A/P W/RENAL PROTO.	{'SEG', nan}	{'TCIA-tcga-kirc', 'IDC-IDC_tcga_kirc'}	{'IDC', 'TCIA'}	2
-PELVIS FULLL	{'CT', nan}	{'IDC-IDC_pelvic_reference_data', 'TCIA-pelvic-reference-data'}	{'IDC', 'TCIA'}	2
-c+c	{'SEG', nan}	{'IDC-IDC_lung_pet_ct_dx', 'TCIA-lung-pet-ct-dx'}	{'IDC', 'TCIA'}	2
-P/P A/P, W/RENAL PROTO	{'SEG', nan}	{'TCIA-tcga-kirc', 'IDC-IDC_tcga_kirc'}	{'IDC', 'TCIA'}	2
-P/P C/A	{'SEG', nan}	{'IDC-IDC_hcc_tace_seg', 'TCIA-hcc-tace-seg'}	{'IDC', 'TCIA'}	2
-P/P C/A/P W/LIVER PRO	{'SEG', nan}	{'IDC-IDC_hcc_tace_seg', 'TCIA-hcc-tace-seg'}	{'IDC', 'TCIA'}	2
-P/P C/A/P,LIVER PROTO.	{'SEG', nan}	{'IDC-IDC_hcc_tace_seg', 'TCIA-hcc-tace-seg'}	{'IDC', 'TCIA'}	2
-ABD/PELVIS W/W/O	{'CT', nan}	{'TCIA-tcga-kirc', 'IDC-IDC_tcga_kirc'}	{'IDC', 'TCIA'}	2
-PC TX AS	{'CT', nan}	{'TCIA-tcga-stad', 'IDC-IDC_tcga_stad'}	{'IDC', 'TCIA'}	2
-ABD/PELVIS ANGIO/VENO	{'CT', nan}	{'TCIA-adrenal-acc-ki67-seg', 'IDC-IDC_adrenal_acc_ki67_seg'}	{'IDC', 'TCIA'}	2
-PE CHEST WITH	{'SEG', nan}	{'TCIA-lidc-idri', 'IDC-IDC_lidc_idri'}	{'IDC', 'TCIA'}	2
-c t ap	{'CT', nan}	{'TCIA-tcga-ov', 'IDC-IDC_tcga_ov'}	{'IDC', 'TCIA'}	2
-PELVE	{'MR', nan}	{'IDC-IDC_tcga_cesc', 'TCIA-tcga-cesc'}	{'IDC', 'TCIA'}	2
-ABD/PEL W/C	{'SEG', nan}	{'IDC-IDC_hcc_tace_seg', 'TCIA-hcc-tace-seg'}	{'IDC', 'TCIA'}	2
-ABD/PEL LIVER PROTOCOL	{'SEG', nan}	{'IDC-IDC_hcc_tace_seg', 'TCIA-hcc-tace-seg'}	{'IDC', 'TCIA'}	2
-ABD/PEL  LIVER	{'CT', nan}	{'IDC-IDC_hcc_tace_seg', 'TCIA-hcc-tace-seg'}	{'IDC', 'TCIA'}	2
-PELVIS FULL BLADDER	{'CT', nan}	{'IDC-IDC_pelvic_reference_data', 'TCIA-pelvic-reference-data'}	{'IDC', 'TCIA'}	2
-NSCLC	{'PT', nan}	{'TCIA-acrin-nsclc-fdg-pet', 'IDC-IDC_acrin_nsclc_fdg_pet'}	{'IDC', 'TCIA'}	2
-NSC LUNG RESTG	{'SEG', nan}	{'TCIA-acrin-nsclc-fdg-pet', 'IDC-IDC_acrin_nsclc_fdg_pet'}	{'IDC', 'TCIA'}	2
-ANKLE LEFT 3 VIEWS (WEIGHT BEARING)	{'CR', 'DX'}	{'MIDRC-Open-R1'}	{'MIDRC'}	2
-ACWOWC ANGIO CHEST WO/WC	{'CT'}	{'MIDRC-Open-A1_SCCM_VIRUS'}	{'MIDRC'}	2
-e+1 FDG 6AFOV TORSO	{'SEG', nan}	{'IDC-IDC_rider_lung_pet_ct', 'TCIA-rider-lung-pet-ct'}	{'IDC', 'TCIA'}	2
-ACRIN6667 CONTRA-LAT.	{'MR', nan}	{'IDC-IDC_acrin_contralateral_breast_mr', 'TCIA-acrin-contralateral-breast-mr'}	{'IDC', 'TCIA'}	2
-MRI_L_Shoulder	{'MR', nan}	{'IDC-IDC_cmb_mml', 'TCIA-cmb-mml'}	{'IDC', 'TCIA'}	2
-ACRIN CT COLONGRAPHY	{'CT', nan}	{'TCIA-ct-colonography', 'IDC-IDC_ct_colonography'}	{'IDC', 'TCIA'}	2
-ACRIN COLON	{'CT', nan}	{'TCIA-ct-colonography', 'IDC-IDC_ct_colonography'}	{'IDC', 'TCIA'}	2
-e+1 F/U	{'CT', nan}	{'TCIA-acrin-nsclc-fdg-pet', 'IDC-IDC_acrin_nsclc_fdg_pet'}	{'IDC', 'TCIA'}	2
-e+1 CT LUNG SCREEN	{'CT', nan}	{'TCIA-lidc-idri', 'IDC-IDC_lidc_idri'}	{'IDC', 'TCIA'}	2
-e+1 CT Chest W/ Non Ionic	{'CT', nan}	{'TCIA-acrin-nsclc-fdg-pet', 'IDC-IDC_acrin_nsclc_fdg_pet'}	{'IDC', 'TCIA'}	2
-e+1 CT CHEST WO CONTRAST	{'CT'}	{'MIDRC-Open-A1'}	{'MIDRC'}	2
-MRM  6667	{'MR', nan}	{'IDC-IDC_acrin_contralateral_breast_mr', 'TCIA-acrin-contralateral-breast-mr'}	{'IDC', 'TCIA'}	2
-e+1 BREAST W/WO	{'MR', nan}	{'IDC-IDC_acrin_contralateral_breast_mr', 'TCIA-acrin-contralateral-breast-mr'}	{'IDC', 'TCIA'}	2
-ACRIN 6668 PET	{'SEG', nan}	{'TCIA-acrin-nsclc-fdg-pet', 'IDC-IDC_acrin_nsclc_fdg_pet'}	{'IDC', 'TCIA'}	2
-e+1 BILAT/ATTN LEFT	{'MR', nan}	{'IDC-IDC_acrin_contralateral_breast_mr', 'TCIA-acrin-contralateral-breast-mr'}	{'IDC', 'TCIA'}	2
-1V1E-2	{'SR', nan}	{'IDC-IDC_qiba_ct_1c', 'TCIA-qiba-ct-1c'}	{'IDC', 'TCIA'}	2
-ACRIN 6667 CONTRA. BRE	{'MR', nan}	{'IDC-IDC_acrin_contralateral_breast_mr', 'TCIA-acrin-contralateral-breast-mr'}	{'IDC', 'TCIA'}	2
-ACRIN6667CONTRALAT. BR	{'MR', nan}	{'IDC-IDC_acrin_contralateral_breast_mr', 'TCIA-acrin-contralateral-breast-mr'}	{'IDC', 'TCIA'}	2
-MRI-UNLISTED AREA	{'MR', nan}	{'IDC-IDC_soft_tissue_sarcoma', 'TCIA-soft-tissue-sarcoma'}	{'IDC', 'TCIA'}	2
-MRM/DYN	{'MR', nan}	{'IDC-IDC_acrin_contralateral_breast_mr', 'TCIA-acrin-contralateral-breast-mr'}	{'IDC', 'TCIA'}	2
-MRI-RT THIGH	{'RTSTRUCT', nan}	{'IDC-IDC_soft_tissue_sarcoma', 'TCIA-soft-tissue-sarcoma'}	{'IDC', 'TCIA'}	2
-MRI THIGH C+ LEFT	{'MR', nan}	{'IDC-IDC_soft_tissue_sarcoma', 'TCIA-soft-tissue-sarcoma'}	{'IDC', 'TCIA'}	2
-MRI THIGH C+ RIGHT	{'RTSTRUCT', nan}	{'IDC-IDC_soft_tissue_sarcoma', 'TCIA-soft-tissue-sarcoma'}	{'IDC', 'TCIA'}	2
-e+1 HANCHE GAUCHE C+	{'RTSTRUCT', nan}	{'IDC-IDC_soft_tissue_sarcoma', 'TCIA-soft-tissue-sarcoma'}	{'IDC', 'TCIA'}	2
-MRI THORACIC W/WO CONTRAST	{'MR', nan}	{'IDC-IDC_tcga_sarc', 'TCIA-tcga-sarc'}	{'IDC', 'TCIA'}	2
-MRI W/O CONT UNIBR	{'MR', nan}	{'IDC-IDC_acrin_contralateral_breast_mr', 'TCIA-acrin-contralateral-breast-mr'}	{'IDC', 'TCIA'}	2
-MRI W/WO CONT BI	{'MR', nan}	{'IDC-IDC_acrin_contralateral_breast_mr', 'TCIA-acrin-contralateral-breast-mr'}	{'IDC', 'TCIA'}	2
-MRI, BRAIN W&W/O CONTR	{'MR', nan}	{'TCIA-acrin-nsclc-fdg-pet', 'IDC-IDC_acrin_nsclc_fdg_pet'}	{'IDC', 'TCIA'}	2
-MRI, BRAIN W&W/O CONTRAST	{'MR', nan}	{'TCIA-acrin-nsclc-fdg-pet', 'IDC-IDC_acrin_nsclc_fdg_pet'}	{'IDC', 'TCIA'}	2
-MRI,BRAIN W&W/O	{'MR', nan}	{'IDC-IDC_icdc_glioma', 'TCIA-icdc-glioma'}	{'IDC', 'TCIA'}	2
-MRI-EXTREMITIES	{'MR', nan}	{'IDC-IDC_soft_tissue_sarcoma', 'TCIA-soft-tissue-sarcoma'}	{'IDC', 'TCIA'}	2
-MRI-LT LEG	{'MR', nan}	{'IDC-IDC_soft_tissue_sarcoma', 'TCIA-soft-tissue-sarcoma'}	{'IDC', 'TCIA'}	2
-ANGIO - CHEST (PE STUDY)	{'CT'}	{'MIDRC-Open-A1_SCCM_VIRUS'}	{'MIDRC'}	2
-MRI-Pelvis	{'MR', nan}	{'IDC-IDC_cptac_sar', 'TCIA-cptac-sar'}	{'IDC', 'TCIA'}	2
-MRI-RT BUTTOCK	{'MR', nan}	{'IDC-IDC_soft_tissue_sarcoma', 'TCIA-soft-tissue-sarcoma'}	{'IDC', 'TCIA'}	2
-MRI-RT LEG	{'RTSTRUCT', nan}	{'IDC-IDC_soft_tissue_sarcoma', 'TCIA-soft-tissue-sarcoma'}	{'IDC', 'TCIA'}	2
-e+1 A/P	{'CT', nan}	{'TCIA-tcga-kirc', 'IDC-IDC_tcga_kirc'}	{'IDC', 'TCIA'}	2
-MR_BREAST-LT STUDY PT	{'MR', nan}	{'IDC-IDC_acrin_contralateral_breast_mr', 'TCIA-acrin-contralateral-breast-mr'}	{'IDC', 'TCIA'}	2
-ABDOMEN LIVER PROTOCOL	{'SEG', nan}	{'IDC-IDC_hcc_tace_seg', 'TCIA-hcc-tace-seg'}	{'IDC', 'TCIA'}	2
-ABDOMEN^1 ACRIN PRONE COLONOGRAPHY	{'CT', nan}	{'TCIA-ct-colonography', 'IDC-IDC_ct_colonography'}	{'IDC', 'TCIA'}	2
-ABDOMEN/PELVIS CT	{'CT', nan}	{'TCIA-acrin-nsclc-fdg-pet', 'IDC-IDC_acrin_nsclc_fdg_pet'}	{'IDC', 'TCIA'}	2
-1V2A-1	{'SR', nan}	{'IDC-IDC_qiba_ct_1c', 'TCIA-qiba-ct-1c'}	{'IDC', 'TCIA'}	2
-NM Chest	{'DX', nan}	{'TCIA-cmb-crc', 'IDC-IDC_cmb_crc'}	{'IDC', 'TCIA'}	2
-ct a/p w/wo	{'SEG', nan}	{'TCIA-tcga-kirc', 'IDC-IDC_tcga_kirc'}	{'IDC', 'TCIA'}	2
-ABDOMEN, AP (KUB)	{'CR', nan}	{'IDC-IDC_tcga_blca', 'TCIA-tcga-blca'}	{'IDC', 'TCIA'}	2
-NM PET 18 FDG  SKULL T	{'PT', nan}	{'TCIA-cptac-luad', 'IDC-IDC_cptac_luad'}	{'IDC', 'TCIA'}	2
-ABDOMEN+C	{'RTSTRUCT', nan}	{'TCIA-cptac-ccrcc', 'IDC-IDC_cptac_ccrcc'}	{'IDC', 'TCIA'}	2
-contrabreast (LEFT)	{'MR', nan}	{'IDC-IDC_acrin_contralateral_breast_mr', 'TCIA-acrin-contralateral-breast-mr'}	{'IDC', 'TCIA'}	2
-NM PET STOT LUNG CA RESTG	{'SEG', nan}	{'TCIA-acrin-nsclc-fdg-pet', 'IDC-IDC_acrin_nsclc_fdg_pet'}	{'IDC', 'TCIA'}	2
-NM PETCT 18FDG BASE OF SKULL TO THIGHS	{'CT', nan}	{'TCIA-cptac-luad', 'IDC-IDC_cptac_luad'}	{'IDC', 'TCIA'}	2
-ABDOMEN SERIES INCL CHEST-CS	{'CR'}	{'MIDRC-Open-A1'}	{'MIDRC'}	2
-1V2A-2	{'SR', nan}	{'IDC-IDC_qiba_ct_1c', 'TCIA-qiba-ct-1c'}	{'IDC', 'TCIA'}	2
-NM_Bone_WB	{'NM', nan}	{'TCIA-cmb-crc', 'IDC-IDC_cmb_crc'}	{'IDC', 'TCIA'}	2
-NM_Chest	{'NM', nan}	{'TCIA-cmb-lca', 'IDC-IDC_cmb_lca'}	{'IDC', 'TCIA'}	2
-1V2B-1	{'SR', nan}	{'IDC-IDC_qiba_ct_1c', 'TCIA-qiba-ct-1c'}	{'IDC', 'TCIA'}	2
-1V1F-2	{'SR', nan}	{'IDC-IDC_qiba_ct_1c', 'TCIA-qiba-ct-1c'}	{'IDC', 'TCIA'}	2
-Multiple Line Source Background	{'PT', nan}	{'IDC-IDC_rider_lung_pet_ct', 'TCIA-rider-lung-pet-ct'}	{'IDC', 'TCIA'}	2
-ABDPEL C	{'CT', nan}	{'TCIA-tcga-ov', 'IDC-IDC_tcga_ov'}	{'IDC', 'TCIA'}	2
-ct chest with contrast,	{'CT', nan}	{'TCIA-acrin-nsclc-fdg-pet', 'IDC-IDC_acrin_nsclc_fdg_pet'}	{'IDC', 'TCIA'}	2
-MR_BREAST-lT	{'MR', nan}	{'IDC-IDC_acrin_contralateral_breast_mr', 'TCIA-acrin-contralateral-breast-mr'}	{'IDC', 'TCIA'}	2
-MR_CSpine	{'MR', nan}	{'IDC-IDC_cmb_mml', 'TCIA-cmb-mml'}	{'IDC', 'TCIA'}	2
-MR_LT BR	{'MR', nan}	{'IDC-IDC_acrin_contralateral_breast_mr', 'TCIA-acrin-contralateral-breast-mr'}	{'IDC', 'TCIA'}	2
-MR_LT BREAST-STUDY PT	{'MR', nan}	{'IDC-IDC_acrin_contralateral_breast_mr', 'TCIA-acrin-contralateral-breast-mr'}	{'IDC', 'TCIA'}	2
-MR_RT BREAST	{'MR', nan}	{'IDC-IDC_acrin_contralateral_breast_mr', 'TCIA-acrin-contralateral-breast-mr'}	{'IDC', 'TCIA'}	2
-MS4183/GAD   Abdomen w & w/o	{'MR', nan}	{'IDC-IDC_tcga_kich', 'TCIA-tcga-kich'}	{'IDC', 'TCIA'}	2
-MSKT organov grudnoy k	{'CT', nan}	{'TCIA-cptac-lscc', 'IDC-IDC_cptac_lscc'}	{'IDC', 'TCIA'}	2
-e+1	{'CT', nan}	{'IDC-IDC_lung_pet_ct_dx', 'TCIA-lung-pet-ct-dx'}	{'IDC', 'TCIA'}	2
-MSK^HIP	{'RTSTRUCT', nan}	{'IDC-IDC_soft_tissue_sarcoma', 'TCIA-soft-tissue-sarcoma'}	{'IDC', 'TCIA'}	2
-ct thorax with contrast	{'CT', nan}	{'TCIA-acrin-nsclc-fdg-pet', 'IDC-IDC_acrin_nsclc_fdg_pet'}	{'IDC', 'TCIA'}	2
-MW CT ,ABD W CONT, 74160	{'SEG', nan}	{'TCIA-tcga-lihc', 'IDC-IDC_tcga_lihc'}	{'IDC', 'TCIA'}	2
-ABDOMINAL CT W/ + W/O CONTRAST	{'CT', nan}	{'TCIA-tcga-ucec', 'IDC-IDC_tcga_ucec'}	{'IDC', 'TCIA'}	2
-ABDOMEN^UPPER	{'RTSTRUCT', nan}	{'TCIA-cptac-pda', 'IDC-IDC_cptac_pda'}	{'IDC', 'TCIA'}	2
-ABDOMEN^METRO MRI	{'SEG', nan}	{'TCIA-tcga-lihc', 'IDC-IDC_tcga_lihc'}	{'IDC', 'TCIA'}	2
-ct head w/wo contrast	{'CT', nan}	{'TCIA-acrin-nsclc-fdg-pet', 'IDC-IDC_acrin_nsclc_fdg_pet'}	{'IDC', 'TCIA'}	2
-SCAN THORAX C+ -THO	{'SEG', nan}	{'TCIA-tcga-lihc', 'IDC-IDC_tcga_lihc'}	{'IDC', 'TCIA'}	2
-6V1D-2	{'SR', nan}	{'IDC-IDC_qiba_ct_1c', 'TCIA-qiba-ct-1c'}	{'IDC', 'TCIA'}	2
-_t5of9MRI IAMS	{'MR', nan}	{'IDC-IDC_vestibular_schwannoma_mc_rc', 'TCIA-vestibular-schwannoma-mc-rc'}	{'IDC', 'TCIA'}	2
-3V4A-1	{'SR', nan}	{'IDC-IDC_qiba_ct_1c', 'TCIA-qiba-ct-1c'}	{'IDC', 'TCIA'}	2
-US_Biopsy_Liver	{'XA', nan}	{'TCIA-cmb-crc', 'IDC-IDC_cmb_crc'}	{'IDC', 'TCIA'}	2
-US_CT_Abdomen	{'CT', nan}	{'TCIA-cmb-crc', 'IDC-IDC_cmb_crc'}	{'IDC', 'TCIA'}	2
-US_Chest	{'US', nan}	{'TCIA-cmb-crc', 'IDC-IDC_cmb_crc'}	{'IDC', 'TCIA'}	2
-US_biopsyliver	{'US', nan}	{'IDC-IDC_cmb_mel', 'TCIA-cmb-mel'}	{'IDC', 'TCIA'}	2
-2V1A-2	{'SR', nan}	{'IDC-IDC_qiba_ct_1c', 'TCIA-qiba-ct-1c'}	{'IDC', 'TCIA'}	2
-3V4A-2	{'SR', nan}	{'IDC-IDC_qiba_ct_1c', 'TCIA-qiba-ct-1c'}	{'IDC', 'TCIA'}	2
-_t1of9MRI Head	{'MR', nan}	{'IDC-IDC_vestibular_schwannoma_mc_rc', 'TCIA-vestibular-schwannoma-mc-rc'}	{'IDC', 'TCIA'}	2
-3V3F-2	{'SR', nan}	{'IDC-IDC_qiba_ct_1c', 'TCIA-qiba-ct-1c'}	{'IDC', 'TCIA'}	2
-3V2C-1	{'SR', nan}	{'IDC-IDC_qiba_ct_1c', 'TCIA-qiba-ct-1c'}	{'IDC', 'TCIA'}	2
-Unspecified CT ABDOMEN	{'CT', nan}	{'IDC-IDC_rider_lung_pet_ct', 'TCIA-rider-lung-pet-ct'}	{'IDC', 'TCIA'}	2
-3V3E-2	{'SR', nan}	{'IDC-IDC_qiba_ct_1c', 'TCIA-qiba-ct-1c'}	{'IDC', 'TCIA'}	2
-Unspecified MG BREAST	{'MG'}	{'ACRdart-EA1141Restricted'}	{'ACRdart'}	2
-3V3E-1	{'SR', nan}	{'IDC-IDC_qiba_ct_1c', 'TCIA-qiba-ct-1c'}	{'IDC', 'TCIA'}	2
-3V3D-2	{'SR', nan}	{'IDC-IDC_qiba_ct_1c', 'TCIA-qiba-ct-1c'}	{'IDC', 'TCIA'}	2
-VIRTUAL  RECTUM	{'CT', nan}	{'IDC-IDC_pelvic_reference_data', 'TCIA-pelvic-reference-data'}	{'IDC', 'TCIA'}	2
-2V1B-1	{'SR', nan}	{'IDC-IDC_qiba_ct_1c', 'TCIA-qiba-ct-1c'}	{'IDC', 'TCIA'}	2
-3V4B-1	{'SR', nan}	{'IDC-IDC_qiba_ct_1c', 'TCIA-qiba-ct-1c'}	{'IDC', 'TCIA'}	2
-3V4B-2	{'SR', nan}	{'IDC-IDC_qiba_ct_1c', 'TCIA-qiba-ct-1c'}	{'IDC', 'TCIA'}	2
-US UPPER EXTREMITY VENOUS DUPLEX LTD - RIGHT	{'US'}	{'MIDRC-Open-A1'}	{'MIDRC'}	2
-2V1A-1	{'SR', nan}	{'IDC-IDC_qiba_ct_1c', 'TCIA-qiba-ct-1c'}	{'IDC', 'TCIA'}	2
-US Abdomen Complete	{'US', nan}	{'TCIA-cmb-crc', 'IDC-IDC_cmb_crc'}	{'IDC', 'TCIA'}	2
-US BREAST CORE BX	{'US'}	{'ACRdart-ACRIN_6666'}	{'ACRdart'}	2
-US Biopsy Axilla	{'US', nan}	{'IDC-IDC_cmb_mel', 'TCIA-cmb-mel'}	{'IDC', 'TCIA'}	2
-3V4E-1	{'SR', nan}	{'IDC-IDC_qiba_ct_1c', 'TCIA-qiba-ct-1c'}	{'IDC', 'TCIA'}	2
-US Biopsy LymphNode	{'US', nan}	{'TCIA-cmb-lca', 'IDC-IDC_cmb_lca'}	{'IDC', 'TCIA'}	2
-US Breast Bilateral	{'US'}	{'ACRdart-ACRIN_6666'}	{'ACRdart'}	2
-US Breast Right	{'US'}	{'ACRdart-ACRIN_6666'}	{'ACRdart'}	2
-US DOPPLER LOWER EXTREMITY VENOUS, BILATERAL (S)	{'US'}	{'MIDRC-Open-R1'}	{'MIDRC'}	2
-US Echocardiogram	{'US', nan}	{'TCIA-cmb-crc', 'IDC-IDC_cmb_crc'}	{'IDC', 'TCIA'}	2
-3V4D-2	{'SR', nan}	{'IDC-IDC_qiba_ct_1c', 'TCIA-qiba-ct-1c'}	{'IDC', 'TCIA'}	2
-US KIDNEY TRANSPLANT	{'US'}	{'MIDRC-Open-A1'}	{'MIDRC'}	2
-3V4D-1	{'SR', nan}	{'IDC-IDC_qiba_ct_1c', 'TCIA-qiba-ct-1c'}	{'IDC', 'TCIA'}	2
-2AFOV PELVIS POST CATH	{'PT', nan}	{'IDC-IDC_rider_lung_pet_ct', 'TCIA-rider-lung-pet-ct'}	{'IDC', 'TCIA'}	2
-3V4C-2	{'SR', nan}	{'IDC-IDC_qiba_ct_1c', 'TCIA-qiba-ct-1c'}	{'IDC', 'TCIA'}	2
-3V4C-1	{'SR', nan}	{'IDC-IDC_qiba_ct_1c', 'TCIA-qiba-ct-1c'}	{'IDC', 'TCIA'}	2
-VIRTUAL ABDOMEN/PELVIS	{'CT', nan}	{'IDC-IDC_pelvic_reference_data', 'TCIA-pelvic-reference-data'}	{'IDC', 'TCIA'}	2
-_t1of8_MRI External Films	{'MR', nan}	{'IDC-IDC_vestibular_schwannoma_mc_rc', 'TCIA-vestibular-schwannoma-mc-rc'}	{'IDC', 'TCIA'}	2
-VIRTUAL GYN PELVIS FULL BLADDER	{'CT', nan}	{'IDC-IDC_pelvic_reference_data', 'TCIA-pelvic-reference-data'}	{'IDC', 'TCIA'}	2
-3V3A-1	{'SR', nan}	{'IDC-IDC_qiba_ct_1c', 'TCIA-qiba-ct-1c'}	{'IDC', 'TCIA'}	2
-Vascular^FL_CTPA (Adult)	{'CT'}	{'MIDRC-Open-A1_PETAL_REDCORAL'}	{'MIDRC'}	2
-Vascular^GATED_CHEST_CTA (Adult)	{'CT', nan}	{'IDC-IDC_nsclc_radiogenomics', 'TCIA-nsclc-radiogenomics'}	{'IDC', 'TCIA'}	2
-3V2E-2	{'SR', nan}	{'IDC-IDC_qiba_ct_1c', 'TCIA-qiba-ct-1c'}	{'IDC', 'TCIA'}	2
-Vascular^PEAngio(Adiult) (Adult)	{'CT', nan}	{'TCIA-acrin-nsclc-fdg-pet', 'IDC-IDC_acrin_nsclc_fdg_pet'}	{'IDC', 'TCIA'}	2
-3V2E-1	{'SR', nan}	{'IDC-IDC_qiba_ct_1c', 'TCIA-qiba-ct-1c'}	{'IDC', 'TCIA'}	2
-_t1of7External Images for PACS	{'MR', nan}	{'IDC-IDC_vestibular_schwannoma_mc_rc', 'TCIA-vestibular-schwannoma-mc-rc'}	{'IDC', 'TCIA'}	2
-Vascular^PULMONARY_VEIN_STUDY (Adult)	{'CT'}	{'MIDRC-Open-A1'}	{'MIDRC'}	2
-_t1of7  MRI Head	{'MR', nan}	{'IDC-IDC_vestibular_schwannoma_mc_rc', 'TCIA-vestibular-schwannoma-mc-rc'}	{'IDC', 'TCIA'}	2
-2V1C-2	{'SR', nan}	{'IDC-IDC_qiba_ct_1c', 'TCIA-qiba-ct-1c'}	{'IDC', 'TCIA'}	2
-Vascular^RUNOFF_CTA (Adult)	{'CT'}	{'MIDRC-Open-A1'}	{'MIDRC'}	2
-Vascular^THORACIC_ANEURYSM_CTA (Adult)	{'CT'}	{'MIDRC-Open-A1'}	{'MIDRC'}	2
-3V2D-2	{'SR', nan}	{'IDC-IDC_qiba_ct_1c', 'TCIA-qiba-ct-1c'}	{'IDC', 'TCIA'}	2
-WB	{'SEG', nan}	{'TCIA-acrin-nsclc-fdg-pet', 'IDC-IDC_acrin_nsclc_fdg_pet'}	{'IDC', 'TCIA'}	2
-3V2D-1	{'SR', nan}	{'IDC-IDC_qiba_ct_1c', 'TCIA-qiba-ct-1c'}	{'IDC', 'TCIA'}	2
-WB PET & LUNG DELAYS	{'SEG', nan}	{'TCIA-acrin-nsclc-fdg-pet', 'IDC-IDC_acrin_nsclc_fdg_pet'}	{'IDC', 'TCIA'}	2
-3V2F-2	{'SR', nan}	{'IDC-IDC_qiba_ct_1c', 'TCIA-qiba-ct-1c'}	{'IDC', 'TCIA'}	2
-3V3A-2	{'SR', nan}	{'IDC-IDC_qiba_ct_1c', 'TCIA-qiba-ct-1c'}	{'IDC', 'TCIA'}	2
-VIRTUAL PELVIS	{'CT', nan}	{'IDC-IDC_pelvic_reference_data', 'TCIA-pelvic-reference-data'}	{'IDC', 'TCIA'}	2
-_t1of7_MRI External Films	{'MR', nan}	{'IDC-IDC_vestibular_schwannoma_mc_rc', 'TCIA-vestibular-schwannoma-mc-rc'}	{'IDC', 'TCIA'}	2
-VIRTUAL PELVIS  FULL BLADDER	{'CT', nan}	{'IDC-IDC_pelvic_reference_data', 'TCIA-pelvic-reference-data'}	{'IDC', 'TCIA'}	2
-VIRTUAL PELVIS FULL BLADDER	{'CT', nan}	{'IDC-IDC_pelvic_reference_data', 'TCIA-pelvic-reference-data'}	{'IDC', 'TCIA'}	2
-Vascular^01_0_Abdominal_Aorta_CTA_Pre_Post_Stent (Adult)	{'CT', nan}	{'TCIA-tcga-ov', 'IDC-IDC_tcga_ov'}	{'IDC', 'TCIA'}	2
-3V3D-1	{'SR', nan}	{'IDC-IDC_qiba_ct_1c', 'TCIA-qiba-ct-1c'}	{'IDC', 'TCIA'}	2
-Vascular^06CTA_Abd_(Post-stent) (Adult)	{'CT', nan}	{'TCIA-tcga-kirc', 'IDC-IDC_tcga_kirc'}	{'IDC', 'TCIA'}	2
-3V3C-2	{'SR', nan}	{'IDC-IDC_qiba_ct_1c', 'TCIA-qiba-ct-1c'}	{'IDC', 'TCIA'}	2
-Vascular^CH03A_CHST_W_PE (Adult)	{'CT'}	{'MIDRC-Open-A1_PETAL_BLUECORAL'}	{'MIDRC'}	2
-3V3C-1	{'SR', nan}	{'IDC-IDC_qiba_ct_1c', 'TCIA-qiba-ct-1c'}	{'IDC', 'TCIA'}	2
-_t1of8_MR IAMs	{nan}	{'TCIA-vestibular-schwannoma-mc-rc'}	{'TCIA'}	2
-_t1of8_MR IAM's	{'MR'}	{'IDC-IDC_vestibular_schwannoma_mc_rc'}	{'IDC'}	2
-3V3B-2	{'SR', nan}	{'IDC-IDC_qiba_ct_1c', 'TCIA-qiba-ct-1c'}	{'IDC', 'TCIA'}	2
-Vascular^CTA_MESSENTERIC (Adult)	{'CT'}	{'MIDRC-Open-A1'}	{'MIDRC'}	2
-2V1B-2	{'SR', nan}	{'IDC-IDC_qiba_ct_1c', 'TCIA-qiba-ct-1c'}	{'IDC', 'TCIA'}	2
-2V1C-1	{'SR', nan}	{'IDC-IDC_qiba_ct_1c', 'TCIA-qiba-ct-1c'}	{'IDC', 'TCIA'}	2
-3V3B-1	{'SR', nan}	{'IDC-IDC_qiba_ct_1c', 'TCIA-qiba-ct-1c'}	{'IDC', 'TCIA'}	2
-_t2of3  MRI HEAD	{'MR', nan}	{'IDC-IDC_vestibular_schwannoma_mc_rc', 'TCIA-vestibular-schwannoma-mc-rc'}	{'IDC', 'TCIA'}	2
-US ABDOMEN COMPLETE=AB	{'US', nan}	{'TCIA-cptac-pda', 'IDC-IDC_cptac_pda'}	{'IDC', 'TCIA'}	2
-3V4E-2	{'SR', nan}	{'IDC-IDC_qiba_ct_1c', 'TCIA-qiba-ct-1c'}	{'IDC', 'TCIA'}	2
-Thorax^PE_ROUTINE (Adult)	{'CT', nan}	{'TCIA-acrin-nsclc-fdg-pet', 'IDC-IDC_acrin_nsclc_fdg_pet'}	{'IDC', 'TCIA'}	2
-1V6E-2	{'SR', nan}	{'IDC-IDC_qiba_ct_1c', 'TCIA-qiba-ct-1c'}	{'IDC', 'TCIA'}	2
-Thorax^ROUTINE_CHEST_5MM (Adult)	{'CT', nan}	{'TCIA-acrin-nsclc-fdg-pet', 'IDC-IDC_acrin_nsclc_fdg_pet'}	{'IDC', 'TCIA'}	2
-4V1C-1	{'SR', nan}	{'IDC-IDC_qiba_ct_1c', 'TCIA-qiba-ct-1c'}	{'IDC', 'TCIA'}	2
-_t2of3MRI IAMS post Gad	{'MR', nan}	{'IDC-IDC_vestibular_schwannoma_mc_rc', 'TCIA-vestibular-schwannoma-mc-rc'}	{'IDC', 'TCIA'}	2
-4V1B-2	{'SR', nan}	{'IDC-IDC_qiba_ct_1c', 'TCIA-qiba-ct-1c'}	{'IDC', 'TCIA'}	2
-4V1B-1	{'SR', nan}	{'IDC-IDC_qiba_ct_1c', 'TCIA-qiba-ct-1c'}	{'IDC', 'TCIA'}	2
-4V1A-2	{'SR', nan}	{'IDC-IDC_qiba_ct_1c', 'TCIA-qiba-ct-1c'}	{'IDC', 'TCIA'}	2
-4V1A-1	{'SR', nan}	{'IDC-IDC_qiba_ct_1c', 'TCIA-qiba-ct-1c'}	{'IDC', 'TCIA'}	2
-4D CT THORAX	{'RTSTRUCT', 'CT'}	{'IDC-IDC_lctsc'}	{'IDC'}	2
-Thorax^RoutineChest (Adult)	{'CT', nan}	{'TCIA-acrin-nsclc-fdg-pet', 'IDC-IDC_acrin_nsclc_fdg_pet'}	{'IDC', 'TCIA'}	2
-_t2of3MRI Head	{'MR', nan}	{'IDC-IDC_vestibular_schwannoma_mc_rc', 'TCIA-vestibular-schwannoma-mc-rc'}	{'IDC', 'TCIA'}	2
-Thorax^THORACIC_DISSECTION (Adult)	{'CT'}	{'MIDRC-Open-A1'}	{'MIDRC'}	2
-Thorax^TRAUMA_CHEST_ABD_PEL (Adult)	{'CT'}	{'MIDRC-Open-A1'}	{'MIDRC'}	2
-1V6F-2	{'SR', nan}	{'IDC-IDC_qiba_ct_1c', 'TCIA-qiba-ct-1c'}	{'IDC', 'TCIA'}	2
-3V6F-2	{'SR', nan}	{'IDC-IDC_qiba_ct_1c', 'TCIA-qiba-ct-1c'}	{'IDC', 'TCIA'}	2
-4V1C-2	{'SR', nan}	{'IDC-IDC_qiba_ct_1c', 'TCIA-qiba-ct-1c'}	{'IDC', 'TCIA'}	2
-Thorax^PE_CHEST (Adult)	{'CT', nan}	{'TCIA-acrin-nsclc-fdg-pet', 'IDC-IDC_acrin_nsclc_fdg_pet'}	{'IDC', 'TCIA'}	2
-Thorax^VERAN_MEDIUM (Adult)	{'CT'}	{'MIDRC-Open-A1'}	{'MIDRC'}	2
-4V1D-1	{'SR', nan}	{'IDC-IDC_qiba_ct_1c', 'TCIA-qiba-ct-1c'}	{'IDC', 'TCIA'}	2
-4V2C-2	{'SR', nan}	{'IDC-IDC_qiba_ct_1c', 'TCIA-qiba-ct-1c'}	{'IDC', 'TCIA'}	2
-Thorax^LOW_DOSE_NON_CONCHEST (Adult)	{'CT', nan}	{'IDC-IDC_nsclc_radiogenomics', 'TCIA-nsclc-radiogenomics'}	{'IDC', 'TCIA'}	2
-4V2C-1	{'SR', nan}	{'IDC-IDC_qiba_ct_1c', 'TCIA-qiba-ct-1c'}	{'IDC', 'TCIA'}	2
-4V2B-2	{'SR', nan}	{'IDC-IDC_qiba_ct_1c', 'TCIA-qiba-ct-1c'}	{'IDC', 'TCIA'}	2
-4V2B-1	{'SR', nan}	{'IDC-IDC_qiba_ct_1c', 'TCIA-qiba-ct-1c'}	{'IDC', 'TCIA'}	2
-4V2A-2	{'SR', nan}	{'IDC-IDC_qiba_ct_1c', 'TCIA-qiba-ct-1c'}	{'IDC', 'TCIA'}	2
-4V2A-1	{'SR', nan}	{'IDC-IDC_qiba_ct_1c', 'TCIA-qiba-ct-1c'}	{'IDC', 'TCIA'}	2
-_t2of7  MRI IAMS	{'MR', nan}	{'IDC-IDC_vestibular_schwannoma_mc_rc', 'TCIA-vestibular-schwannoma-mc-rc'}	{'IDC', 'TCIA'}	2
-_t2of5  External Images for PACS	{'MR', nan}	{'IDC-IDC_vestibular_schwannoma_mc_rc', 'TCIA-vestibular-schwannoma-mc-rc'}	{'IDC', 'TCIA'}	2
-4V1F-2	{'SR', nan}	{'IDC-IDC_qiba_ct_1c', 'TCIA-qiba-ct-1c'}	{'IDC', 'TCIA'}	2
-4V1E-2	{'SR', nan}	{'IDC-IDC_qiba_ct_1c', 'TCIA-qiba-ct-1c'}	{'IDC', 'TCIA'}	2
-4V1E-1	{'SR', nan}	{'IDC-IDC_qiba_ct_1c', 'TCIA-qiba-ct-1c'}	{'IDC', 'TCIA'}	2
-4V1D-2	{'SR', nan}	{'IDC-IDC_qiba_ct_1c', 'TCIA-qiba-ct-1c'}	{'IDC', 'TCIA'}	2
-_t2of4External Images for PACS	{'MR', nan}	{'IDC-IDC_vestibular_schwannoma_mc_rc', 'TCIA-vestibular-schwannoma-mc-rc'}	{'IDC', 'TCIA'}	2
-1V6E-1	{'SR', nan}	{'IDC-IDC_qiba_ct_1c', 'TCIA-qiba-ct-1c'}	{'IDC', 'TCIA'}	2
-3V6E-2	{'SR', nan}	{'IDC-IDC_qiba_ct_1c', 'TCIA-qiba-ct-1c'}	{'IDC', 'TCIA'}	2
-3V6E-1	{'SR', nan}	{'IDC-IDC_qiba_ct_1c', 'TCIA-qiba-ct-1c'}	{'IDC', 'TCIA'}	2
-UROGRAPHY STUDY	{'CT', nan}	{'IDC-IDC_tcga_blca', 'TCIA-tcga-blca'}	{'IDC', 'TCIA'}	2
-Tomografia komputerowa jamy brzusznej z kontrastem	{'RTSTRUCT', nan}	{'TCIA-cptac-pda', 'IDC-IDC_cptac_pda'}	{'IDC', 'TCIA'}	2
-3V5D-1	{'SR', nan}	{'IDC-IDC_qiba_ct_1c', 'TCIA-qiba-ct-1c'}	{'IDC', 'TCIA'}	2
-Tomoscintigrafia PET total body TOMOSCINTIGRAFIA TOTAL BODY-Tomo	{'SEG', nan}	{'IDC-IDC_rider_lung_pet_ct', 'TCIA-rider-lung-pet-ct'}	{'IDC', 'TCIA'}	2
-3V5C-2	{'SR', nan}	{'IDC-IDC_qiba_ct_1c', 'TCIA-qiba-ct-1c'}	{'IDC', 'TCIA'}	2
-Trio RoutineImage Guidance	{'RTSTRUCT', nan}	{'TCIA-vestibular-schwannoma-seg', 'IDC-IDC_vestibular_schwannoma_seg'}	{'IDC', 'TCIA'}	2
-3V5C-1	{'SR', nan}	{'IDC-IDC_qiba_ct_1c', 'TCIA-qiba-ct-1c'}	{'IDC', 'TCIA'}	2
-3V5B-2	{'SR', nan}	{'IDC-IDC_qiba_ct_1c', 'TCIA-qiba-ct-1c'}	{'IDC', 'TCIA'}	2
-2-FOV uniform.test	{'PT', nan}	{'IDC-IDC_rider_lung_pet_ct', 'TCIA-rider-lung-pet-ct'}	{'IDC', 'TCIA'}	2
-ULTRASOUND/ASPIRATION EXAM	{'US'}	{'ACRdart-ACRIN_6666'}	{'ACRdart'}	2
-3V5B-1	{'SR', nan}	{'IDC-IDC_qiba_ct_1c', 'TCIA-qiba-ct-1c'}	{'IDC', 'TCIA'}	2
-UNILAT BREAST US	{'US'}	{'ACRdart-ACRIN_6666'}	{'ACRdart'}	2
-3V5A-2	{'SR', nan}	{'IDC-IDC_qiba_ct_1c', 'TCIA-qiba-ct-1c'}	{'IDC', 'TCIA'}	2
-3V5A-1	{'SR', nan}	{'IDC-IDC_qiba_ct_1c', 'TCIA-qiba-ct-1c'}	{'IDC', 'TCIA'}	2
-UROGRAM	{'SEG', nan}	{'TCIA-adrenal-acc-ki67-seg', 'IDC-IDC_adrenal_acc_ki67_seg'}	{'IDC', 'TCIA'}	2
-UROGRAM CT	{'CT', nan}	{'TCIA-tcga-kirc', 'IDC-IDC_tcga_kirc'}	{'IDC', 'TCIA'}	2
-3V4F-2	{'SR', nan}	{'IDC-IDC_qiba_ct_1c', 'TCIA-qiba-ct-1c'}	{'IDC', 'TCIA'}	2
-3V5D-2	{'SR', nan}	{'IDC-IDC_qiba_ct_1c', 'TCIA-qiba-ct-1c'}	{'IDC', 'TCIA'}	2
-Tomografia klatki piersiowej - inne	{'CT', nan}	{'TCIA-cptac-lscc', 'IDC-IDC_cptac_lscc'}	{'IDC', 'TCIA'}	2
-_t2of3 MRI IAMS	{'MR', nan}	{'IDC-IDC_vestibular_schwannoma_mc_rc', 'TCIA-vestibular-schwannoma-mc-rc'}	{'IDC', 'TCIA'}	2
-3V5E-1	{'SR', nan}	{'IDC-IDC_qiba_ct_1c', 'TCIA-qiba-ct-1c'}	{'IDC', 'TCIA'}	2
-Thorax^XL_CAP_WITH_Customized (Adult)	{'CT'}	{'MIDRC-Open-A1'}	{'MIDRC'}	2
-3V6D-2	{'SR', nan}	{'IDC-IDC_qiba_ct_1c', 'TCIA-qiba-ct-1c'}	{'IDC', 'TCIA'}	2
-3V6D-1	{'SR', nan}	{'IDC-IDC_qiba_ct_1c', 'TCIA-qiba-ct-1c'}	{'IDC', 'TCIA'}	2
-3V6C-2	{'SR', nan}	{'IDC-IDC_qiba_ct_1c', 'TCIA-qiba-ct-1c'}	{'IDC', 'TCIA'}	2
-3V6C-1	{'SR', nan}	{'IDC-IDC_qiba_ct_1c', 'TCIA-qiba-ct-1c'}	{'IDC', 'TCIA'}	2
-_t2of3  MRI IAMS post Gad	{'MR', nan}	{'IDC-IDC_vestibular_schwannoma_mc_rc', 'TCIA-vestibular-schwannoma-mc-rc'}	{'IDC', 'TCIA'}	2
-3V6B-2	{'SR', nan}	{'IDC-IDC_qiba_ct_1c', 'TCIA-qiba-ct-1c'}	{'IDC', 'TCIA'}	2
-1_PETCT_cerv_WB_CAUDCRAN (Adult)	{'PT', nan}	{'IDC-IDC_cc_tumor_heterogeneity', 'TCIA-cc-tumor-heterogeneity'}	{'IDC', 'TCIA'}	2
-3V6B-1	{'SR', nan}	{'IDC-IDC_qiba_ct_1c', 'TCIA-qiba-ct-1c'}	{'IDC', 'TCIA'}	2
-Thorax^chest abd	{'CT', nan}	{'TCIA-acrin-nsclc-fdg-pet', 'IDC-IDC_acrin_nsclc_fdg_pet'}	{'IDC', 'TCIA'}	2
-3V6A-2	{'SR', nan}	{'IDC-IDC_qiba_ct_1c', 'TCIA-qiba-ct-1c'}	{'IDC', 'TCIA'}	2
-3V6A-1	{'SR', nan}	{'IDC-IDC_qiba_ct_1c', 'TCIA-qiba-ct-1c'}	{'IDC', 'TCIA'}	2
-3V5F-2	{'SR', nan}	{'IDC-IDC_qiba_ct_1c', 'TCIA-qiba-ct-1c'}	{'IDC', 'TCIA'}	2
-TomoHD Unilateral Left	{'MG'}	{'ACRdart-EA1141Restricted', 'IDC-IDC_ea1141'}	{'ACRdart', 'IDC'}	2
-3V5E-2	{'SR', nan}	{'IDC-IDC_qiba_ct_1c', 'TCIA-qiba-ct-1c'}	{'IDC', 'TCIA'}	2
-3V2C-2	{'SR', nan}	{'IDC-IDC_qiba_ct_1c', 'TCIA-qiba-ct-1c'}	{'IDC', 'TCIA'}	2
-3V2B-2	{'SR', nan}	{'IDC-IDC_qiba_ct_1c', 'TCIA-qiba-ct-1c'}	{'IDC', 'TCIA'}	2
-4V2D-2	{'SR', nan}	{'IDC-IDC_qiba_ct_1c', 'TCIA-qiba-ct-1c'}	{'IDC', 'TCIA'}	2
-2V2E-2	{'SR', nan}	{'IDC-IDC_qiba_ct_1c', 'TCIA-qiba-ct-1c'}	{'IDC', 'TCIA'}	2
-2V2E-1	{'SR', nan}	{'IDC-IDC_qiba_ct_1c', 'TCIA-qiba-ct-1c'}	{'IDC', 'TCIA'}	2
-2V5E-1	{'SR', nan}	{'IDC-IDC_qiba_ct_1c', 'TCIA-qiba-ct-1c'}	{'IDC', 'TCIA'}	2
-XT CHEST W/CONT	{'SEG', nan}	{'IDC-IDC_nsclc_radiogenomics', 'TCIA-nsclc-radiogenomics'}	{'IDC', 'TCIA'}	2
-XR LUMBAR SPINE AND BEND 4+ VIEWS	{'DX'}	{'MIDRC-Open-R1'}	{'MIDRC'}	2
-2V5D-2	{'SR', nan}	{'IDC-IDC_qiba_ct_1c', 'TCIA-qiba-ct-1c'}	{'IDC', 'TCIA'}	2
-XR LUMBAR SPINE FLEXION AND EXTENSION ONLY	{'DX'}	{'MIDRC-Open-R1'}	{'MIDRC'}	2
-2V5D-1	{'SR', nan}	{'IDC-IDC_qiba_ct_1c', 'TCIA-qiba-ct-1c'}	{'IDC', 'TCIA'}	2
-XR_ThoracicSpine	{'DX', nan}	{'TCIA-cmb-lca', 'IDC-IDC_cmb_lca'}	{'IDC', 'TCIA'}	2
-WB PET/CT W/DELAYS	{'SEG', nan}	{'TCIA-acrin-nsclc-fdg-pet', 'IDC-IDC_acrin_nsclc_fdg_pet'}	{'IDC', 'TCIA'}	2
-XR PORT ABDOMEN 1V LINE PLCMNT - NO CHARGE	{'CR'}	{'MIDRC-Open-A1'}	{'MIDRC'}	2
-XR PORT ABDOMEN SINGLE VIEW AP	{'CR'}	{'MIDRC-Open-A1', 'MIDRC-Open-R1'}	{'MIDRC'}	2
-2V5C-2	{'SR', nan}	{'IDC-IDC_qiba_ct_1c', 'TCIA-qiba-ct-1c'}	{'IDC', 'TCIA'}	2
-XR_RF AbdPelvis	{'DX', nan}	{'IDC-IDC_cmb_pca', 'TCIA-cmb-pca'}	{'IDC', 'TCIA'}	2
-XR_LSpine	{'XA', nan}	{'IDC-IDC_cmb_mml', 'TCIA-cmb-mml'}	{'IDC', 'TCIA'}	2
-2V5C-1	{'SR', nan}	{'IDC-IDC_qiba_ct_1c', 'TCIA-qiba-ct-1c'}	{'IDC', 'TCIA'}	2
-2V5B-2	{'SR', nan}	{'IDC-IDC_qiba_ct_1c', 'TCIA-qiba-ct-1c'}	{'IDC', 'TCIA'}	2
-2V5E-2	{'SR', nan}	{'IDC-IDC_qiba_ct_1c', 'TCIA-qiba-ct-1c'}	{'IDC', 'TCIA'}	2
-XR LEFT TOES 2 VIEWS	{'CR', 'DX'}	{'MIDRC-Open-A1'}	{'MIDRC'}	2
-XR LEFT TIBIA FIBULA 3+ VIEWS	{'DX'}	{'MIDRC-Open-A1'}	{'MIDRC'}	2
-^THIGH	{'RTSTRUCT', nan}	{'IDC-IDC_soft_tissue_sarcoma', 'TCIA-soft-tissue-sarcoma'}	{'IDC', 'TCIA'}	2
-2V6E-2	{'SR', nan}	{'IDC-IDC_qiba_ct_1c', 'TCIA-qiba-ct-1c'}	{'IDC', 'TCIA'}	2
-2V6E-1	{'SR', nan}	{'IDC-IDC_qiba_ct_1c', 'TCIA-qiba-ct-1c'}	{'IDC', 'TCIA'}	2
-2V2D-1	{'SR', nan}	{'IDC-IDC_qiba_ct_1c', 'TCIA-qiba-ct-1c'}	{'IDC', 'TCIA'}	2
-2V6D-2	{'SR', nan}	{'IDC-IDC_qiba_ct_1c', 'TCIA-qiba-ct-1c'}	{'IDC', 'TCIA'}	2
-XR LEFT HIP 1 VIEW	{'CR'}	{'MIDRC-Open-A1'}	{'MIDRC'}	2
-2V6D-1	{'SR', nan}	{'IDC-IDC_qiba_ct_1c', 'TCIA-qiba-ct-1c'}	{'IDC', 'TCIA'}	2
-2V6C-2	{'SR', nan}	{'IDC-IDC_qiba_ct_1c', 'TCIA-qiba-ct-1c'}	{'IDC', 'TCIA'}	2
-2V6C-1	{'SR', nan}	{'IDC-IDC_qiba_ct_1c', 'TCIA-qiba-ct-1c'}	{'IDC', 'TCIA'}	2
-2V6B-2	{'SR', nan}	{'IDC-IDC_qiba_ct_1c', 'TCIA-qiba-ct-1c'}	{'IDC', 'TCIA'}	2
-2V2D-2	{'SR', nan}	{'IDC-IDC_qiba_ct_1c', 'TCIA-qiba-ct-1c'}	{'IDC', 'TCIA'}	2
-2V6B-1	{'SR', nan}	{'IDC-IDC_qiba_ct_1c', 'TCIA-qiba-ct-1c'}	{'IDC', 'TCIA'}	2
-2V6A-2	{'SR', nan}	{'IDC-IDC_qiba_ct_1c', 'TCIA-qiba-ct-1c'}	{'IDC', 'TCIA'}	2
-_t10of10MRI IAMS	{'MR', nan}	{'IDC-IDC_vestibular_schwannoma_mc_rc', 'TCIA-vestibular-schwannoma-mc-rc'}	{'IDC', 'TCIA'}	2
-2V6A-1	{'SR', nan}	{'IDC-IDC_qiba_ct_1c', 'TCIA-qiba-ct-1c'}	{'IDC', 'TCIA'}	2
-2V5F-2	{'SR', nan}	{'IDC-IDC_qiba_ct_1c', 'TCIA-qiba-ct-1c'}	{'IDC', 'TCIA'}	2
-2V5B-1	{'SR', nan}	{'IDC-IDC_qiba_ct_1c', 'TCIA-qiba-ct-1c'}	{'IDC', 'TCIA'}	2
-2V5A-2	{'SR', nan}	{'IDC-IDC_qiba_ct_1c', 'TCIA-qiba-ct-1c'}	{'IDC', 'TCIA'}	2
-2V5A-1	{'SR', nan}	{'IDC-IDC_qiba_ct_1c', 'TCIA-qiba-ct-1c'}	{'IDC', 'TCIA'}	2
-2V3B-1	{'SR', nan}	{'IDC-IDC_qiba_ct_1c', 'TCIA-qiba-ct-1c'}	{'IDC', 'TCIA'}	2
-2V3E-2	{'SR', nan}	{'IDC-IDC_qiba_ct_1c', 'TCIA-qiba-ct-1c'}	{'IDC', 'TCIA'}	2
-2V3E-1	{'SR', nan}	{'IDC-IDC_qiba_ct_1c', 'TCIA-qiba-ct-1c'}	{'IDC', 'TCIA'}	2
-XR RIGHT SHOULDER 1 VIEW	{'DX'}	{'MIDRC-Open-A1'}	{'MIDRC'}	2
-2V3D-2	{'SR', nan}	{'IDC-IDC_qiba_ct_1c', 'TCIA-qiba-ct-1c'}	{'IDC', 'TCIA'}	2
-2V3D-1	{'SR', nan}	{'IDC-IDC_qiba_ct_1c', 'TCIA-qiba-ct-1c'}	{'IDC', 'TCIA'}	2
-2V3C-2	{'SR', nan}	{'IDC-IDC_qiba_ct_1c', 'TCIA-qiba-ct-1c'}	{'IDC', 'TCIA'}	2
-2V3C-1	{'SR', nan}	{'IDC-IDC_qiba_ct_1c', 'TCIA-qiba-ct-1c'}	{'IDC', 'TCIA'}	2
-XR SACROILIAC JOINTS 1-2 VIEWS	{'CR', 'DX'}	{'MIDRC-Open-A1'}	{'MIDRC'}	2
-XR SACRUM AND COCCYX	{'DX'}	{'MIDRC-Open-R1'}	{'MIDRC'}	2
-XR STERNUM PA AND LATERAL	{'DX'}	{'MIDRC-Open-R1'}	{'MIDRC'}	2
-XR SHOULDER 2 OR MORE VIEW	{'DX'}	{'MIDRC-Open-A1'}	{'MIDRC'}	2
-XR SHOULDER RT 1 VIEW	{'DX'}	{'MIDRC-Open-A1'}	{'MIDRC'}	2
-XR SHOULDER RT 2 OR MORE VIEWS	{'DX'}	{'MIDRC-Open-A1'}	{'MIDRC'}	2
-XR SPINE THORACIC (AP+LAT)	{'DX'}	{'MIDRC-Open-A1'}	{'MIDRC'}	2
-XR SPINE LUMBAR (AP, LAT, FLEX/EX)	{'DX'}	{'MIDRC-Open-A1'}	{'MIDRC'}	2
-2V3F-2	{'SR', nan}	{'IDC-IDC_qiba_ct_1c', 'TCIA-qiba-ct-1c'}	{'IDC', 'TCIA'}	2
-2V4A-1	{'SR', nan}	{'IDC-IDC_qiba_ct_1c', 'TCIA-qiba-ct-1c'}	{'IDC', 'TCIA'}	2
-2V4F-2	{'SR', nan}	{'IDC-IDC_qiba_ct_1c', 'TCIA-qiba-ct-1c'}	{'IDC', 'TCIA'}	2
-2V4A-2	{'SR', nan}	{'IDC-IDC_qiba_ct_1c', 'TCIA-qiba-ct-1c'}	{'IDC', 'TCIA'}	2
-XR RIGHT CALCANEUS 2 VIEWS	{'CR'}	{'MIDRC-Open-A1'}	{'MIDRC'}	2
-2V4E-2	{'SR', nan}	{'IDC-IDC_qiba_ct_1c', 'TCIA-qiba-ct-1c'}	{'IDC', 'TCIA'}	2
-2V2F-2	{'SR', nan}	{'IDC-IDC_qiba_ct_1c', 'TCIA-qiba-ct-1c'}	{'IDC', 'TCIA'}	2
-XR RIGHT ELBOW 4+ VIEWS	{'DX'}	{'MIDRC-Open-A1'}	{'MIDRC'}	2
-2V4E-1	{'SR', nan}	{'IDC-IDC_qiba_ct_1c', 'TCIA-qiba-ct-1c'}	{'IDC', 'TCIA'}	2
-2V4D-2	{'SR', nan}	{'IDC-IDC_qiba_ct_1c', 'TCIA-qiba-ct-1c'}	{'IDC', 'TCIA'}	2
-2V4D-1	{'SR', nan}	{'IDC-IDC_qiba_ct_1c', 'TCIA-qiba-ct-1c'}	{'IDC', 'TCIA'}	2
-2V4C-2	{'SR', nan}	{'IDC-IDC_qiba_ct_1c', 'TCIA-qiba-ct-1c'}	{'IDC', 'TCIA'}	2
-2V3A-1	{'SR', nan}	{'IDC-IDC_qiba_ct_1c', 'TCIA-qiba-ct-1c'}	{'IDC', 'TCIA'}	2
-XR WRIST RIGHT (ROUTINE: AP,LAT,OBL)	{'CR', 'DX'}	{'MIDRC-Open-A1'}	{'MIDRC'}	2
-2V4C-1	{'SR', nan}	{'IDC-IDC_qiba_ct_1c', 'TCIA-qiba-ct-1c'}	{'IDC', 'TCIA'}	2
-2V4B-2	{'SR', nan}	{'IDC-IDC_qiba_ct_1c', 'TCIA-qiba-ct-1c'}	{'IDC', 'TCIA'}	2
-2V3A-2	{'SR', nan}	{'IDC-IDC_qiba_ct_1c', 'TCIA-qiba-ct-1c'}	{'IDC', 'TCIA'}	2
-2V4B-1	{'SR', nan}	{'IDC-IDC_qiba_ct_1c', 'TCIA-qiba-ct-1c'}	{'IDC', 'TCIA'}	2
-XR THORACIC SPINE AP AND LATERAL	{'DX'}	{'MIDRC-Open-R1'}	{'MIDRC'}	2
-2V6F-2	{'SR', nan}	{'IDC-IDC_qiba_ct_1c', 'TCIA-qiba-ct-1c'}	{'IDC', 'TCIA'}	2
-_t17of17_MRI IAMS	{'MR', nan}	{'IDC-IDC_vestibular_schwannoma_mc_rc', 'TCIA-vestibular-schwannoma-mc-rc'}	{'IDC', 'TCIA'}	2
-XR LEFT FEMUR MIN 2 VIEWS	{'DX'}	{'MIDRC-Open-A1'}	{'MIDRC'}	2
-3V1B-2	{'SR', nan}	{'IDC-IDC_qiba_ct_1c', 'TCIA-qiba-ct-1c'}	{'IDC', 'TCIA'}	2
-_t1of5External Images for PACS	{'MR', nan}	{'IDC-IDC_vestibular_schwannoma_mc_rc', 'TCIA-vestibular-schwannoma-mc-rc'}	{'IDC', 'TCIA'}	2
-3V1B-1	{'SR', nan}	{'IDC-IDC_qiba_ct_1c', 'TCIA-qiba-ct-1c'}	{'IDC', 'TCIA'}	2
-X-RAY CLAVICLE COMPLETE - RIGHT	{'CR', 'DX'}	{'MIDRC-Open-A1'}	{'MIDRC'}	2
-2V1D-2	{'SR', nan}	{'IDC-IDC_qiba_ct_1c', 'TCIA-qiba-ct-1c'}	{'IDC', 'TCIA'}	2
-X-RAY ELBOW COMPLETE MIN 3 VWS - LEFT	{'CR', 'DX'}	{'MIDRC-Open-A1'}	{'MIDRC'}	2
-_t1of4 MRI IAMS	{'MR', nan}	{'IDC-IDC_vestibular_schwannoma_mc_rc', 'TCIA-vestibular-schwannoma-mc-rc'}	{'IDC', 'TCIA'}	2
-2V1E-1	{'SR', nan}	{'IDC-IDC_qiba_ct_1c', 'TCIA-qiba-ct-1c'}	{'IDC', 'TCIA'}	2
-3V1A-2	{'SR', nan}	{'IDC-IDC_qiba_ct_1c', 'TCIA-qiba-ct-1c'}	{'IDC', 'TCIA'}	2
-2V1E-2	{'SR', nan}	{'IDC-IDC_qiba_ct_1c', 'TCIA-qiba-ct-1c'}	{'IDC', 'TCIA'}	2
-3V1A-1	{'SR', nan}	{'IDC-IDC_qiba_ct_1c', 'TCIA-qiba-ct-1c'}	{'IDC', 'TCIA'}	2
-3PHASE, DUAL E	{'CT', nan}	{'IDC-IDC_rider_lung_pet_ct', 'TCIA-rider-lung-pet-ct'}	{'IDC', 'TCIA'}	2
-3MM	{nan}	{'TCIA-pancreatic-ct-cbct-seg'}	{'TCIA'}	2
-2V1F-2	{'SR', nan}	{'IDC-IDC_qiba_ct_1c', 'TCIA-qiba-ct-1c'}	{'IDC', 'TCIA'}	2
-3D decay linearity	{'CT', nan}	{'IDC-IDC_rider_lung_pet_ct', 'TCIA-rider-lung-pet-ct'}	{'IDC', 'TCIA'}	2
-X-RAY GI UPPER DOUBLE CONTRAST W/KUB	{'DX'}	{'MIDRC-Open-A1'}	{'MIDRC'}	2
-X-RAY CHEST OUTSIDE IMAGE	{'CR', 'DX'}	{'MIDRC-Open-A1'}	{'MIDRC'}	2
-3V1C-1	{'SR', nan}	{'IDC-IDC_qiba_ct_1c', 'TCIA-qiba-ct-1c'}	{'IDC', 'TCIA'}	2
-3D MULTIPLANAR/C-A-P	{'SEG', nan}	{'TCIA-tcga-kirc', 'IDC-IDC_tcga_kirc'}	{'IDC', 'TCIA'}	2
-3V1C-2	{'SR', nan}	{'IDC-IDC_qiba_ct_1c', 'TCIA-qiba-ct-1c'}	{'IDC', 'TCIA'}	2
-3V2B-1	{'SR', nan}	{'IDC-IDC_qiba_ct_1c', 'TCIA-qiba-ct-1c'}	{'IDC', 'TCIA'}	2
-WHOLE BODY	{'PT', nan}	{'TCIA-cptac-luad', 'IDC-IDC_cptac_luad'}	{'IDC', 'TCIA'}	2
-3V2A-2	{'SR', nan}	{'IDC-IDC_qiba_ct_1c', 'TCIA-qiba-ct-1c'}	{'IDC', 'TCIA'}	2
-_t1of6 MRI IAMS	{'MR', nan}	{'IDC-IDC_vestibular_schwannoma_mc_rc', 'TCIA-vestibular-schwannoma-mc-rc'}	{'IDC', 'TCIA'}	2
-WRIST COMPLETE RIGHT 3 VIEWS MIN	{'CR', 'DX'}	{'MIDRC-Open-R1'}	{'MIDRC'}	2
-3V2A-1	{'SR', nan}	{'IDC-IDC_qiba_ct_1c', 'TCIA-qiba-ct-1c'}	{'IDC', 'TCIA'}	2
-3V1F-2	{'SR', nan}	{'IDC-IDC_qiba_ct_1c', 'TCIA-qiba-ct-1c'}	{'IDC', 'TCIA'}	2
-_t1of6 External Images for PACS	{'MR', nan}	{'IDC-IDC_vestibular_schwannoma_mc_rc', 'TCIA-vestibular-schwannoma-mc-rc'}	{'IDC', 'TCIA'}	2
-3V1E-2	{'SR', nan}	{'IDC-IDC_qiba_ct_1c', 'TCIA-qiba-ct-1c'}	{'IDC', 'TCIA'}	2
-3V1E-1	{'SR', nan}	{'IDC-IDC_qiba_ct_1c', 'TCIA-qiba-ct-1c'}	{'IDC', 'TCIA'}	2
-3V1D-2	{'SR', nan}	{'IDC-IDC_qiba_ct_1c', 'TCIA-qiba-ct-1c'}	{'IDC', 'TCIA'}	2
-_t1of6  MRI IAMS	{'MR', nan}	{'IDC-IDC_vestibular_schwannoma_mc_rc', 'TCIA-vestibular-schwannoma-mc-rc'}	{'IDC', 'TCIA'}	2
-3V1D-1	{'SR', nan}	{'IDC-IDC_qiba_ct_1c', 'TCIA-qiba-ct-1c'}	{'IDC', 'TCIA'}	2
-X-RAY CALCANEUS MINIMUM 2 VIEWS - RIGHT	{'DX'}	{'MIDRC-Open-A1'}	{'MIDRC'}	2
-2V1D-1	{'SR', nan}	{'IDC-IDC_qiba_ct_1c', 'TCIA-qiba-ct-1c'}	{'IDC', 'TCIA'}	2
-2V2A-1	{'SR', nan}	{'IDC-IDC_qiba_ct_1c', 'TCIA-qiba-ct-1c'}	{'IDC', 'TCIA'}	2
-3615 MR RIGHT BREAST WO/W CONT	{'MR', nan}	{'IDC-IDC_acrin_contralateral_breast_mr', 'TCIA-acrin-contralateral-breast-mr'}	{'IDC', 'TCIA'}	2
-2V2C-2	{'SR', nan}	{'IDC-IDC_qiba_ct_1c', 'TCIA-qiba-ct-1c'}	{'IDC', 'TCIA'}	2
-XR CERVICAL SPINE 2-3 VIEWS WITH FLEXION EXTENSION	{'DX'}	{'MIDRC-Open-A1'}	{'MIDRC'}	2
-XR FOOT 3+ VIEWS	{'CR'}	{'MIDRC-Open-A1'}	{'MIDRC'}	2
-2V2B-2	{'SR', nan}	{'IDC-IDC_qiba_ct_1c', 'TCIA-qiba-ct-1c'}	{'IDC', 'TCIA'}	2
-XR HAND LEFT (ROUTINE: AP,LAT,OBL)	{'CR', 'DX'}	{'MIDRC-Open-A1'}	{'MIDRC'}	2
-_t1of17  External Images for PACS	{'MR', nan}	{'IDC-IDC_vestibular_schwannoma_mc_rc', 'TCIA-vestibular-schwannoma-mc-rc'}	{'IDC', 'TCIA'}	2
-XR HAND RIGHT (ROUTINE: AP,LAT,OBL)	{'CR', 'DX'}	{'MIDRC-Open-A1'}	{'MIDRC'}	2
-_t1of11_MRI RNTNE historical imaging	{'MR', nan}	{'IDC-IDC_vestibular_schwannoma_mc_rc', 'TCIA-vestibular-schwannoma-mc-rc'}	{'IDC', 'TCIA'}	2
-XR HIP LEFT 2-3 VIEWS WWO PELVIS	{'CR'}	{'MIDRC-Open-A1'}	{'MIDRC'}	2
-XR HIP RIGHT 1 VIEW	{'DX'}	{'MIDRC-Open-A1'}	{'MIDRC'}	2
-2V2C-1	{'SR', nan}	{'IDC-IDC_qiba_ct_1c', 'TCIA-qiba-ct-1c'}	{'IDC', 'TCIA'}	2
-XR KNEE LT 4 OR MORE VIEWS	{'CR'}	{'MIDRC-Open-A1'}	{'MIDRC'}	2
-XR KNEE RT 1 OR 2 VIEWS	{'DX'}	{'MIDRC-Open-A1'}	{'MIDRC'}	2
-XR KNEE RT 3 VIEWS	{'DX'}	{'MIDRC-Open-A1'}	{'MIDRC'}	2
-XR KNEES ANTEROPOSTERIOR STANDING BILATERAL	{'DX'}	{'MIDRC-Open-A1'}	{'MIDRC'}	2
-_t1of10External Images for PACS	{'MR', nan}	{'IDC-IDC_vestibular_schwannoma_mc_rc', 'TCIA-vestibular-schwannoma-mc-rc'}	{'IDC', 'TCIA'}	2
-XR KUB UPRIGHT, ABDOMEN 1 VIEW	{'DX'}	{'MIDRC-Open-R1'}	{'MIDRC'}	2
-_t1of2  MRI Head	{'MR', nan}	{'IDC-IDC_vestibular_schwannoma_mc_rc', 'TCIA-vestibular-schwannoma-mc-rc'}	{'IDC', 'TCIA'}	2
-XR CAP	{'DX', nan}	{'TCIA-cmb-crc', 'IDC-IDC_cmb_crc'}	{'IDC', 'TCIA'}	2
-3615 - MR BREAST WO/W CONT #6667	{'MR', nan}	{'IDC-IDC_acrin_contralateral_breast_mr', 'TCIA-acrin-contralateral-breast-mr'}	{'IDC', 'TCIA'}	2
-XR ANKLE RIGHT (ROUTINE: AP,LAT,OBL)	{'CR', 'DX'}	{'MIDRC-Open-A1'}	{'MIDRC'}	2
-3615 - 6667 LIMITED MR RT BREAST WO/W CONT	{'MR', nan}	{'IDC-IDC_acrin_contralateral_breast_mr', 'TCIA-acrin-contralateral-breast-mr'}	{'IDC', 'TCIA'}	2
-2V2A-2	{'SR', nan}	{'IDC-IDC_qiba_ct_1c', 'TCIA-qiba-ct-1c'}	{'IDC', 'TCIA'}	2
-X-RAY HIPS BILATERAL WITH PELVIS 3 OR 4 VIEWS	{'DX'}	{'MIDRC-Open-A1'}	{'MIDRC'}	2
-X-RAY HIPS BILATERAL WITH PELVIS MINIMUM 5 VIEWS	{'DX'}	{'MIDRC-Open-A1'}	{'MIDRC'}	2
-_t1of3  MRI IAMS post Gad	{'MR', nan}	{'IDC-IDC_vestibular_schwannoma_mc_rc', 'TCIA-vestibular-schwannoma-mc-rc'}	{'IDC', 'TCIA'}	2
-3607 MR LT BREAST WO/W CONT	{'MR', 'SEG'}	{'IDC-IDC_ispy1'}	{'IDC'}	2
-X-RAY SCAPULA COMPLETE - RIGHT	{'DX'}	{'MIDRC-Open-A1'}	{'MIDRC'}	2
-_t1of3  MRI IAMS	{'MR', nan}	{'IDC-IDC_vestibular_schwannoma_mc_rc', 'TCIA-vestibular-schwannoma-mc-rc'}	{'IDC', 'TCIA'}	2
-X-RAY TIBIA & FIBULA 2 VIEWS - RIGHT	{'CR', 'DX'}	{'MIDRC-Open-A1'}	{'MIDRC'}	2
-_t1of3  MRI Head	{'MR', nan}	{'IDC-IDC_vestibular_schwannoma_mc_rc', 'TCIA-vestibular-schwannoma-mc-rc'}	{'IDC', 'TCIA'}	2
-2V2B-1	{'SR', nan}	{'IDC-IDC_qiba_ct_1c', 'TCIA-qiba-ct-1c'}	{'IDC', 'TCIA'}	2
-XA_Biopsy	{'XA', nan}	{'TCIA-cmb-aml', 'IDC-IDC_cmb_aml'}	{'IDC', 'TCIA'}	2
-XA_Pelvis	{'XA', nan}	{'TCIA-cmb-aml', 'IDC-IDC_cmb_aml'}	{'IDC', 'TCIA'}	2
-3607 MR BREAST WO OR W BILAT	{'MR', 'SEG'}	{'IDC-IDC_ispy1'}	{'IDC'}	2
-XR ABDOMEN 2 VIEWS	{'DX'}	{'MIDRC-Open-A1'}	{'MIDRC'}	2
-4V2D-1	{'SR', nan}	{'IDC-IDC_qiba_ct_1c', 'TCIA-qiba-ct-1c'}	{'IDC', 'TCIA'}	2
-4V2E-1	{'SR', nan}	{'IDC-IDC_qiba_ct_1c', 'TCIA-qiba-ct-1c'}	{'IDC', 'TCIA'}	2
-6V1E-2	{'SR', nan}	{'IDC-IDC_qiba_ct_1c', 'TCIA-qiba-ct-1c'}	{'IDC', 'TCIA'}	2
-5V4B-1	{'SR', nan}	{'IDC-IDC_qiba_ct_1c', 'TCIA-qiba-ct-1c'}	{'IDC', 'TCIA'}	2
-5V4B-2	{'SR', nan}	{'IDC-IDC_qiba_ct_1c', 'TCIA-qiba-ct-1c'}	{'IDC', 'TCIA'}	2
-T/A/P W/C LIVER	{'SEG', nan}	{'IDC-IDC_hcc_tace_seg', 'TCIA-hcc-tace-seg'}	{'IDC', 'TCIA'}	2
-1V5C-1	{'SR', nan}	{'IDC-IDC_qiba_ct_1c', 'TCIA-qiba-ct-1c'}	{'IDC', 'TCIA'}	2
-T1 - US	{'US'}	{'ACRdart-ACRIN_6666'}	{'ACRdart'}	2
-T11-L1/RT CLAVICLE	{'SEG', nan}	{'TCIA-spine-mets-ct-seg', 'IDC-IDC_spine_mets_ct_seg'}	{'IDC', 'TCIA'}	2
-T3	{'SEG', nan}	{'TCIA-spine-mets-ct-seg', 'IDC-IDC_spine_mets_ct_seg'}	{'IDC', 'TCIA'}	2
-TAP LIVER W/C	{'SEG', nan}	{'IDC-IDC_hcc_tace_seg', 'TCIA-hcc-tace-seg'}	{'IDC', 'TCIA'}	2
-5V4A-2	{'SR', nan}	{'IDC-IDC_qiba_ct_1c', 'TCIA-qiba-ct-1c'}	{'IDC', 'TCIA'}	2
-5V3B-1	{'SR', nan}	{'IDC-IDC_qiba_ct_1c', 'TCIA-qiba-ct-1c'}	{'IDC', 'TCIA'}	2
-TB TOTAL BODY	{'NM', nan}	{'TCIA-tcga-luad', 'IDC-IDC_tcga_luad'}	{'IDC', 'TCIA'}	2
-THOR.ABD.PEL.BED.	{'CT', nan}	{'IDC-IDC_cptac_sar', 'TCIA-cptac-sar'}	{'IDC', 'TCIA'}	2
-1V5C-2	{'SR', nan}	{'IDC-IDC_qiba_ct_1c', 'TCIA-qiba-ct-1c'}	{'IDC', 'TCIA'}	2
-THORACIC SPINE 3 VIEWS	{'CR', 'DX'}	{'MIDRC-Open-R1'}	{'MIDRC'}	2
-THORAX	{'RTSTRUCT', 'CT'}	{'IDC-IDC_lctsc'}	{'IDC'}	2
-THORAX (Adult)	{'CT', nan}	{'TCIA-acrin-nsclc-fdg-pet', 'IDC-IDC_acrin_nsclc_fdg_pet'}	{'IDC', 'TCIA'}	2
-5V4A-1	{'SR', nan}	{'IDC-IDC_qiba_ct_1c', 'TCIA-qiba-ct-1c'}	{'IDC', 'TCIA'}	2
-T/A/P LIVER W/C	{'SEG', nan}	{'IDC-IDC_hcc_tace_seg', 'TCIA-hcc-tace-seg'}	{'IDC', 'TCIA'}	2
-T SPINERIB & PELVIS	{'SEG', nan}	{'TCIA-spine-mets-ct-seg', 'IDC-IDC_spine_mets_ct_seg'}	{'IDC', 'TCIA'}	2
-5V4C-1	{'SR', nan}	{'IDC-IDC_qiba_ct_1c', 'TCIA-qiba-ct-1c'}	{'IDC', 'TCIA'}	2
-T L S SPINE	{'CT', nan}	{'TCIA-spine-mets-ct-seg', 'IDC-IDC_spine_mets_ct_seg'}	{'IDC', 'TCIA'}	2
-5V5B-2	{'SR', nan}	{'IDC-IDC_qiba_ct_1c', 'TCIA-qiba-ct-1c'}	{'IDC', 'TCIA'}	2
-5V5B-1	{'SR', nan}	{'IDC-IDC_qiba_ct_1c', 'TCIA-qiba-ct-1c'}	{'IDC', 'TCIA'}	2
-5V5A-2	{'SR', nan}	{'IDC-IDC_qiba_ct_1c', 'TCIA-qiba-ct-1c'}	{'IDC', 'TCIA'}	2
-Specials^ADRENAL_ABD_WO_W (Adult)	{'CT', nan}	{'TCIA-adrenal-acc-ki67-seg', 'IDC-IDC_adrenal_acc_ki67_seg'}	{'IDC', 'TCIA'}	2
-Specials^RCCTPET_THORAX_8F (Adult)	{'RTSTRUCT', 'CT'}	{'IDC-IDC_lctsc'}	{'IDC'}	2
-Spine^CRANIOSPINAL_SUPINE (Adult)	{'SEG', nan}	{'TCIA-spine-mets-ct-seg', 'IDC-IDC_spine_mets_ct_seg'}	{'IDC', 'TCIA'}	2
-5V5A-1	{'SR', nan}	{'IDC-IDC_qiba_ct_1c', 'TCIA-qiba-ct-1c'}	{'IDC', 'TCIA'}	2
-Spine^SPINE_BONE_SBRT_4D (Adult)	{'SEG', nan}	{'TCIA-spine-mets-ct-seg', 'IDC-IDC_spine_mets_ct_seg'}	{'IDC', 'TCIA'}	2
-5V4F-2	{'SR', nan}	{'IDC-IDC_qiba_ct_1c', 'TCIA-qiba-ct-1c'}	{'IDC', 'TCIA'}	2
-Standard Diagnostic- TomoHD	{'MG', nan}	{'TCIA-breast-cancer-screening-dbt', 'IDC-IDC_breast_cancer_screening_dbt'}	{'IDC', 'TCIA'}	2
-5V4E-2	{'SR', nan}	{'IDC-IDC_qiba_ct_1c', 'TCIA-qiba-ct-1c'}	{'IDC', 'TCIA'}	2
-5V4E-1	{'SR', nan}	{'IDC-IDC_qiba_ct_1c', 'TCIA-qiba-ct-1c'}	{'IDC', 'TCIA'}	2
-5V4D-2	{'SR', nan}	{'IDC-IDC_qiba_ct_1c', 'TCIA-qiba-ct-1c'}	{'IDC', 'TCIA'}	2
-5V4D-1	{'SR', nan}	{'IDC-IDC_qiba_ct_1c', 'TCIA-qiba-ct-1c'}	{'IDC', 'TCIA'}	2
-5V4C-2	{'SR', nan}	{'IDC-IDC_qiba_ct_1c', 'TCIA-qiba-ct-1c'}	{'IDC', 'TCIA'}	2
-1V5D-1	{'SR', nan}	{'IDC-IDC_qiba_ct_1c', 'TCIA-qiba-ct-1c'}	{'IDC', 'TCIA'}	2
-5V3F-2	{'SR', nan}	{'IDC-IDC_qiba_ct_1c', 'TCIA-qiba-ct-1c'}	{'IDC', 'TCIA'}	2
-_t4of6  MRI IAMS post Gad	{'MR', nan}	{'IDC-IDC_vestibular_schwannoma_mc_rc', 'TCIA-vestibular-schwannoma-mc-rc'}	{'IDC', 'TCIA'}	2
-5V3D-1	{'SR', nan}	{'IDC-IDC_qiba_ct_1c', 'TCIA-qiba-ct-1c'}	{'IDC', 'TCIA'}	2
-TK jamy brzusznej lub miednicy mniejszej bez wzmoc.kontr. i co n	{'RTSTRUCT', nan}	{'TCIA-cptac-ccrcc', 'IDC-IDC_cptac_ccrcc'}	{'IDC', 'TCIA'}	2
-TK jamy brzusznej z ko	{'RTSTRUCT', nan}	{'TCIA-cptac-pda', 'IDC-IDC_cptac_pda'}	{'IDC', 'TCIA'}	2
-TK jamy brzusznej z kontrastem	{'RTSTRUCT', nan}	{'TCIA-cptac-pda', 'IDC-IDC_cptac_pda'}	{'IDC', 'TCIA'}	2
-TK klatki piersiowej	{'RTSTRUCT', nan}	{'TCIA-cptac-pda', 'IDC-IDC_cptac_pda'}	{'IDC', 'TCIA'}	2
-TK klatki piersiowej bez i ze wzmocnieniem kontrastowym	{'CT', nan}	{'TCIA-cptac-lscc', 'IDC-IDC_cptac_lscc'}	{'IDC', 'TCIA'}	2
-TK klatki piersiowej bez i ze wzmocnieniem kontrastowym - VISIPA	{'CT', nan}	{'TCIA-cptac-lscc', 'IDC-IDC_cptac_lscc'}	{'IDC', 'TCIA'}	2
-1V5E-1	{'SR', nan}	{'IDC-IDC_qiba_ct_1c', 'TCIA-qiba-ct-1c'}	{'IDC', 'TCIA'}	2
-TK klatki piersiowej bez kontrastu i z kontrastem	{'CT', nan}	{'TCIA-cptac-lscc', 'IDC-IDC_cptac_lscc'}	{'IDC', 'TCIA'}	2
-MRI Abdomen W, W/O Contrast	{'SEG', nan}	{'TCIA-tcga-lihc', 'IDC-IDC_tcga_lihc'}	{'IDC', 'TCIA'}	2
-5V3C-2	{'SR', nan}	{'IDC-IDC_qiba_ct_1c', 'TCIA-qiba-ct-1c'}	{'IDC', 'TCIA'}	2
-TOMO DIAGNOSTIC MAMM RIGHT	{'MG'}	{'ACRdart-EA1141Restricted', 'IDC-IDC_ea1141'}	{'ACRdart', 'IDC'}	2
-TOMOGRAFIA COMPUTADORI	{'CT', nan}	{'TCIA-tcga-stad', 'IDC-IDC_tcga_stad'}	{'IDC', 'TCIA'}	2
-TOMOGRAFIA JAMY BRZUSZNEJ Z KONTRASTEM	{'RTSTRUCT', nan}	{'TCIA-cptac-pda', 'IDC-IDC_cptac_pda'}	{'IDC', 'TCIA'}	2
-5V3C-1	{'SR', nan}	{'IDC-IDC_qiba_ct_1c', 'TCIA-qiba-ct-1c'}	{'IDC', 'TCIA'}	2
-5V3B-2	{'SR', nan}	{'IDC-IDC_qiba_ct_1c', 'TCIA-qiba-ct-1c'}	{'IDC', 'TCIA'}	2
-TK jamy brzusznej lub miednicy malej bez kontrastu i z kontraste	{'RTSTRUCT', nan}	{'TCIA-cptac-pda', 'IDC-IDC_cptac_pda'}	{'IDC', 'TCIA'}	2
-TK j.brzusznej/mied malej BK i min 2 fazy ZK	{'RTSTRUCT', nan}	{'TCIA-cptac-pda', 'IDC-IDC_cptac_pda'}	{'IDC', 'TCIA'}	2
-1V5D-2	{'SR', nan}	{'IDC-IDC_qiba_ct_1c', 'TCIA-qiba-ct-1c'}	{'IDC', 'TCIA'}	2
-TK SPECJ. JAMY BRZUSZN	{'SEG', nan}	{'TCIA-cptac-ccrcc', 'IDC-IDC_cptac_ccrcc'}	{'IDC', 'TCIA'}	2
-5V3E-2	{'SR', nan}	{'IDC-IDC_qiba_ct_1c', 'TCIA-qiba-ct-1c'}	{'IDC', 'TCIA'}	2
-THORAX WITH	{'SEG', nan}	{'TCIA-lidc-idri', 'IDC-IDC_lidc_idri'}	{'IDC', 'TCIA'}	2
-5V3E-1	{'SR', nan}	{'IDC-IDC_qiba_ct_1c', 'TCIA-qiba-ct-1c'}	{'IDC', 'TCIA'}	2
-TK - BRZUCHA Z K	{'RTSTRUCT', nan}	{'TCIA-cptac-pda', 'IDC-IDC_cptac_pda'}	{'IDC', 'TCIA'}	2
-TK - KLP	{'CT', nan}	{'TCIA-cptac-luad', 'IDC-IDC_cptac_luad'}	{'IDC', 'TCIA'}	2
-TK - j. brzusznej	{'RTSTRUCT', nan}	{'TCIA-cptac-ccrcc', 'IDC-IDC_cptac_ccrcc'}	{'IDC', 'TCIA'}	2
-TK - jama brzuszna z kontrastem	{'RTSTRUCT', nan}	{'TCIA-cptac-pda', 'IDC-IDC_cptac_pda'}	{'IDC', 'TCIA'}	2
-TK Angiografia tt. i zyl plucnych	{'CT', nan}	{'TCIA-cptac-luad', 'IDC-IDC_cptac_luad'}	{'IDC', 'TCIA'}	2
-TK J BRZUSZNEJ	{'RTSTRUCT', nan}	{'TCIA-cptac-pda', 'IDC-IDC_cptac_pda'}	{'IDC', 'TCIA'}	2
-_t4of5  MRI Head	{'MR', nan}	{'IDC-IDC_vestibular_schwannoma_mc_rc', 'TCIA-vestibular-schwannoma-mc-rc'}	{'IDC', 'TCIA'}	2
-TK J. BRZ. I M.M	{'RTSTRUCT', nan}	{'TCIA-cptac-pda', 'IDC-IDC_cptac_pda'}	{'IDC', 'TCIA'}	2
-TK JAMA BRZUSZNA I MIE	{'RTSTRUCT', nan}	{'TCIA-cptac-pda', 'IDC-IDC_cptac_pda'}	{'IDC', 'TCIA'}	2
-5V3D-2	{'SR', nan}	{'IDC-IDC_qiba_ct_1c', 'TCIA-qiba-ct-1c'}	{'IDC', 'TCIA'}	2
-TK JAMY BRZUSZNEJ I MIEDNICY MNIEJSZEJ	{'RTSTRUCT', nan}	{'TCIA-cptac-pda', 'IDC-IDC_cptac_pda'}	{'IDC', 'TCIA'}	2
-TK Klatki piersiowej bez kontrastu	{'CT', nan}	{'TCIA-cptac-lscc', 'IDC-IDC_cptac_lscc'}	{'IDC', 'TCIA'}	2
-Specials^01_Biopsy_1 (Adult)	{'CT', nan}	{'TCIA-cptac-luad', 'IDC-IDC_cptac_luad'}	{'IDC', 'TCIA'}	2
-Specials 1PETCT_Wholebody	{'SEG', nan}	{'TCIA-acrin-nsclc-fdg-pet', 'IDC-IDC_acrin_nsclc_fdg_pet'}	{'IDC', 'TCIA'}	2
-5V5C-1	{'SR', nan}	{'IDC-IDC_qiba_ct_1c', 'TCIA-qiba-ct-1c'}	{'IDC', 'TCIA'}	2
-SUPINE RECTUM	{'CT', nan}	{'IDC-IDC_pelvic_reference_data', 'TCIA-pelvic-reference-data'}	{'IDC', 'TCIA'}	2
-6667 acrin	{'MR', nan}	{'IDC-IDC_acrin_contralateral_breast_mr', 'TCIA-acrin-contralateral-breast-mr'}	{'IDC', 'TCIA'}	2
-6667 LT BREAST/GAD	{'MR', nan}	{'IDC-IDC_acrin_contralateral_breast_mr', 'TCIA-acrin-contralateral-breast-mr'}	{'IDC', 'TCIA'}	2
-6667 CONTRALATERAL	{'MR', nan}	{'IDC-IDC_acrin_contralateral_breast_mr', 'TCIA-acrin-contralateral-breast-mr'}	{'IDC', 'TCIA'}	2
-_t5of8MRI IAMS post Gad	{'MR', nan}	{'IDC-IDC_vestibular_schwannoma_mc_rc', 'TCIA-vestibular-schwannoma-mc-rc'}	{'IDC', 'TCIA'}	2
-1V5A-1	{'SR', nan}	{'IDC-IDC_qiba_ct_1c', 'TCIA-qiba-ct-1c'}	{'IDC', 'TCIA'}	2
-6667 CONTRA BREAST	{'MR', nan}	{'IDC-IDC_acrin_contralateral_breast_mr', 'TCIA-acrin-contralateral-breast-mr'}	{'IDC', 'TCIA'}	2
-1V5A-2	{'SR', nan}	{'IDC-IDC_qiba_ct_1c', 'TCIA-qiba-ct-1c'}	{'IDC', 'TCIA'}	2
-_t5of7  MRI IAMS	{'MR', nan}	{'IDC-IDC_vestibular_schwannoma_mc_rc', 'TCIA-vestibular-schwannoma-mc-rc'}	{'IDC', 'TCIA'}	2
-6667 BREAST WO/W CONT	{'MR', nan}	{'IDC-IDC_acrin_contralateral_breast_mr', 'TCIA-acrin-contralateral-breast-mr'}	{'IDC', 'TCIA'}	2
-6026   ABD CT W/C	{'CT', nan}	{'TCIA-tcga-kirc', 'IDC-IDC_tcga_kirc'}	{'IDC', 'TCIA'}	2
-5mm chest	{'CT', nan}	{'IDC-IDC_lung_pet_ct_dx', 'TCIA-lung-pet-ct-dx'}	{'IDC', 'TCIA'}	2
-5V6F-2	{'SR', nan}	{'IDC-IDC_qiba_ct_1c', 'TCIA-qiba-ct-1c'}	{'IDC', 'TCIA'}	2
-5V6E-2	{'SR', nan}	{'IDC-IDC_qiba_ct_1c', 'TCIA-qiba-ct-1c'}	{'IDC', 'TCIA'}	2
-_t5of6  MRI IAMS	{'MR', nan}	{'IDC-IDC_vestibular_schwannoma_mc_rc', 'TCIA-vestibular-schwannoma-mc-rc'}	{'IDC', 'TCIA'}	2
-5V6E-1	{'SR', nan}	{'IDC-IDC_qiba_ct_1c', 'TCIA-qiba-ct-1c'}	{'IDC', 'TCIA'}	2
-1V4F-2	{'SR', nan}	{'IDC-IDC_qiba_ct_1c', 'TCIA-qiba-ct-1c'}	{'IDC', 'TCIA'}	2
-STUDY RT BREAST	{'MR', nan}	{'IDC-IDC_acrin_contralateral_breast_mr', 'TCIA-acrin-contralateral-breast-mr'}	{'IDC', 'TCIA'}	2
-5V6D-1	{'SR', nan}	{'IDC-IDC_qiba_ct_1c', 'TCIA-qiba-ct-1c'}	{'IDC', 'TCIA'}	2
-STANDARD Abdomen	{'RTSTRUCT', nan}	{'TCIA-cptac-pda', 'IDC-IDC_cptac_pda'}	{'IDC', 'TCIA'}	2
-6V1E-1	{'SR', nan}	{'IDC-IDC_qiba_ct_1c', 'TCIA-qiba-ct-1c'}	{'IDC', 'TCIA'}	2
-2V3B-2	{'SR', nan}	{'IDC-IDC_qiba_ct_1c', 'TCIA-qiba-ct-1c'}	{'IDC', 'TCIA'}	2
-6V1D-1	{'SR', nan}	{'IDC-IDC_qiba_ct_1c', 'TCIA-qiba-ct-1c'}	{'IDC', 'TCIA'}	2
-6V1C-2	{'SR', nan}	{'IDC-IDC_qiba_ct_1c', 'TCIA-qiba-ct-1c'}	{'IDC', 'TCIA'}	2
-6V1C-1	{'SR', nan}	{'IDC-IDC_qiba_ct_1c', 'TCIA-qiba-ct-1c'}	{'IDC', 'TCIA'}	2
-6V1B-2	{'SR', nan}	{'IDC-IDC_qiba_ct_1c', 'TCIA-qiba-ct-1c'}	{'IDC', 'TCIA'}	2
-6V1B-1	{'SR', nan}	{'IDC-IDC_qiba_ct_1c', 'TCIA-qiba-ct-1c'}	{'IDC', 'TCIA'}	2
-6V1A-2	{'SR', nan}	{'IDC-IDC_qiba_ct_1c', 'TCIA-qiba-ct-1c'}	{'IDC', 'TCIA'}	2
-6V1A-1	{'SR', nan}	{'IDC-IDC_qiba_ct_1c', 'TCIA-qiba-ct-1c'}	{'IDC', 'TCIA'}	2
-SPINE	{'SEG', nan}	{'TCIA-spine-mets-ct-seg', 'IDC-IDC_spine_mets_ct_seg'}	{'IDC', 'TCIA'}	2
-_t5of9MRI Head	{'MR', nan}	{'IDC-IDC_vestibular_schwannoma_mc_rc', 'TCIA-vestibular-schwannoma-mc-rc'}	{'IDC', 'TCIA'}	2
-SPINE^C-SPINE	{'MR'}	{'MIDRC-Open-A1'}	{'MIDRC'}	2
-6667CONDRLATERAL BREAS	{'MR', nan}	{'IDC-IDC_acrin_contralateral_breast_mr', 'TCIA-acrin-contralateral-breast-mr'}	{'IDC', 'TCIA'}	2
-6667/sodium	{'MR', nan}	{'IDC-IDC_acrin_contralateral_breast_mr', 'TCIA-acrin-contralateral-breast-mr'}	{'IDC', 'TCIA'}	2
-_t5of9  MRI IAMS	{'MR', nan}	{'IDC-IDC_vestibular_schwannoma_mc_rc', 'TCIA-vestibular-schwannoma-mc-rc'}	{'IDC', 'TCIA'}	2
-5V6D-2	{'SR', nan}	{'IDC-IDC_qiba_ct_1c', 'TCIA-qiba-ct-1c'}	{'IDC', 'TCIA'}	2
-_t5of5_MRI IAMS	{'MR', nan}	{'IDC-IDC_vestibular_schwannoma_mc_rc', 'TCIA-vestibular-schwannoma-mc-rc'}	{'IDC', 'TCIA'}	2
-5V5C-2	{'SR', nan}	{'IDC-IDC_qiba_ct_1c', 'TCIA-qiba-ct-1c'}	{'IDC', 'TCIA'}	2
-_t5of5EXTERNAL IMAGES	{'MR', nan}	{'IDC-IDC_vestibular_schwannoma_mc_rc', 'TCIA-vestibular-schwannoma-mc-rc'}	{'IDC', 'TCIA'}	2
-Scanner-Philips_Exp-50_Pitch-1.2_SlCol-16x0.75	{'CT', nan}	{'IDC-IDC_phantom_fda', 'TCIA-phantom-fda'}	{'IDC', 'TCIA'}	2
-Scanner-Philips_Exp-50_Pitch-1.2_SlCol-16x1.5	{'CT', nan}	{'IDC-IDC_phantom_fda', 'TCIA-phantom-fda'}	{'IDC', 'TCIA'}	2
-1V5B-1	{'SR', nan}	{'IDC-IDC_qiba_ct_1c', 'TCIA-qiba-ct-1c'}	{'IDC', 'TCIA'}	2
-Scanner-SIEMENS_Exp-100_Pitch-0.9_SlCol-64x0.6mm	{'CT', nan}	{'IDC-IDC_phantom_fda', 'TCIA-phantom-fda'}	{'IDC', 'TCIA'}	2
-_t5of5  MRI Head	{'MR', nan}	{'IDC-IDC_vestibular_schwannoma_mc_rc', 'TCIA-vestibular-schwannoma-mc-rc'}	{'IDC', 'TCIA'}	2
-Scanner-SIEMENS_Exp-100_Pitch-1.2_SlCol-64x0.6mm	{'CT', nan}	{'IDC-IDC_phantom_fda', 'TCIA-phantom-fda'}	{'IDC', 'TCIA'}	2
-Scanner-SIEMENS_Exp-200_Pitch-0.9_SlCol-64x0.6mm	{'CT', nan}	{'IDC-IDC_phantom_fda', 'TCIA-phantom-fda'}	{'IDC', 'TCIA'}	2
-Scanner-SIEMENS_Exp-200_Pitch-1.2_SlCol-64x0.6mm	{'CT', nan}	{'IDC-IDC_phantom_fda', 'TCIA-phantom-fda'}	{'IDC', 'TCIA'}	2
-_t4of8MRI IAMS	{'MR', nan}	{'IDC-IDC_vestibular_schwannoma_mc_rc', 'TCIA-vestibular-schwannoma-mc-rc'}	{'IDC', 'TCIA'}	2
-Scanner-SIEMENS_Exp-25_Pitch-0.9_SlCol-64x0.6mm	{'CT', nan}	{'IDC-IDC_phantom_fda', 'TCIA-phantom-fda'}	{'IDC', 'TCIA'}	2
-Scanner-SIEMENS_Exp-25_Pitch-1.2_SlCol-64x0.6mm	{'CT', nan}	{'IDC-IDC_phantom_fda', 'TCIA-phantom-fda'}	{'IDC', 'TCIA'}	2
-1V5B-2	{'SR', nan}	{'IDC-IDC_qiba_ct_1c', 'TCIA-qiba-ct-1c'}	{'IDC', 'TCIA'}	2
-5V5D-2	{'SR', nan}	{'IDC-IDC_qiba_ct_1c', 'TCIA-qiba-ct-1c'}	{'IDC', 'TCIA'}	2
-5V5D-1	{'SR', nan}	{'IDC-IDC_qiba_ct_1c', 'TCIA-qiba-ct-1c'}	{'IDC', 'TCIA'}	2
-Screening-Bilateral Mammography	{'MG', nan}	{'IDC-IDC_tcga_brca', 'TCIA-tcga-brca'}	{'IDC', 'TCIA'}	2
-Scanner-Philips_Exp-50_Pitch-0.9_SlCol-16x1.5	{'CT', nan}	{'IDC-IDC_phantom_fda', 'TCIA-phantom-fda'}	{'IDC', 'TCIA'}	2
-Scanner-Philips_Exp-50_Pitch-0.9_SlCol-16x0.75	{'CT', nan}	{'IDC-IDC_phantom_fda', 'TCIA-phantom-fda'}	{'IDC', 'TCIA'}	2
-5V6C-2	{'SR', nan}	{'IDC-IDC_qiba_ct_1c', 'TCIA-qiba-ct-1c'}	{'IDC', 'TCIA'}	2
-5V5E-1	{'SR', nan}	{'IDC-IDC_qiba_ct_1c', 'TCIA-qiba-ct-1c'}	{'IDC', 'TCIA'}	2
-5V6C-1	{'SR', nan}	{'IDC-IDC_qiba_ct_1c', 'TCIA-qiba-ct-1c'}	{'IDC', 'TCIA'}	2
-_t5of5MRI IAMS post Gad	{'MR', nan}	{'IDC-IDC_vestibular_schwannoma_mc_rc', 'TCIA-vestibular-schwannoma-mc-rc'}	{'IDC', 'TCIA'}	2
-_t5of5MRI IAMS	{'MR', nan}	{'IDC-IDC_vestibular_schwannoma_mc_rc', 'TCIA-vestibular-schwannoma-mc-rc'}	{'IDC', 'TCIA'}	2
-5V6B-2	{'SR', nan}	{'IDC-IDC_qiba_ct_1c', 'TCIA-qiba-ct-1c'}	{'IDC', 'TCIA'}	2
-Scanner-Philips_Exp-20_Pitch-1.2_SlCol-16x0.75	{'CT', nan}	{'IDC-IDC_phantom_fda', 'TCIA-phantom-fda'}	{'IDC', 'TCIA'}	2
-Scanner-Philips_Exp-20_Pitch-1.2_SlCol-16x0.75mm	{'CT', nan}	{'IDC-IDC_phantom_fda', 'TCIA-phantom-fda'}	{'IDC', 'TCIA'}	2
-Scanner-Philips_Exp-20_Pitch-1.2_SlCol-16x1.5	{'CT', nan}	{'IDC-IDC_phantom_fda', 'TCIA-phantom-fda'}	{'IDC', 'TCIA'}	2
-Scanner-Philips_Exp-20_Pitch-1.2_SlCol-16x1.5mm	{'CT', nan}	{'IDC-IDC_phantom_fda', 'TCIA-phantom-fda'}	{'IDC', 'TCIA'}	2
-5V6B-1	{'SR', nan}	{'IDC-IDC_qiba_ct_1c', 'TCIA-qiba-ct-1c'}	{'IDC', 'TCIA'}	2
-5V6A-2	{'SR', nan}	{'IDC-IDC_qiba_ct_1c', 'TCIA-qiba-ct-1c'}	{'IDC', 'TCIA'}	2
-5V6A-1	{'SR', nan}	{'IDC-IDC_qiba_ct_1c', 'TCIA-qiba-ct-1c'}	{'IDC', 'TCIA'}	2
-5V5F-2	{'SR', nan}	{'IDC-IDC_qiba_ct_1c', 'TCIA-qiba-ct-1c'}	{'IDC', 'TCIA'}	2
-Scanner-Philips_Exp-25_Pitch-1.2_SlCol-16x0.75	{'CT', nan}	{'IDC-IDC_phantom_fda', 'TCIA-phantom-fda'}	{'IDC', 'TCIA'}	2
-5V5E-2	{'SR', nan}	{'IDC-IDC_qiba_ct_1c', 'TCIA-qiba-ct-1c'}	{'IDC', 'TCIA'}	2
-Scanner-Philips_Exp-25_Pitch-1.2_SlCol-16x1.5	{'CT', nan}	{'IDC-IDC_phantom_fda', 'TCIA-phantom-fda'}	{'IDC', 'TCIA'}	2
-_t4of4_MRI IAMS WITH CONTRAST	{'MR', nan}	{'IDC-IDC_vestibular_schwannoma_mc_rc', 'TCIA-vestibular-schwannoma-mc-rc'}	{'IDC', 'TCIA'}	2
-_t4of4MRI Head	{'MR', nan}	{'IDC-IDC_vestibular_schwannoma_mc_rc', 'TCIA-vestibular-schwannoma-mc-rc'}	{'IDC', 'TCIA'}	2
-Thorax^LOW_DOSE_CHEST_SCREENING (Adult)	{'CT', nan}	{'IDC-IDC_nsclc_radiogenomics', 'TCIA-nsclc-radiogenomics'}	{'IDC', 'TCIA'}	2
-_t3of3_MR IAM's	{'MR'}	{'IDC-IDC_vestibular_schwannoma_mc_rc'}	{'IDC'}	2
-_t3of4  MRI IAMS	{'MR', nan}	{'IDC-IDC_vestibular_schwannoma_mc_rc', 'TCIA-vestibular-schwannoma-mc-rc'}	{'IDC', 'TCIA'}	2
-_t3of4  External Images for PACS	{'MR', nan}	{'IDC-IDC_vestibular_schwannoma_mc_rc', 'TCIA-vestibular-schwannoma-mc-rc'}	{'IDC', 'TCIA'}	2
-4V5C-1	{'SR', nan}	{'IDC-IDC_qiba_ct_1c', 'TCIA-qiba-ct-1c'}	{'IDC', 'TCIA'}	2
-Thorax^CTA_CAP_Customized (Adult)	{'CT'}	{'MIDRC-Open-A1'}	{'MIDRC'}	2
-_t3of3_MRI RNTNE historical imaging	{'MR', nan}	{'IDC-IDC_vestibular_schwannoma_mc_rc', 'TCIA-vestibular-schwannoma-mc-rc'}	{'IDC', 'TCIA'}	2
-4V5B-2	{'SR', nan}	{'IDC-IDC_qiba_ct_1c', 'TCIA-qiba-ct-1c'}	{'IDC', 'TCIA'}	2
-_t3of3_MR IAMs	{nan}	{'TCIA-vestibular-schwannoma-mc-rc'}	{'TCIA'}	2
-_t3of3_MR Head	{'MR', nan}	{'IDC-IDC_vestibular_schwannoma_mc_rc', 'TCIA-vestibular-schwannoma-mc-rc'}	{'IDC', 'TCIA'}	2
-5V3A-2	{'SR', nan}	{'IDC-IDC_qiba_ct_1c', 'TCIA-qiba-ct-1c'}	{'IDC', 'TCIA'}	2
-4V5B-1	{'SR', nan}	{'IDC-IDC_qiba_ct_1c', 'TCIA-qiba-ct-1c'}	{'IDC', 'TCIA'}	2
-1V6A-2	{'SR', nan}	{'IDC-IDC_qiba_ct_1c', 'TCIA-qiba-ct-1c'}	{'IDC', 'TCIA'}	2
-4V5A-2	{'SR', nan}	{'IDC-IDC_qiba_ct_1c', 'TCIA-qiba-ct-1c'}	{'IDC', 'TCIA'}	2
-4V5A-1	{'SR', nan}	{'IDC-IDC_qiba_ct_1c', 'TCIA-qiba-ct-1c'}	{'IDC', 'TCIA'}	2
-4V4F-2	{'SR', nan}	{'IDC-IDC_qiba_ct_1c', 'TCIA-qiba-ct-1c'}	{'IDC', 'TCIA'}	2
-4V4E-2	{'SR', nan}	{'IDC-IDC_qiba_ct_1c', 'TCIA-qiba-ct-1c'}	{'IDC', 'TCIA'}	2
-Thorax^CT_CHEST_LOW_DOSE_NODULE_WO (Adult)	{'CT'}	{'MIDRC-Open-A1'}	{'MIDRC'}	2
-4V5C-2	{'SR', nan}	{'IDC-IDC_qiba_ct_1c', 'TCIA-qiba-ct-1c'}	{'IDC', 'TCIA'}	2
-4V5D-1	{'SR', nan}	{'IDC-IDC_qiba_ct_1c', 'TCIA-qiba-ct-1c'}	{'IDC', 'TCIA'}	2
-4V5D-2	{'SR', nan}	{'IDC-IDC_qiba_ct_1c', 'TCIA-qiba-ct-1c'}	{'IDC', 'TCIA'}	2
-Thorax^CHEST_WO_IRIS (Adult)	{'CT'}	{'MIDRC-Open-R1'}	{'MIDRC'}	2
-4V6E-2	{'SR', nan}	{'IDC-IDC_qiba_ct_1c', 'TCIA-qiba-ct-1c'}	{'IDC', 'TCIA'}	2
-Thorax^CHEST_ABD_WITH (Adult)	{'CT', nan}	{'TCIA-acrin-nsclc-fdg-pet', 'IDC-IDC_acrin_nsclc_fdg_pet'}	{'IDC', 'TCIA'}	2
-4V6E-1	{'SR', nan}	{'IDC-IDC_qiba_ct_1c', 'TCIA-qiba-ct-1c'}	{'IDC', 'TCIA'}	2
-4V6D-2	{'SR', nan}	{'IDC-IDC_qiba_ct_1c', 'TCIA-qiba-ct-1c'}	{'IDC', 'TCIA'}	2
-4V6D-1	{'SR', nan}	{'IDC-IDC_qiba_ct_1c', 'TCIA-qiba-ct-1c'}	{'IDC', 'TCIA'}	2
-Thorax^CHEST_NON_CONTRAST (Adult)	{'CT', nan}	{'IDC-IDC_nsclc_radiogenomics', 'TCIA-nsclc-radiogenomics'}	{'IDC', 'TCIA'}	2
-4V6C-2	{'SR', nan}	{'IDC-IDC_qiba_ct_1c', 'TCIA-qiba-ct-1c'}	{'IDC', 'TCIA'}	2
-4V6C-1	{'SR', nan}	{'IDC-IDC_qiba_ct_1c', 'TCIA-qiba-ct-1c'}	{'IDC', 'TCIA'}	2
-4V6B-2	{'SR', nan}	{'IDC-IDC_qiba_ct_1c', 'TCIA-qiba-ct-1c'}	{'IDC', 'TCIA'}	2
-4V6B-1	{'SR', nan}	{'IDC-IDC_qiba_ct_1c', 'TCIA-qiba-ct-1c'}	{'IDC', 'TCIA'}	2
-4V6A-2	{'SR', nan}	{'IDC-IDC_qiba_ct_1c', 'TCIA-qiba-ct-1c'}	{'IDC', 'TCIA'}	2
-4V6A-1	{'SR', nan}	{'IDC-IDC_qiba_ct_1c', 'TCIA-qiba-ct-1c'}	{'IDC', 'TCIA'}	2
-4V5F-2	{'SR', nan}	{'IDC-IDC_qiba_ct_1c', 'TCIA-qiba-ct-1c'}	{'IDC', 'TCIA'}	2
-4V5E-2	{'SR', nan}	{'IDC-IDC_qiba_ct_1c', 'TCIA-qiba-ct-1c'}	{'IDC', 'TCIA'}	2
-4V5E-1	{'SR', nan}	{'IDC-IDC_qiba_ct_1c', 'TCIA-qiba-ct-1c'}	{'IDC', 'TCIA'}	2
-4V4E-1	{'SR', nan}	{'IDC-IDC_qiba_ct_1c', 'TCIA-qiba-ct-1c'}	{'IDC', 'TCIA'}	2
-4V4D-2	{'SR', nan}	{'IDC-IDC_qiba_ct_1c', 'TCIA-qiba-ct-1c'}	{'IDC', 'TCIA'}	2
-Thorax^CT_CHEST_WO_AND_HI_RES_CUTS (Adult)	{'CT'}	{'MIDRC-Open-A1'}	{'MIDRC'}	2
-4V3C-1	{'SR', nan}	{'IDC-IDC_qiba_ct_1c', 'TCIA-qiba-ct-1c'}	{'IDC', 'TCIA'}	2
-Thorax^GH_ThoraxHR (Adult)	{'CT'}	{'MIDRC-Open-A1_SCCM_VIRUS'}	{'MIDRC'}	2
-4V3B-1	{'SR', nan}	{'IDC-IDC_qiba_ct_1c', 'TCIA-qiba-ct-1c'}	{'IDC', 'TCIA'}	2
-4V3A-2	{'SR', nan}	{'IDC-IDC_qiba_ct_1c', 'TCIA-qiba-ct-1c'}	{'IDC', 'TCIA'}	2
-_t3of3MRI IAMS	{'MR', nan}	{'IDC-IDC_vestibular_schwannoma_mc_rc', 'TCIA-vestibular-schwannoma-mc-rc'}	{'IDC', 'TCIA'}	2
-1V6B-2	{'SR', nan}	{'IDC-IDC_qiba_ct_1c', 'TCIA-qiba-ct-1c'}	{'IDC', 'TCIA'}	2
-4V3A-1	{'SR', nan}	{'IDC-IDC_qiba_ct_1c', 'TCIA-qiba-ct-1c'}	{'IDC', 'TCIA'}	2
-Thorax^KLATKA_PIERSIOWA_kontrast (Adult)	{'CT', nan}	{'TCIA-cptac-lscc', 'IDC-IDC_cptac_lscc'}	{'IDC', 'TCIA'}	2
-Thorax^KlatkaPiersiowa (Adult)	{'RTSTRUCT', nan}	{'IDC-IDC_cptac_ucec', 'TCIA-cptac-ucec'}	{'IDC', 'TCIA'}	2
-1V6C-1	{'SR', nan}	{'IDC-IDC_qiba_ct_1c', 'TCIA-qiba-ct-1c'}	{'IDC', 'TCIA'}	2
-1V6C-2	{'SR', nan}	{'IDC-IDC_qiba_ct_1c', 'TCIA-qiba-ct-1c'}	{'IDC', 'TCIA'}	2
-4V2F-2	{'SR', nan}	{'IDC-IDC_qiba_ct_1c', 'TCIA-qiba-ct-1c'}	{'IDC', 'TCIA'}	2
-1V6D-1	{'SR', nan}	{'IDC-IDC_qiba_ct_1c', 'TCIA-qiba-ct-1c'}	{'IDC', 'TCIA'}	2
-4V2E-2	{'SR', nan}	{'IDC-IDC_qiba_ct_1c', 'TCIA-qiba-ct-1c'}	{'IDC', 'TCIA'}	2
-Thorax^LOW_DOSE_CHEST_CT_NON_CON (Adult)	{'CT', nan}	{'IDC-IDC_nsclc_radiogenomics', 'TCIA-nsclc-radiogenomics'}	{'IDC', 'TCIA'}	2
-1V6D-2	{'SR', nan}	{'IDC-IDC_qiba_ct_1c', 'TCIA-qiba-ct-1c'}	{'IDC', 'TCIA'}	2
-4V3B-2	{'SR', nan}	{'IDC-IDC_qiba_ct_1c', 'TCIA-qiba-ct-1c'}	{'IDC', 'TCIA'}	2
-4V3C-2	{'SR', nan}	{'IDC-IDC_qiba_ct_1c', 'TCIA-qiba-ct-1c'}	{'IDC', 'TCIA'}	2
-Thorax^CT_CHST_ABD_PELVIS_WO_W_IVCON (Adult)	{'SEG', nan}	{'IDC-IDC_anti_pd_1_lung', 'TCIA-anti-pd-1_lung'}	{'IDC', 'TCIA'}	2
-4V3D-1	{'SR', nan}	{'IDC-IDC_qiba_ct_1c', 'TCIA-qiba-ct-1c'}	{'IDC', 'TCIA'}	2
-4V4D-1	{'SR', nan}	{'IDC-IDC_qiba_ct_1c', 'TCIA-qiba-ct-1c'}	{'IDC', 'TCIA'}	2
-4V4C-2	{'SR', nan}	{'IDC-IDC_qiba_ct_1c', 'TCIA-qiba-ct-1c'}	{'IDC', 'TCIA'}	2
-Thorax^C_A_P_WITH _XXL (Adult)	{'CT'}	{'MIDRC-Open-A1'}	{'MIDRC'}	2
-4V4C-1	{'SR', nan}	{'IDC-IDC_qiba_ct_1c', 'TCIA-qiba-ct-1c'}	{'IDC', 'TCIA'}	2
-4V4B-2	{'SR', nan}	{'IDC-IDC_qiba_ct_1c', 'TCIA-qiba-ct-1c'}	{'IDC', 'TCIA'}	2
-Thorax^Chest (Adult)	{'CT', nan}	{'TCIA-acrin-nsclc-fdg-pet', 'IDC-IDC_acrin_nsclc_fdg_pet'}	{'IDC', 'TCIA'}	2
-4V4B-1	{'SR', nan}	{'IDC-IDC_qiba_ct_1c', 'TCIA-qiba-ct-1c'}	{'IDC', 'TCIA'}	2
-4V4A-2	{'SR', nan}	{'IDC-IDC_qiba_ct_1c', 'TCIA-qiba-ct-1c'}	{'IDC', 'TCIA'}	2
-4V4A-1	{'SR', nan}	{'IDC-IDC_qiba_ct_1c', 'TCIA-qiba-ct-1c'}	{'IDC', 'TCIA'}	2
-Thorax^DE_TRAUMA_CAP_WITH_FEET_FIRST__INFUSION_AUTO_Customized (	{'CT'}	{'MIDRC-Open-A1'}	{'MIDRC'}	2
-1V6B-1	{'SR', nan}	{'IDC-IDC_qiba_ct_1c', 'TCIA-qiba-ct-1c'}	{'IDC', 'TCIA'}	2
-4V3F-2	{'SR', nan}	{'IDC-IDC_qiba_ct_1c', 'TCIA-qiba-ct-1c'}	{'IDC', 'TCIA'}	2
-4V3E-2	{'SR', nan}	{'IDC-IDC_qiba_ct_1c', 'TCIA-qiba-ct-1c'}	{'IDC', 'TCIA'}	2
-4V3E-1	{'SR', nan}	{'IDC-IDC_qiba_ct_1c', 'TCIA-qiba-ct-1c'}	{'IDC', 'TCIA'}	2
-4V3D-2	{'SR', nan}	{'IDC-IDC_qiba_ct_1c', 'TCIA-qiba-ct-1c'}	{'IDC', 'TCIA'}	2
-4V6F-2	{'SR', nan}	{'IDC-IDC_qiba_ct_1c', 'TCIA-qiba-ct-1c'}	{'IDC', 'TCIA'}	2
-_t3of4MRI Head	{'MR', nan}	{'IDC-IDC_vestibular_schwannoma_mc_rc', 'TCIA-vestibular-schwannoma-mc-rc'}	{'IDC', 'TCIA'}	2
-57MRI BREAST BILAT WO/W CONTRAST	{'MR'}	{'ACRdart-EA1141Restricted', 'IDC-IDC_ea1141'}	{'ACRdart', 'IDC'}	2
-Thorax^01_ThoraxRoutine (Adult)	{'CT', nan}	{'IDC-IDC_lung_pet_ct_dx', 'TCIA-lung-pet-ct-dx'}	{'IDC', 'TCIA'}	2
-5V2B-2	{'SR', nan}	{'IDC-IDC_qiba_ct_1c', 'TCIA-qiba-ct-1c'}	{'IDC', 'TCIA'}	2
-Thorax^02_0_Chest_Routine (Adult)	{'SEG', nan}	{'TCIA-tcga-lihc', 'IDC-IDC_tcga_lihc'}	{'IDC', 'TCIA'}	2
-5V2B-1	{'SR', nan}	{'IDC-IDC_qiba_ct_1c', 'TCIA-qiba-ct-1c'}	{'IDC', 'TCIA'}	2
-Thorax^03_THORAX_ROUTINE (Adult)	{'CT', nan}	{'TCIA-acrin-nsclc-fdg-pet', 'IDC-IDC_acrin_nsclc_fdg_pet'}	{'IDC', 'TCIA'}	2
-Thorax^04Chest_Biphase _Liver_Panc (Adult)	{'SEG', nan}	{'TCIA-tcga-lihc', 'IDC-IDC_tcga_lihc'}	{'IDC', 'TCIA'}	2
-5V2A-2	{'SR', nan}	{'IDC-IDC_qiba_ct_1c', 'TCIA-qiba-ct-1c'}	{'IDC', 'TCIA'}	2
-_t4of4  External Images for PACS	{'MR', nan}	{'IDC-IDC_vestibular_schwannoma_mc_rc', 'TCIA-vestibular-schwannoma-mc-rc'}	{'IDC', 'TCIA'}	2
-Thorax^04_Chest_Biphase_Liver_Panc (Adult)	{'SEG', nan}	{'TCIA-tcga-lihc', 'IDC-IDC_tcga_lihc'}	{'IDC', 'TCIA'}	2
-Thorax^04_PE (Adult)	{'CT', nan}	{'TCIA-tcga-ov', 'IDC-IDC_tcga_ov'}	{'IDC', 'TCIA'}	2
-Thorax^08 PE ROUTINE	{'CT', nan}	{'TCIA-tcga-ov', 'IDC-IDC_tcga_ov'}	{'IDC', 'TCIA'}	2
-5V2A-1	{'SR', nan}	{'IDC-IDC_qiba_ct_1c', 'TCIA-qiba-ct-1c'}	{'IDC', 'TCIA'}	2
-Thorax^1 CHEST BIPHASE LIVER	{'SEG', nan}	{'TCIA-tcga-lihc', 'IDC-IDC_tcga_lihc'}	{'IDC', 'TCIA'}	2
-5V1F-2	{'SR', nan}	{'IDC-IDC_qiba_ct_1c', 'TCIA-qiba-ct-1c'}	{'IDC', 'TCIA'}	2
-_t3of7  External Images for PACS	{'MR', nan}	{'IDC-IDC_vestibular_schwannoma_mc_rc', 'TCIA-vestibular-schwannoma-mc-rc'}	{'IDC', 'TCIA'}	2
-Thorax^11WBPETCT	{'SEG', nan}	{'TCIA-acrin-nsclc-fdg-pet', 'IDC-IDC_acrin_nsclc_fdg_pet'}	{'IDC', 'TCIA'}	2
-Thorax^02CAPRoutine (Adult)	{'CT', nan}	{'TCIA-tcga-kirc', 'IDC-IDC_tcga_kirc'}	{'IDC', 'TCIA'}	2
-Thorax^01_ThoraxNative (Adult)	{'CT', nan}	{'TCIA-cptac-luad', 'IDC-IDC_cptac_luad'}	{'IDC', 'TCIA'}	2
-5V1E-2	{'SR', nan}	{'IDC-IDC_qiba_ct_1c', 'TCIA-qiba-ct-1c'}	{'IDC', 'TCIA'}	2
-5V2C-1	{'SR', nan}	{'IDC-IDC_qiba_ct_1c', 'TCIA-qiba-ct-1c'}	{'IDC', 'TCIA'}	2
-5V3A-1	{'SR', nan}	{'IDC-IDC_qiba_ct_1c', 'TCIA-qiba-ct-1c'}	{'IDC', 'TCIA'}	2
-_t4of4  MRI IAMS	{'MR', nan}	{'IDC-IDC_vestibular_schwannoma_mc_rc', 'TCIA-vestibular-schwannoma-mc-rc'}	{'IDC', 'TCIA'}	2
-TUMOR PET RES	{'PT', nan}	{'IDC-IDC_tcga_prad', 'TCIA-tcga-prad'}	{'IDC', 'TCIA'}	2
-5V2F-2	{'SR', nan}	{'IDC-IDC_qiba_ct_1c', 'TCIA-qiba-ct-1c'}	{'IDC', 'TCIA'}	2
-5V2E-2	{'SR', nan}	{'IDC-IDC_qiba_ct_1c', 'TCIA-qiba-ct-1c'}	{'IDC', 'TCIA'}	2
-Thorax 01_PE (Adult)	{'CT', nan}	{'TCIA-acrin-nsclc-fdg-pet', 'IDC-IDC_acrin_nsclc_fdg_pet'}	{'IDC', 'TCIA'}	2
-5V2E-1	{'SR', nan}	{'IDC-IDC_qiba_ct_1c', 'TCIA-qiba-ct-1c'}	{'IDC', 'TCIA'}	2
-Thorax^01 Chest 1mm Collimator	{'CT', nan}	{'TCIA-acrin-nsclc-fdg-pet', 'IDC-IDC_acrin_nsclc_fdg_pet'}	{'IDC', 'TCIA'}	2
-5V2D-2	{'SR', nan}	{'IDC-IDC_qiba_ct_1c', 'TCIA-qiba-ct-1c'}	{'IDC', 'TCIA'}	2
-5V2D-1	{'SR', nan}	{'IDC-IDC_qiba_ct_1c', 'TCIA-qiba-ct-1c'}	{'IDC', 'TCIA'}	2
-Thorax^01_CHEST (Adult)	{'CT', nan}	{'TCIA-acrin-nsclc-fdg-pet', 'IDC-IDC_acrin_nsclc_fdg_pet'}	{'IDC', 'TCIA'}	2
-5V2C-2	{'SR', nan}	{'IDC-IDC_qiba_ct_1c', 'TCIA-qiba-ct-1c'}	{'IDC', 'TCIA'}	2
-Thorax^01_CHEST_ROUTINE (Adult)	{'CT', nan}	{'TCIA-cptac-luad', 'IDC-IDC_cptac_luad'}	{'IDC', 'TCIA'}	2
-Thorax^01_CHEST_ROUTINE_WITH (Adult)	{'CT'}	{'MIDRC-Open-R1'}	{'MIDRC'}	2
-Thorax^01_Chest_Routine (Adult)	{'CT', nan}	{'TCIA-tcga-lihc', 'IDC-IDC_tcga_lihc'}	{'IDC', 'TCIA'}	2
-Thorax^11_Chest_BX_Startup_NObreathing (Adult)	{'CT'}	{'MIDRC-Open-A1'}	{'MIDRC'}	2
-5V1E-1	{'SR', nan}	{'IDC-IDC_qiba_ct_1c', 'TCIA-qiba-ct-1c'}	{'IDC', 'TCIA'}	2
-5AFOV LUNG	{'PT', nan}	{'IDC-IDC_rider_lung_pet_ct', 'TCIA-rider-lung-pet-ct'}	{'IDC', 'TCIA'}	2
-5V1B-1	{'SR', nan}	{'IDC-IDC_qiba_ct_1c', 'TCIA-qiba-ct-1c'}	{'IDC', 'TCIA'}	2
-1V5F-2	{'SR', nan}	{'IDC-IDC_qiba_ct_1c', 'TCIA-qiba-ct-1c'}	{'IDC', 'TCIA'}	2
-Thorax^AVERAGE_CHEST_WITH_IV_CONTRAST (Adult)	{nan}	{'TCIA-varepop-apollo'}	{'TCIA'}	2
-_t3of5External Images for PACS	{'MR', nan}	{'IDC-IDC_vestibular_schwannoma_mc_rc', 'TCIA-vestibular-schwannoma-mc-rc'}	{'IDC', 'TCIA'}	2
-Thorax^CAP (Adult)	{'SEG', nan}	{'TCIA-tcga-lihc', 'IDC-IDC_tcga_lihc'}	{'IDC', 'TCIA'}	2
-_t3of5  MRI IAMS post Gad	{'MR', nan}	{'IDC-IDC_vestibular_schwannoma_mc_rc', 'TCIA-vestibular-schwannoma-mc-rc'}	{'IDC', 'TCIA'}	2
-1V6A-1	{'SR', nan}	{'IDC-IDC_qiba_ct_1c', 'TCIA-qiba-ct-1c'}	{'IDC', 'TCIA'}	2
-Thorax^CAP_ARTERIAL_PORTVENOUS (Adult)	{'SEG', nan}	{'TCIA-tcga-lihc', 'IDC-IDC_tcga_lihc'}	{'IDC', 'TCIA'}	2
-Thorax^CAP_WITH (Adult)	{'CT'}	{'MIDRC-Open-A1', 'MIDRC-Open-A1_PETAL_REDCORAL'}	{'MIDRC'}	2
-5V1A-2	{'SR', nan}	{'IDC-IDC_qiba_ct_1c', 'TCIA-qiba-ct-1c'}	{'IDC', 'TCIA'}	2
-5V1A-1	{'SR', nan}	{'IDC-IDC_qiba_ct_1c', 'TCIA-qiba-ct-1c'}	{'IDC', 'TCIA'}	2
-Thorax^CAP_WO (Adult)	{'CT'}	{'MIDRC-Open-A1'}	{'MIDRC'}	2
-Thorax^CHEST (Adult)	{'CT', nan}	{'TCIA-cptac-luad', 'IDC-IDC_cptac_luad'}	{'IDC', 'TCIA'}	2
-Thorax^CHESTABDPELVIS.WCONTRAST	{'CT', nan}	{'TCIA-acrin-nsclc-fdg-pet', 'IDC-IDC_acrin_nsclc_fdg_pet'}	{'IDC', 'TCIA'}	2
-5AFOV TORSO	{'PT', nan}	{'IDC-IDC_rider_lung_pet_ct', 'TCIA-rider-lung-pet-ct'}	{'IDC', 'TCIA'}	2
-_t3of4MRI IAMS	{'MR', nan}	{'IDC-IDC_vestibular_schwannoma_mc_rc', 'TCIA-vestibular-schwannoma-mc-rc'}	{'IDC', 'TCIA'}	2
-Thorax^AVERAGE_CHEST_LOW_DOSE (Adult)	{nan}	{'TCIA-varepop-apollo'}	{'TCIA'}	2
-Thorax^3_CHEST_ABD_PELV_BMI_SM (Adult)	{'RTSTRUCT', nan}	{'IDC-IDC_cptac_ucec', 'TCIA-cptac-ucec'}	{'IDC', 'TCIA'}	2
-5V1D-2	{'SR', nan}	{'IDC-IDC_qiba_ct_1c', 'TCIA-qiba-ct-1c'}	{'IDC', 'TCIA'}	2
-Thorax^31_ThorAbd_N_CE (Adult)	{'CT', nan}	{'IDC-IDC_ctpred_sunitinib_pannet', 'TCIA-ctpred-sunitinib-pannet'}	{'IDC', 'TCIA'}	2
-_t3of6  MRI IAMS post Gad	{'MR', nan}	{'IDC-IDC_vestibular_schwannoma_mc_rc', 'TCIA-vestibular-schwannoma-mc-rc'}	{'IDC', 'TCIA'}	2
-Thorax^1MM_CHEST_ROUTINE (Adult)	{'CT', nan}	{'TCIA-acrin-nsclc-fdg-pet', 'IDC-IDC_acrin_nsclc_fdg_pet'}	{'IDC', 'TCIA'}	2
-5V1D-1	{'SR', nan}	{'IDC-IDC_qiba_ct_1c', 'TCIA-qiba-ct-1c'}	{'IDC', 'TCIA'}	2
-5V1C-2	{'SR', nan}	{'IDC-IDC_qiba_ct_1c', 'TCIA-qiba-ct-1c'}	{'IDC', 'TCIA'}	2
-1V5E-2	{'SR', nan}	{'IDC-IDC_qiba_ct_1c', 'TCIA-qiba-ct-1c'}	{'IDC', 'TCIA'}	2
-Thorax^1_CAP_W_WO (Adult)	{'SEG', nan}	{'TCIA-tcga-lihc', 'IDC-IDC_tcga_lihc'}	{'IDC', 'TCIA'}	2
-Thorax^1_CHEST_ROUTINE_3MM	{'CT', nan}	{'TCIA-acrin-nsclc-fdg-pet', 'IDC-IDC_acrin_nsclc_fdg_pet'}	{'IDC', 'TCIA'}	2
-5V1C-1	{'SR', nan}	{'IDC-IDC_qiba_ct_1c', 'TCIA-qiba-ct-1c'}	{'IDC', 'TCIA'}	2
-Thorax^1_CHEST_WO (Adult)	{'CT', nan}	{'TCIA-acrin-nsclc-fdg-pet', 'IDC-IDC_acrin_nsclc_fdg_pet'}	{'IDC', 'TCIA'}	2
-Thorax^1_CHEST_WO_IRIS (Adult)	{'CT'}	{'MIDRC-Open-R1'}	{'MIDRC'}	2
-Thorax^1_PULMONARY_EMBOLIS (Adult)	{'CT', nan}	{'TCIA-tcga-ucec', 'IDC-IDC_tcga_ucec'}	{'IDC', 'TCIA'}	2
-Thorax^1_ROUTINE_CHEST_LARGE (Adult)	{'CT', nan}	{'TCIA-cptac-luad', 'IDC-IDC_cptac_luad'}	{'IDC', 'TCIA'}	2
-Thorax^1_Routine_Chest (Adult)	{'CT', nan}	{'TCIA-tcga-lihc', 'IDC-IDC_tcga_lihc'}	{'IDC', 'TCIA'}	2
-5V1B-2	{'SR', nan}	{'IDC-IDC_qiba_ct_1c', 'TCIA-qiba-ct-1c'}	{'IDC', 'TCIA'}	2
-Thorax^3 PE PROTOCOL + LEGS	{'CT', nan}	{'TCIA-tcga-ov', 'IDC-IDC_tcga_ov'}	{'IDC', 'TCIA'}	2
-TK- j. brzuszna z kontr.	{'RTSTRUCT', nan}	{'TCIA-cptac-pda', 'IDC-IDC_cptac_pda'}	{'IDC', 'TCIA'}	2
-CT CHE/ABD/PEL	{'SEG', nan}	{'TCIA-lidc-idri', 'IDC-IDC_lidc_idri'}	{'IDC', 'TCIA'}	2
-MRI Abd wo+w	{'MR', nan}	{'TCIA-tcga-lihc', 'IDC-IDC_tcga_lihc'}	{'IDC', 'TCIA'}	2
-CT A/P  LIVER	{'SEG', nan}	{'IDC-IDC_hcc_tace_seg', 'TCIA-hcc-tace-seg'}	{'IDC', 'TCIA'}	2
-CT A/P LIVER PR.	{'SEG', nan}	{'IDC-IDC_hcc_tace_seg', 'TCIA-hcc-tace-seg'}	{'IDC', 'TCIA'}	2
-CT_R_Hip	{'CT', nan}	{'IDC-IDC_cmb_mml', 'TCIA-cmb-mml'}	{'IDC', 'TCIA'}	2
-CT_SkullMidThigh	{'CT', nan}	{'TCIA-cmb-crc', 'IDC-IDC_cmb_crc'}	{'IDC', 'TCIA'}	2
-CT_T_Spine	{'CT', nan}	{'IDC-IDC_cmb_mml', 'TCIA-cmb-mml'}	{'IDC', 'TCIA'}	2
-CT_WholeBody	{'CT', nan}	{'TCIA-cmb-gec', 'IDC-IDC_cmb_gec'}	{'IDC', 'TCIA'}	2
-CT_biopstbonemarrow	{'CT', nan}	{'IDC-IDC_cmb_mml', 'TCIA-cmb-mml'}	{'IDC', 'TCIA'}	2
-CT A/P LIVER	{'SEG', nan}	{'IDC-IDC_hcc_tace_seg', 'TCIA-hcc-tace-seg'}	{'IDC', 'TCIA'}	2
-CT A/P IV PO	{'CT', nan}	{'TCIA-tcga-kirc', 'IDC-IDC_tcga_kirc'}	{'IDC', 'TCIA'}	2
-CT A/P (LIVER) W/WO	{'SEG', nan}	{'IDC-IDC_hcc_tace_seg', 'TCIA-hcc-tace-seg'}	{'IDC', 'TCIA'}	2
-CT_pelvisbonebiopsy	{'CT', nan}	{'IDC-IDC_cmb_mml', 'TCIA-cmb-mml'}	{'IDC', 'TCIA'}	2
-CVA12	{'CT', nan}	{'IDC-IDC_rider_lung_pet_ct', 'TCIA-rider-lung-pet-ct'}	{'IDC', 'TCIA'}	2
-CXR	{'DX'}	{'MIDRC-Open-R1', 'MIDRC-Open-A1_PETAL_REDCORAL'}	{'MIDRC'}	2
-CXR  COUGHX 3 MONTHS	{'CT', nan}	{'TCIA-acrin-nsclc-fdg-pet', 'IDC-IDC_acrin_nsclc_fdg_pet'}	{'IDC', 'TCIA'}	2
-Cardiac^02_0_Constrictive_Pericarditis (Adult)	{'CT', nan}	{'TCIA-tcga-ov', 'IDC-IDC_tcga_ov'}	{'IDC', 'TCIA'}	2
-Cardiac^CORONARY_RETROSPECTIVE_MORE_PAD (Adult)	{'CT'}	{'MIDRC-Open-A1'}	{'MIDRC'}	2
-CT A/P RENAL	{'SEG', nan}	{'TCIA-tcga-kirc', 'IDC-IDC_tcga_kirc'}	{'IDC', 'TCIA'}	2
-CT A/P W/W/O	{'CT', nan}	{'TCIA-tcga-ucec', 'IDC-IDC_tcga_ucec'}	{'IDC', 'TCIA'}	2
-CT_Lung	{'CT', nan}	{'TCIA-cmb-crc', 'IDC-IDC_cmb_crc'}	{'IDC', 'TCIA'}	2
-CT_Biopsy_Liver	{'CT', nan}	{'IDC-IDC_cmb_mel', 'TCIA-cmb-mel'}	{'IDC', 'TCIA'}	2
-CTAPWO	{'CT', nan}	{'TCIA-acrin-nsclc-fdg-pet', 'IDC-IDC_acrin_nsclc_fdg_pet'}	{'IDC', 'TCIA'}	2
-CT ABD LIV PRO	{'SEG', nan}	{'IDC-IDC_hcc_tace_seg', 'TCIA-hcc-tace-seg'}	{'IDC', 'TCIA'}	2
-CTCAP/CT6   CT CHE/BODY(SCH	{'CT', nan}	{'IDC-IDC_tcga_kich', 'TCIA-tcga-kich'}	{'IDC', 'TCIA'}	2
-CT ABD AND/OR PEL - CD	{'CT', nan}	{'IDC-IDC_pseudo_phi_dicom_data', 'TCIA-pseudo-phi-dicom-data'}	{'IDC', 'TCIA'}	2
-CTTHOR2 CT THORAX W/WO CONTR	{'CT', nan}	{'TCIA-tcga-ucec', 'IDC-IDC_tcga_ucec'}	{'IDC', 'TCIA'}	2
-CT ABD & PELVIS W/O CONTRAST	{nan}	{'TCIA-varepop-apollo'}	{'TCIA'}	2
-CT ABD & PELV W/CONTRAST	{nan}	{'TCIA-varepop-apollo'}	{'TCIA'}	2
-CT_L_Hip	{'CT', nan}	{'IDC-IDC_cmb_mml', 'TCIA-cmb-mml'}	{'IDC', 'TCIA'}	2
-CT_Brain	{nan}	{'TCIA-cmb-mel'}	{'TCIA'}	2
-CT AB/PEL W & W/O CONTRAST	{'CT', nan}	{'TCIA-tcga-kirc', 'IDC-IDC_tcga_kirc'}	{'IDC', 'TCIA'}	2
-CT_CHEST	{'CT', nan}	{'TCIA-acrin-nsclc-fdg-pet', 'IDC-IDC_acrin_nsclc_fdg_pet'}	{'IDC', 'TCIA'}	2
-CT AB WITH	{'CT', nan}	{'TCIA-tcga-ov', 'IDC-IDC_tcga_ov'}	{'IDC', 'TCIA'}	2
-CT_ChestAbd	{'CT', nan}	{'TCIA-cmb-gec', 'IDC-IDC_cmb_gec'}	{'IDC', 'TCIA'}	2
-CT A/P-RENAL	{'SEG', nan}	{'TCIA-tcga-kirc', 'IDC-IDC_tcga_kirc'}	{'IDC', 'TCIA'}	2
-Cardiac^FLASH_PILOT_LAMODEL (Adult)	{'CT'}	{'MIDRC-Open-A1'}	{'MIDRC'}	2
-CT A-P LIVER	{'SEG', nan}	{'IDC-IDC_hcc_tace_seg', 'TCIA-hcc-tace-seg'}	{'IDC', 'TCIA'}	2
-CT URETERS W/O	{'CT', nan}	{'TCIA-tcga-kirc', 'IDC-IDC_tcga_kirc'}	{'IDC', 'TCIA'}	2
-CT A	{'RTSTRUCT', nan}	{'TCIA-cptac-ccrcc', 'IDC-IDC_cptac_ccrcc'}	{'IDC', 'TCIA'}	2
-ComboHD Unilateral Left	{'MG', nan}	{'TCIA-breast-cancer-screening-dbt', 'IDC-IDC_breast_cancer_screening_dbt'}	{'IDC', 'TCIA'}	2
-Cryomacrotome anatomic images	{'XC'}	{'IDC-IDC_nlm_visible_human_project'}	{'IDC'}	2
-DELAYS	{'CT', nan}	{'TCIA-tcga-ov', 'IDC-IDC_tcga_ov'}	{'IDC', 'TCIA'}	2
-CRANE 3MM	{'CT'}	{'IDC-IDC_pancreatic_ct_cbct_seg'}	{'IDC'}	2
-DG RIBS BILAT 3V	{'DX'}	{'MIDRC-Open-A1'}	{'MIDRC'}	2
-DIG CB DX TOMO MAM	{'MG'}	{'IDC-IDC_ea1141'}	{'IDC'}	2
-DIG DX TOMO MAMMO BIL	{'MG'}	{'ACRdart-EA1141Restricted', 'IDC-IDC_ea1141'}	{'ACRdart', 'IDC'}	2
-DIG MAM DIAGNOSTIC UNI LT	{'MG'}	{'ACRdart-EA1141Restricted', 'IDC-IDC_ea1141'}	{'ACRdart', 'IDC'}	2
-DIG MAM SCRN>UNI DX SAME DAY	{'MG'}	{'ACRdart-EA1141Restricted'}	{'ACRdart'}	2
-CORONARY_AFIB (Adult)	{'CT'}	{'AIMI-COCA'}	{'AIMI'}	2
-DIGITAL BILAT SCREENING MAMMO	{'MG', nan}	{'IDC-IDC_tcga_brca', 'TCIA-tcga-brca'}	{'IDC', 'TCIA'}	2
-DIGITAL DX MAMMO UNILAT (NO CAD)	{'MG'}	{'ACRdart-EA1141Restricted'}	{'ACRdart'}	2
-DIGITAL MAMMOGRAM UNILATERAL	{nan}	{'TCIA-breast-diagnosis'}	{'TCIA'}	2
-CONTRABREAST -LT	{'MR', nan}	{'IDC-IDC_acrin_contralateral_breast_mr', 'TCIA-acrin-contralateral-breast-mr'}	{'IDC', 'TCIA'}	2
-CONTRABREAST  (LEFT)	{'MR', nan}	{'IDC-IDC_acrin_contralateral_breast_mr', 'TCIA-acrin-contralateral-breast-mr'}	{'IDC', 'TCIA'}	2
-Combo Unilateral Right	{'MG'}	{'ACRdart-EA1141Restricted', 'IDC-IDC_ea1141'}	{'ACRdart', 'IDC'}	2
-Chest Single View Frontal	{'CR'}	{'MIDRC-Open-A1_PETAL_BLUECORAL', 'MIDRC-Open-A1_PETAL_REDCORAL'}	{'MIDRC'}	2
-CST ABD WITH	{'CT', nan}	{'TCIA-acrin-nsclc-fdg-pet', 'IDC-IDC_acrin_nsclc_fdg_pet'}	{'IDC', 'TCIA'}	2
-Chest 3	{'CT', nan}	{'IDC-IDC_lung_pet_ct_dx', 'TCIA-lung-pet-ct-dx'}	{'IDC', 'TCIA'}	2
-CT ,CHEST ABD PEL W/, CONTRAST	{'SEG', nan}	{'TCIA-tcga-lihc', 'IDC-IDC_tcga_lihc'}	{'IDC', 'TCIA'}	2
-Chest +C(T)	{'SEG', nan}	{'IDC-IDC_lung_pet_ct_dx', 'TCIA-lung-pet-ct-dx'}	{'IDC', 'TCIA'}	2
-Chest 1 View	{'CR'}	{'MIDRC-Open-R1'}	{'MIDRC'}	2
-CT  F/U CA STAGING	{'CT', nan}	{'TCIA-acrin-nsclc-fdg-pet', 'IDC-IDC_acrin_nsclc_fdg_pet'}	{'IDC', 'TCIA'}	2
-CT  C/A/P  W/O CONT	{'SEG', nan}	{'TCIA-lidc-idri', 'IDC-IDC_lidc_idri'}	{'IDC', 'TCIA'}	2
-CT  C/A/P  UROGRAM	{'CT', nan}	{'IDC-IDC_tcga_blca', 'TCIA-tcga-blca'}	{'IDC', 'TCIA'}	2
-CT  C/A/P	{'CT', nan}	{'TCIA-rider-pilot', 'IDC-IDC_rider_pilot'}	{'IDC', 'TCIA'}	2
-CT  ABD/PEL	{'SEG', nan}	{'TCIA-tcga-kirc', 'IDC-IDC_tcga_kirc'}	{'IDC', 'TCIA'}	2
-Chest CT Enhanced	{'CT', nan}	{'IDC-IDC_ctpred_sunitinib_pannet', 'TCIA-ctpred-sunitinib-pannet'}	{'IDC', 'TCIA'}	2
-CT  Abd/Pelvis	{'CT', nan}	{'TCIA-cmb-crc', 'IDC-IDC_cmb_crc'}	{'IDC', 'TCIA'}	2
-CT  ABDOMEN W CONTRAST	{'CT', nan}	{'TCIA-tcga-kirc', 'IDC-IDC_tcga_kirc'}	{'IDC', 'TCIA'}	2
-CT  ABD/PELVIS   W	{'CT', nan}	{'IDC-IDC_tcga_blca', 'TCIA-tcga-blca'}	{'IDC', 'TCIA'}	2
-Chest Inspiration & Expiration	{'CR', nan}	{'TCIA-acrin-nsclc-fdg-pet', 'IDC-IDC_acrin_nsclc_fdg_pet'}	{'IDC', 'TCIA'}	2
-CT  ABD/PEL  LIVER	{'SEG', nan}	{'IDC-IDC_hcc_tace_seg', 'TCIA-hcc-tace-seg'}	{'IDC', 'TCIA'}	2
-CTAPW	{'CT', nan}	{'TCIA-acrin-nsclc-fdg-pet', 'IDC-IDC_acrin_nsclc_fdg_pet'}	{'IDC', 'TCIA'}	2
-CTABDPELWX	{'RTSTRUCT', nan}	{'TCIA-cptac-ccrcc', 'IDC-IDC_cptac_ccrcc'}	{'IDC', 'TCIA'}	2
-CT ABD LIVER PR.	{'SEG', nan}	{'IDC-IDC_hcc_tace_seg', 'TCIA-hcc-tace-seg'}	{'IDC', 'TCIA'}	2
-CT ABD PANCRERAS	{'SEG', nan}	{'TCIA-tcga-kirc', 'IDC-IDC_tcga_kirc'}	{'IDC', 'TCIA'}	2
-CT,ABD (LIVER)	{'CT', nan}	{'IDC-IDC_hcc_tace_seg', 'TCIA-hcc-tace-seg'}	{'IDC', 'TCIA'}	2
-CT,ABD/PEL LIVER W/C	{'SEG', nan}	{'IDC-IDC_hcc_tace_seg', 'TCIA-hcc-tace-seg'}	{'IDC', 'TCIA'}	2
-CT,ABD/PEL(RENAL) WO/W	{'SEG', nan}	{'TCIA-tcga-kirc', 'IDC-IDC_tcga_kirc'}	{'IDC', 'TCIA'}	2
-CT,C/A/P RENAL W/C	{'SEG', nan}	{'TCIA-tcga-kirc', 'IDC-IDC_tcga_kirc'}	{'IDC', 'TCIA'}	2
-CT,CHEST ROUTINE W/O	{'CT', nan}	{'TCIA-tcga-kirc', 'IDC-IDC_tcga_kirc'}	{'IDC', 'TCIA'}	2
-CT,CHEST/ABD/PEL RENAL	{'SEG', nan}	{'TCIA-tcga-kirc', 'IDC-IDC_tcga_kirc'}	{'IDC', 'TCIA'}	2
-CT-A/P  LIVER PROTOCOL	{'CT', nan}	{'IDC-IDC_hcc_tace_seg', 'TCIA-hcc-tace-seg'}	{'IDC', 'TCIA'}	2
-CT-A/P LIVER PROTOCOL	{'SEG', nan}	{'IDC-IDC_hcc_tace_seg', 'TCIA-hcc-tace-seg'}	{'IDC', 'TCIA'}	2
-CT-ABD W/WO CON (LIVER	{'SEG', nan}	{'IDC-IDC_hcc_tace_seg', 'TCIA-hcc-tace-seg'}	{'IDC', 'TCIA'}	2
-CT-ABD-PEL	{'CT', nan}	{'TCIA-acrin-nsclc-fdg-pet', 'IDC-IDC_acrin_nsclc_fdg_pet'}	{'IDC', 'TCIA'}	2
-CT-Abdomen/Pelvis enha	{'CT', nan}	{'TCIA-tcga-ucec', 'IDC-IDC_tcga_ucec'}	{'IDC', 'TCIA'}	2
-CT-C-A-P  (PA)	{'SEG', nan}	{'TCIA-tcga-kirc', 'IDC-IDC_tcga_kirc'}	{'IDC', 'TCIA'}	2
-CT-C/A/P W/WO CON	{'SEG', nan}	{'IDC-IDC_hcc_tace_seg', 'TCIA-hcc-tace-seg'}	{'IDC', 'TCIA'}	2
-CT-CH/A/P LIVER	{'SEG', nan}	{'TCIA-lidc-idri', 'IDC-IDC_lidc_idri'}	{'IDC', 'TCIA'}	2
-CT-UROGRAM	{'CT', nan}	{'IDC-IDC_tcga_blca', 'TCIA-tcga-blca'}	{'IDC', 'TCIA'}	2
-CT, LUNG,MED, PLEURAL W/CONTRAST	{'CT', nan}	{'TCIA-tcga-kirc', 'IDC-IDC_tcga_kirc'}	{'IDC', 'TCIA'}	2
-CT ABD/PEL W/WO LIVER	{'SEG', nan}	{'IDC-IDC_hcc_tace_seg', 'TCIA-hcc-tace-seg'}	{'IDC', 'TCIA'}	2
-CT, CAP	{'SEG', nan}	{'TCIA-tcga-kirc', 'IDC-IDC_tcga_kirc'}	{'IDC', 'TCIA'}	2
-CT Urography	{'RTSTRUCT', nan}	{'IDC-IDC_cptac_ucec', 'TCIA-cptac-ucec'}	{'IDC', 'TCIA'}	2
-CT ABD/PELVIS WO/W	{'SEG', nan}	{'IDC-IDC_hcc_tace_seg', 'TCIA-hcc-tace-seg'}	{'IDC', 'TCIA'}	2
-CT ABD/PELVIS WITH CONTRAST	{'CT', nan}	{'TCIA-tcga-ucec', 'IDC-IDC_tcga_ucec'}	{'IDC', 'TCIA'}	2
-CT Urogram	{'CT', nan}	{'TCIA-tcga-kirc', 'IDC-IDC_tcga_kirc'}	{'IDC', 'TCIA'}	2
-CT ABD/PELVIS WITH	{'CT', nan}	{'TCIA-tcga-ucec', 'IDC-IDC_tcga_ucec'}	{'IDC', 'TCIA'}	2
-CT ABD/PELVIS W AND WO CONTRAST	{'CT', nan}	{'TCIA-tcga-lihc', 'IDC-IDC_tcga_lihc'}	{'IDC', 'TCIA'}	2
-CT Urogram with 3D	{'CR', nan}	{'TCIA-tcga-kirc', 'IDC-IDC_tcga_kirc'}	{'IDC', 'TCIA'}	2
-CT V ABD/PEL	{'RTSTRUCT', nan}	{'TCIA-cptac-ccrcc', 'IDC-IDC_cptac_ccrcc'}	{'IDC', 'TCIA'}	2
-CT ABD/PELV W/O	{'CT', nan}	{'TCIA-tcga-ov', 'IDC-IDC_tcga_ov'}	{'IDC', 'TCIA'}	2
-CT VIRTUAL COLONOSCOPY	{'CT', nan}	{'TCIA-tcga-coad', 'IDC-IDC_tcga_coad'}	{'IDC', 'TCIA'}	2
-CT ABD/PELVIS LIVER PR	{'SEG', nan}	{'IDC-IDC_hcc_tace_seg', 'TCIA-hcc-tace-seg'}	{'IDC', 'TCIA'}	2
-CT ABD/PELV(STONE)	{'CT', nan}	{'TCIA-tcga-kirc', 'IDC-IDC_tcga_kirc'}	{'IDC', 'TCIA'}	2
-CT head+c	{'CT', nan}	{'IDC-IDC_ctpred_sunitinib_pannet', 'TCIA-ctpred-sunitinib-pannet'}	{'IDC', 'TCIA'}	2
-CT jamy brzusznej z kontrastem	{'RTSTRUCT', nan}	{'TCIA-cptac-pda', 'IDC-IDC_cptac_pda'}	{'IDC', 'TCIA'}	2
-CT, ABD/PEL W/C	{'SEG', nan}	{'IDC-IDC_hcc_tace_seg', 'TCIA-hcc-tace-seg'}	{'IDC', 'TCIA'}	2
-CT/C-A-P/ LIVER	{'SEG', nan}	{'IDC-IDC_hcc_tace_seg', 'TCIA-hcc-tace-seg'}	{'IDC', 'TCIA'}	2
-CT/CC Brain, Unenhanc	{'CT', nan}	{'TCIA-acrin-nsclc-fdg-pet', 'IDC-IDC_acrin_nsclc_fdg_pet'}	{'IDC', 'TCIA'}	2
-CT/CC Chest	{'CT', nan}	{'TCIA-acrin-nsclc-fdg-pet', 'IDC-IDC_acrin_nsclc_fdg_pet'}	{'IDC', 'TCIA'}	2
-CT ABD WO THEN ABD/PEL WITH CONTRAST	{'CT', nan}	{'TCIA-tcga-lihc', 'IDC-IDC_tcga_lihc'}	{'IDC', 'TCIA'}	2
-CT ABD/PEL  LIVER	{'SEG', nan}	{'IDC-IDC_hcc_tace_seg', 'TCIA-hcc-tace-seg'}	{'IDC', 'TCIA'}	2
-CT ABD/CHEST W CONTRAST	{'CT', nan}	{'TCIA-acrin-nsclc-fdg-pet', 'IDC-IDC_acrin_nsclc_fdg_pet'}	{'IDC', 'TCIA'}	2
-CT ABD./PELVIS	{'CT', nan}	{'TCIA-tcga-kirc', 'IDC-IDC_tcga_kirc'}	{'IDC', 'TCIA'}	2
-CT ABD-PEL WO/W CM	{'CT'}	{'MIDRC-Open-A1'}	{'MIDRC'}	2
-CTA CHEST R/O	{'CT', nan}	{'TCIA-acrin-nsclc-fdg-pet', 'IDC-IDC_acrin_nsclc_fdg_pet'}	{'IDC', 'TCIA'}	2
-CTA CHEST W WO CONTRAST	{'CT'}	{'MIDRC-Open-A1_PETAL_BLUECORAL', 'MIDRC-Open-A1_PETAL_REDCORAL'}	{'MIDRC'}	2
-CT ABD W/WO AND PELVIS W CONTRAST	{'SEG', nan}	{'TCIA-tcga-lihc', 'IDC-IDC_tcga_lihc'}	{'IDC', 'TCIA'}	2
-CTA CHEST ANGIO	{'CT'}	{'MIDRC-Open-A1_PETAL_BLUECORAL'}	{'MIDRC'}	2
-CT ABD W/O/W  PELVIS W	{'CT', nan}	{'TCIA-tcga-kirc', 'IDC-IDC_tcga_kirc'}	{'IDC', 'TCIA'}	2
-CT ABD W/O(RENAL STONE	{'CT', nan}	{'TCIA-tcga-kirc', 'IDC-IDC_tcga_kirc'}	{'IDC', 'TCIA'}	2
-CT ABD UN + EN	{'CT', nan}	{'TCIA-adrenal-acc-ki67-seg', 'IDC-IDC_adrenal_acc_ki67_seg'}	{'IDC', 'TCIA'}	2
-CTA HEAD NECK(Adult)	{'CT'}	{'MIDRC-Open-A1'}	{'MIDRC'}	2
-CT ABD PELBIS	{'CT', nan}	{'TCIA-tcga-ov', 'IDC-IDC_tcga_ov'}	{'IDC', 'TCIA'}	2
-CT ABD PEL WITH	{'CT', nan}	{'TCIA-tcga-ov', 'IDC-IDC_tcga_ov'}	{'IDC', 'TCIA'}	2
-CT ABD/PEL  W/WO RENAL	{'SEG', nan}	{'TCIA-tcga-kirc', 'IDC-IDC_tcga_kirc'}	{'IDC', 'TCIA'}	2
-CT ABD/PEL (LIVER PRO)	{'SEG', nan}	{'IDC-IDC_hcc_tace_seg', 'TCIA-hcc-tace-seg'}	{'IDC', 'TCIA'}	2
-CT004   CT CHEST W/O CO	{'CT', nan}	{'TCIA-tcga-ov', 'IDC-IDC_tcga_ov'}	{'IDC', 'TCIA'}	2
-CTA ABDOMEN WWO CONTRAST (AORTA)	{'CT'}	{'MIDRC-Open-A1'}	{'MIDRC'}	2
-CT ABD/PEL W+WO CONT	{'CT', nan}	{'IDC-IDC_tcga_kirp', 'TCIA-tcga-kirp'}	{'IDC', 'TCIA'}	2
-CT009   CT ABDOMEN W&WO	{'CT', nan}	{'TCIA-tcga-kirc', 'IDC-IDC_tcga_kirc'}	{'IDC', 'TCIA'}	2
-CT: Chest w/contrast	{'CT'}	{'MIDRC-Open-A1_PETAL_REDCORAL'}	{'MIDRC'}	2
-CTA ABD AND PELV (ENTIRE AORTA)	{'CT'}	{'MIDRC-Open-A1'}	{'MIDRC'}	2
-CTA ABDM PELVIS RENAL	{'CT', nan}	{'TCIA-tcga-kirc', 'IDC-IDC_tcga_kirc'}	{'IDC', 'TCIA'}	2
-CTA ABDOMEN PELVIS AND BILATERAL EXTREMITY	{'CT'}	{'MIDRC-Open-A1'}	{'MIDRC'}	2
-CTA Abdomen WO and W contrast	{'SEG', nan}	{'TCIA-tcga-lihc', 'IDC-IDC_tcga_lihc'}	{'IDC', 'TCIA'}	2
-CT ABD/PEL (LIVER)	{'SEG', nan}	{'IDC-IDC_hcc_tace_seg', 'TCIA-hcc-tace-seg'}	{'IDC', 'TCIA'}	2
-CTA CARDIAC MORPHOLOGY	{'CT'}	{'MIDRC-Open-A1'}	{'MIDRC'}	2
-CT ABD/PEL W CONT	{'SEG', nan}	{'TCIA-tcga-lusc', 'IDC-IDC_tcga_lusc'}	{'IDC', 'TCIA'}	2
-CT ABD/PEL RENAL	{'SEG', nan}	{'TCIA-tcga-kirc', 'IDC-IDC_tcga_kirc'}	{'IDC', 'TCIA'}	2
-CT ABD/PEL LIV	{'SEG', nan}	{'IDC-IDC_hcc_tace_seg', 'TCIA-hcc-tace-seg'}	{'IDC', 'TCIA'}	2
-CT ABD/PEL (RENAL PRO)	{'SEG', nan}	{'TCIA-tcga-kirc', 'IDC-IDC_tcga_kirc'}	{'IDC', 'TCIA'}	2
-CTA CHEST ABDOMEN PELVIS W/O & W IV CON	{'CT'}	{'MIDRC-Open-R1'}	{'MIDRC'}	2
-DR Chest PORTABLE	{'CR', 'DX'}	{'MIDRC-Open-R1'}	{'MIDRC'}	2
-DRO QIN	{'MR', nan}	{'TCIA-gbm-dsc-mri-dro', 'IDC-IDC_gbm_dsc_mri_dro'}	{'IDC', 'TCIA'}	2
-CONTRA RIGHT BREAST	{'MR', nan}	{'IDC-IDC_acrin_contralateral_breast_mr', 'TCIA-acrin-contralateral-breast-mr'}	{'IDC', 'TCIA'}	2
-GBM DSC DRO b0 3T CA pre quarter bolus Full  - TR 1sec	{'MR', nan}	{'TCIA-gbm-dsc-mri-dro', 'IDC-IDC_gbm_dsc_mri_dro'}	{'IDC', 'TCIA'}	2
-CHEST POST	{'SEG', nan}	{'TCIA-tcga-kirc', 'IDC-IDC_tcga_kirc'}	{'IDC', 'TCIA'}	2
-CHEST PE ER	{'CT'}	{'MIDRC-Open-R1'}	{'MIDRC'}	2
-Head^CT_MAXILLOFACIAL_WO (Adult)	{'CT'}	{'MIDRC-Open-A1'}	{'MIDRC'}	2
-Head^DE_CTA_HEAD (Adult)	{'CT'}	{'MIDRC-Open-A1'}	{'MIDRC'}	2
-Head^DE_CTA_NECK (Adult)	{'CT'}	{'MIDRC-Open-A1'}	{'MIDRC'}	2
-Head^HEAD_FAST (Adult)	{'CT'}	{'MIDRC-Open-A1'}	{'MIDRC'}	2
-CHEST DELAYS	{'SEG', nan}	{'TCIA-acrin-nsclc-fdg-pet', 'IDC-IDC_acrin_nsclc_fdg_pet'}	{'IDC', 'TCIA'}	2
-CHEST DECUB RGHT/LFT/BIL (RAD)-CS	{'CR', 'DX'}	{'MIDRC-Open-A1'}	{'MIDRC'}	2
-CHEST CT [CE,3D]	{'SC', nan}	{'TCIA-acrin-nsclc-fdg-pet', 'IDC-IDC_acrin_nsclc_fdg_pet'}	{'IDC', 'TCIA'}	2
-Head^MAXILLOFACIAL (Adult)	{'CT'}	{'MIDRC-Open-A1'}	{'MIDRC'}	2
-CHEST CT WITH CONTRAST	{'CT'}	{'MIDRC-Open-A1_PETAL_REDCORAL'}	{'MIDRC'}	2
-CHEST CT W/CONTRAST	{'CT', nan}	{'TCIA-acrin-nsclc-fdg-pet', 'IDC-IDC_acrin_nsclc_fdg_pet'}	{'IDC', 'TCIA'}	2
-Head^STEALTH_Sinuses (Adult)	{'CT'}	{'MIDRC-Open-A1'}	{'MIDRC'}	2
-CHEST CT W CONTRAST	{'SEG', nan}	{'TCIA-tcga-lihc', 'IDC-IDC_tcga_lihc'}	{'IDC', 'TCIA'}	2
-Head^head_woandwith_GR (Adult)	{'CT'}	{'MIDRC-Open-A1'}	{'MIDRC'}	2
-Head^BHeadSeq6MM (Adult)	{'CT', nan}	{'IDC-IDC_lung_pet_ct_dx', 'TCIA-lung-pet-ct-dx'}	{'IDC', 'TCIA'}	2
-Head^BHead6MM (Adult)	{'CT', nan}	{'IDC-IDC_lung_pet_ct_dx', 'TCIA-lung-pet-ct-dx'}	{'IDC', 'TCIA'}	2
-HOT SPHERES TEST	{'PT', nan}	{'IDC-IDC_rider_lung_pet_ct', 'TCIA-rider-lung-pet-ct'}	{'IDC', 'TCIA'}	2
-CHEST WITH(Adult)	{'CT'}	{'MIDRC-Open-R1'}	{'MIDRC'}	2
-GBM DSC DRO b0 3T CA pre quarter bolus three-quarter - TR 1.5sec	{'MR', nan}	{'TCIA-gbm-dsc-mri-dro', 'IDC-IDC_gbm_dsc_mri_dro'}	{'IDC', 'TCIA'}	2
-GBM DSC DRO b0 3T CA pre quarter bolus three-quarter - TR 1sec	{'MR', nan}	{'TCIA-gbm-dsc-mri-dro', 'IDC-IDC_gbm_dsc_mri_dro'}	{'IDC', 'TCIA'}	2
-GBM DSC DRO b0 3T CA pre quarter bolus three-quarter - TR 2sec	{'MR', nan}	{'TCIA-gbm-dsc-mri-dro', 'IDC-IDC_gbm_dsc_mri_dro'}	{'IDC', 'TCIA'}	2
-GI	{'RTSTRUCT', nan}	{'IDC-IDC_pancreatic_ct_cbct_seg', 'TCIA-pancreatic-ct-cbct-seg'}	{'IDC', 'TCIA'}	2
-GROIN/PELVIS	{'CT', nan}	{'IDC-IDC_pelvic_reference_data', 'TCIA-pelvic-reference-data'}	{'IDC', 'TCIA'}	2
-Group-487 Cells and 425	{'MR', nan}	{'TCIA-mouse-astrocytoma', 'IDC-IDC_mouse_astrocytoma'}	{'IDC', 'TCIA'}	2
-HCT CHEST ANGIO W/O & W/	{'CT', nan}	{'TCIA-acrin-nsclc-fdg-pet', 'IDC-IDC_acrin_nsclc_fdg_pet'}	{'IDC', 'TCIA'}	2
-CHEST S	{'CT', nan}	{'TCIA-acrin-nsclc-fdg-pet', 'IDC-IDC_acrin_nsclc_fdg_pet'}	{'IDC', 'TCIA'}	2
-HCT CHEST W/ CONTRAST	{'CT', nan}	{'TCIA-acrin-nsclc-fdg-pet', 'IDC-IDC_acrin_nsclc_fdg_pet'}	{'IDC', 'TCIA'}	2
-HDR PROSTATE	{'CT', nan}	{'IDC-IDC_pelvic_reference_data', 'TCIA-pelvic-reference-data'}	{'IDC', 'TCIA'}	2
-HEAD	{'MR', nan}	{'IDC-IDC_icdc_glioma', 'TCIA-icdc-glioma'}	{'IDC', 'TCIA'}	2
-CHEST W CONTRAST CT	{'CT'}	{'MIDRC-Open-A1_PETAL_REDCORAL'}	{'MIDRC'}	2
-CHEST TWO VIEWS PA AND LATERAL	{'CR', nan}	{'TCIA-acrin-nsclc-fdg-pet', 'IDC-IDC_acrin_nsclc_fdg_pet'}	{'IDC', 'TCIA'}	2
-HEPATOCELLULAR CA	{'CT', nan}	{'TCIA-tcga-lihc', 'IDC-IDC_tcga_lihc'}	{'IDC', 'TCIA'}	2
-Hip R	{'CR'}	{'MIDRC-Open-A1'}	{'MIDRC'}	2
-CHEST CT  W/O CONTRAST	{'CT', nan}	{'TCIA-tcga-luad', 'IDC-IDC_tcga_luad'}	{'IDC', 'TCIA'}	2
-IC CT ABD PELV W CONT	{'CT', nan}	{'IDC-IDC_tcga_blca', 'TCIA-tcga-blca'}	{'IDC', 'TCIA'}	2
-JB	{'RTSTRUCT', nan}	{'TCIA-cptac-pda', 'IDC-IDC_cptac_pda'}	{'IDC', 'TCIA'}	2
-Info Sheet	{'CT', nan}	{'TCIA-acrin-nsclc-fdg-pet', 'IDC-IDC_acrin_nsclc_fdg_pet'}	{'IDC', 'TCIA'}	2
-J.B+MM	{'RTSTRUCT', nan}	{'TCIA-cptac-pda', 'IDC-IDC_cptac_pda'}	{'IDC', 'TCIA'}	2
-J.BRZUSZ.	{'CT', nan}	{'TCIA-cptac-pda', 'IDC-IDC_cptac_pda'}	{'IDC', 'TCIA'}	2
-J.BRZUSZNA	{'RTSTRUCT', nan}	{'TCIA-cptac-ccrcc', 'IDC-IDC_cptac_ccrcc'}	{'IDC', 'TCIA'}	2
-JAMA BRZUSZNA	{'RTSTRUCT', nan}	{'TCIA-cptac-ccrcc', 'IDC-IDC_cptac_ccrcc'}	{'IDC', 'TCIA'}	2
-JAMBE^Reso-Concorde	{'RTSTRUCT', nan}	{'IDC-IDC_soft_tissue_sarcoma', 'TCIA-soft-tissue-sarcoma'}	{'IDC', 'TCIA'}	2
-JCCI CT CHEST HRCT	{'CT'}	{'MIDRC-Open-R1'}	{'MIDRC'}	2
-CHEST 2V PA + LAT	{'CR', nan}	{'IDC-IDC_tcga_blca', 'TCIA-tcga-blca'}	{'IDC', 'TCIA'}	2
-JCCI CT CHEST PE	{'CT'}	{'MIDRC-Open-R1'}	{'MIDRC'}	2
-CHEST (THORAX) WITH CONTRAST-CT	{'CT', nan}	{'TCIA-acrin-nsclc-fdg-pet', 'IDC-IDC_acrin_nsclc_fdg_pet'}	{'IDC', 'TCIA'}	2
-CH/ABD/PEL-RENAL 3D	{'SEG', nan}	{'TCIA-tcga-kirc', 'IDC-IDC_tcga_kirc'}	{'IDC', 'TCIA'}	2
-CH/ABD/PEL-RENAL	{'SEG', nan}	{'TCIA-tcga-kirc', 'IDC-IDC_tcga_kirc'}	{'IDC', 'TCIA'}	2
-CH-AB W/WO	{'SEG', nan}	{'TCIA-lidc-idri', 'IDC-IDC_lidc_idri'}	{'IDC', 'TCIA'}	2
-CH W CAT THORAX W/C 71260	{'CT', nan}	{'TCIA-acrin-nsclc-fdg-pet', 'IDC-IDC_acrin_nsclc_fdg_pet'}	{'IDC', 'TCIA'}	2
-Implant Screening - Conventional	{'MG', nan}	{'TCIA-breast-cancer-screening-dbt', 'IDC-IDC_breast_cancer_screening_dbt'}	{'IDC', 'TCIA'}	2
-CHEST ABD LIVER PROTOC	{'CT', nan}	{'IDC-IDC_hcc_tace_seg', 'TCIA-hcc-tace-seg'}	{'IDC', 'TCIA'}	2
-IC MRI ABD WO+W CON	{'MR', nan}	{'TCIA-tcga-lihc', 'IDC-IDC_tcga_lihc'}	{'IDC', 'TCIA'}	2
-IRM EXTRU+00C9MITU+00C9S SANS & AVEC INFUSION	{'MR', nan}	{'IDC-IDC_soft_tissue_sarcoma', 'TCIA-soft-tissue-sarcoma'}	{'IDC', 'TCIA'}	2
-CHEST C 65ML OPTIRAY64	{'CT', nan}	{'TCIA-acrin-nsclc-fdg-pet', 'IDC-IDC_acrin_nsclc_fdg_pet'}	{'IDC', 'TCIA'}	2
-IR BIOPSY LIVER	{'US', nan}	{'TCIA-cmb-lca', 'IDC-IDC_cmb_lca'}	{'IDC', 'TCIA'}	2
-IR BIOPSY LIVER NON FOCAL	{'US'}	{'MIDRC-Open-A1'}	{'MIDRC'}	2
-CHEST AP AM SERVICE ICU	{'DX'}	{'MIDRC-Open-R1'}	{'MIDRC'}	2
-IRM - CUISSE GAUCHE	{'MR', nan}	{'IDC-IDC_soft_tissue_sarcoma', 'TCIA-soft-tissue-sarcoma'}	{'IDC', 'TCIA'}	2
-IRM BRAS GAUCHE C-C+	{'MR', nan}	{'IDC-IDC_soft_tissue_sarcoma', 'TCIA-soft-tissue-sarcoma'}	{'IDC', 'TCIA'}	2
-IRM Extremites Gauche Epaule	{'RTSTRUCT', nan}	{'IDC-IDC_soft_tissue_sarcoma', 'TCIA-soft-tissue-sarcoma'}	{'IDC', 'TCIA'}	2
-CHEST ABDOMEN	{'CT', nan}	{'IDC-IDC_cptac_cm', 'TCIA-cptac-cm'}	{'IDC', 'TCIA'}	2
-IRM FEMUR GAUCHE C-/C+	{'RTSTRUCT', nan}	{'IDC-IDC_soft_tissue_sarcoma', 'TCIA-soft-tissue-sarcoma'}	{'IDC', 'TCIA'}	2
-IRM FEMUR/CUISSE GAUCHE C+	{'MR', nan}	{'IDC-IDC_soft_tissue_sarcoma', 'TCIA-soft-tissue-sarcoma'}	{'IDC', 'TCIA'}	2
-IRM FEMUR/CUISSE GAUCHE C- C+	{'RTSTRUCT', nan}	{'IDC-IDC_soft_tissue_sarcoma', 'TCIA-soft-tissue-sarcoma'}	{'IDC', 'TCIA'}	2
-IRM HANCHE DROITE C+	{'MR', nan}	{'IDC-IDC_soft_tissue_sarcoma', 'TCIA-soft-tissue-sarcoma'}	{'IDC', 'TCIA'}	2
-IRM HANCHE DROITE C- C+	{'MR', nan}	{'IDC-IDC_soft_tissue_sarcoma', 'TCIA-soft-tissue-sarcoma'}	{'IDC', 'TCIA'}	2
-IRM extremite gauche sans et avec contraste	{'MR', nan}	{'IDC-IDC_soft_tissue_sarcoma', 'TCIA-soft-tissue-sarcoma'}	{'IDC', 'TCIA'}	2
-GBM DSC DRO b0 3T CA pre quarter bolus Full  - TR 2sec	{'MR', nan}	{'TCIA-gbm-dsc-mri-dro', 'IDC-IDC_gbm_dsc_mri_dro'}	{'IDC', 'TCIA'}	2
-GBM DSC DRO b0 3T CA pre quarter bolus Full  - TR 1.5sec	{'MR', nan}	{'TCIA-gbm-dsc-mri-dro', 'IDC-IDC_gbm_dsc_mri_dro'}	{'IDC', 'TCIA'}	2
-DX Read Outside Film(s)	{'SEG', nan}	{'IDC-IDC_tcga_kich', 'TCIA-tcga-kich'}	{'IDC', 'TCIA'}	2
-GBM DSC DRO b0 3T CA pre none bolus full - TR 2sec	{'MR', nan}	{'TCIA-gbm-dsc-mri-dro', 'IDC-IDC_gbm_dsc_mri_dro'}	{'IDC', 'TCIA'}	2
-CHEST172	{'CT', nan}	{'TCIA-lidc-idri', 'IDC-IDC_lidc_idri'}	{'IDC', 'TCIA'}	2
-FDG 5AFOV Lung	{'PT', nan}	{'IDC-IDC_rider_lung_pet_ct', 'TCIA-rider-lung-pet-ct'}	{'IDC', 'TCIA'}	2
-FDG 5AFOV SWEEP	{'PT', nan}	{'IDC-IDC_rider_lung_pet_ct', 'TCIA-rider-lung-pet-ct'}	{'IDC', 'TCIA'}	2
-FDG 5AFOV TORSO BU	{'PT', nan}	{'IDC-IDC_rider_lung_pet_ct', 'TCIA-rider-lung-pet-ct'}	{'IDC', 'TCIA'}	2
-FDG 5AFOV UPPER LUNG	{'PT', nan}	{'IDC-IDC_rider_lung_pet_ct', 'TCIA-rider-lung-pet-ct'}	{'IDC', 'TCIA'}	2
-FDG 5FOV TORSO	{'SEG', nan}	{'IDC-IDC_rider_lung_pet_ct', 'TCIA-rider-lung-pet-ct'}	{'IDC', 'TCIA'}	2
-FDG 6AFOV TORSO	{'SEG', nan}	{'IDC-IDC_rider_lung_pet_ct', 'TCIA-rider-lung-pet-ct'}	{'IDC', 'TCIA'}	2
-FDG 7 AFOV TORSO	{'SEG', nan}	{'IDC-IDC_rider_lung_pet_ct', 'TCIA-rider-lung-pet-ct'}	{'IDC', 'TCIA'}	2
-FDG BRIAIN	{'CT', nan}	{'IDC-IDC_rider_lung_pet_ct', 'TCIA-rider-lung-pet-ct'}	{'IDC', 'TCIA'}	2
-FDG/F18 PET/CT BONE SCAN	{'SEG', nan}	{'TCIA-acrin-nsclc-fdg-pet', 'IDC-IDC_acrin_nsclc_fdg_pet'}	{'IDC', 'TCIA'}	2
-CHEST/ABDOMEN	{'SEG', nan}	{'IDC-IDC_hcc_tace_seg', 'TCIA-hcc-tace-seg'}	{'IDC', 'TCIA'}	2
-CHEST/ABD/PEL (LIVER)	{'SEG', nan}	{'IDC-IDC_hcc_tace_seg', 'TCIA-hcc-tace-seg'}	{'IDC', 'TCIA'}	2
-CHEST/ABD-PEL W/WO IP	{'CT'}	{'MIDRC-Open-R1'}	{'MIDRC'}	2
-CHEST/ABD-PEL IV IP	{'CT'}	{'MIDRC-Open-R1'}	{'MIDRC'}	2
-FOOT LEFT 3 VIEWS (WEIGHT BEARING)	{'CR'}	{'MIDRC-Open-R1'}	{'MIDRC'}	2
-FDG 5AFOV CHEST	{'PT', nan}	{'IDC-IDC_rider_lung_pet_ct', 'TCIA-rider-lung-pet-ct'}	{'IDC', 'TCIA'}	2
-FDG 2AFOV PELVIS W/CAT	{'CT', nan}	{'IDC-IDC_rider_lung_pet_ct', 'TCIA-rider-lung-pet-ct'}	{'IDC', 'TCIA'}	2
-FDG 10 AFOV WB	{'PT', nan}	{'IDC-IDC_rider_lung_pet_ct', 'TCIA-rider-lung-pet-ct'}	{'IDC', 'TCIA'}	2
-CNHDWO	{'CT'}	{'MIDRC-Open-A1_PETAL_BLUECORAL'}	{'MIDRC'}	2
-CONTRA HIGH RISK	{'MR', nan}	{'IDC-IDC_acrin_contralateral_breast_mr', 'TCIA-acrin-contralateral-breast-mr'}	{'IDC', 'TCIA'}	2
-CONTRA BREAST(LEFT)	{'MR', nan}	{'IDC-IDC_acrin_contralateral_breast_mr', 'TCIA-acrin-contralateral-breast-mr'}	{'IDC', 'TCIA'}	2
-COLONOGRAPHY	{'CT', nan}	{'TCIA-ct-colonography', 'IDC-IDC_ct_colonography'}	{'IDC', 'TCIA'}	2
-Digital Left Mammogram Diagnostic	{'MG', nan}	{'TCIA-breast-diagnosis', 'IDC-IDC_breast_diagnosis'}	{'IDC', 'TCIA'}	2
-Digital Spot Compression: 9286464	{'MG', nan}	{'TCIA-breast-diagnosis', 'IDC-IDC_breast_diagnosis'}	{'IDC', 'TCIA'}	2
-Dual Energy^DE_PE_SIEMENS (Adult)	{'SEG', nan}	{'IDC-IDC_anti_pd_1_lung', 'TCIA-anti-pd-1_lung'}	{'IDC', 'TCIA'}	2
-ECAT PET Study	{'PT', nan}	{'TCIA-tcga-luad', 'IDC-IDC_tcga_luad'}	{'IDC', 'TCIA'}	2
-CHST2	{'CR', nan}	{'TCIA-acrin-nsclc-fdg-pet', 'IDC-IDC_acrin_nsclc_fdg_pet'}	{'IDC', 'TCIA'}	2
-CLINICAL^BODY	{'MR', nan}	{'IDC-IDC_acrin_contralateral_breast_mr', 'TCIA-acrin-contralateral-breast-mr'}	{'IDC', 'TCIA'}	2
-ECT008   CT ABDOMEN W CO	{'CT', nan}	{'TCIA-tcga-ov', 'IDC-IDC_tcga_ov'}	{'IDC', 'TCIA'}	2
-ECT008/IV   CT ABDOMEN W CO	{'CT', nan}	{'TCIA-tcga-coad', 'IDC-IDC_tcga_coad'}	{'IDC', 'TCIA'}	2
-EVT	{'CT', nan}	{'TCIA-tcga-kirc', 'IDC-IDC_tcga_kirc'}	{'IDC', 'TCIA'}	2
-Echocardiogram 2D Complete	{'US'}	{'MIDRC-Open-A1_PETAL_REDCORAL'}	{'MIDRC'}	2
-CL	{'CT', nan}	{'TCIA-acrin-nsclc-fdg-pet', 'IDC-IDC_acrin_nsclc_fdg_pet'}	{'IDC', 'TCIA'}	2
-CHEST/ABD W/C	{'SEG', nan}	{'TCIA-lidc-idri', 'IDC-IDC_lidc_idri'}	{'IDC', 'TCIA'}	2
-CHEST/ABD	{'SEG', nan}	{'TCIA-tcga-kirc', 'IDC-IDC_tcga_kirc'}	{'IDC', 'TCIA'}	2
-FOREARM RIGHT 2 VIEWS	{'CR', 'DX'}	{'MIDRC-Open-R1'}	{'MIDRC'}	2
-GBM DSC DRO b0 3T CA pre Full bolus Full  - TR 1.5sec	{'MR', nan}	{'TCIA-gbm-dsc-mri-dro', 'IDC-IDC_gbm_dsc_mri_dro'}	{'IDC', 'TCIA'}	2
-GBM DSC DRO b0 1.5T CA pre quarter bolus Full  - TR 1.5sec	{'MR', nan}	{'TCIA-gbm-dsc-mri-dro', 'IDC-IDC_gbm_dsc_mri_dro'}	{'IDC', 'TCIA'}	2
-GBM DSC DRO b0 1.5T CA pre quarter bolus Full  - TR 1sec	{'MR', nan}	{'TCIA-gbm-dsc-mri-dro', 'IDC-IDC_gbm_dsc_mri_dro'}	{'IDC', 'TCIA'}	2
-GBM DSC DRO b0 1.5T CA pre quarter bolus Full  - TR 2sec	{'MR', nan}	{'TCIA-gbm-dsc-mri-dro', 'IDC-IDC_gbm_dsc_mri_dro'}	{'IDC', 'TCIA'}	2
-GBM DSC DRO b0 1.5T CA pre quarter bolus three-quarter - TR 1.5s	{'MR', nan}	{'TCIA-gbm-dsc-mri-dro', 'IDC-IDC_gbm_dsc_mri_dro'}	{'IDC', 'TCIA'}	2
-GBM DSC DRO b0 1.5T CA pre quarter bolus three-quarter - TR 1sec	{'MR', nan}	{'TCIA-gbm-dsc-mri-dro', 'IDC-IDC_gbm_dsc_mri_dro'}	{'IDC', 'TCIA'}	2
-GBM DSC DRO b0 1.5T CA pre quarter bolus three-quarter - TR 2sec	{'MR', nan}	{'TCIA-gbm-dsc-mri-dro', 'IDC-IDC_gbm_dsc_mri_dro'}	{'IDC', 'TCIA'}	2
-GBM DSC DRO b0 3T CA pre Full bolus Full  - TR 1sec	{'MR', nan}	{'TCIA-gbm-dsc-mri-dro', 'IDC-IDC_gbm_dsc_mri_dro'}	{'IDC', 'TCIA'}	2
-GBM DSC DRO b0 1.5T CA pre none bolus full - TR 1sec	{'MR', nan}	{'TCIA-gbm-dsc-mri-dro', 'IDC-IDC_gbm_dsc_mri_dro'}	{'IDC', 'TCIA'}	2
-GBM DSC DRO b0 3T CA pre Full bolus Full  - TR 2sec	{'MR', nan}	{'TCIA-gbm-dsc-mri-dro', 'IDC-IDC_gbm_dsc_mri_dro'}	{'IDC', 'TCIA'}	2
-GBM DSC DRO b0 3T CA pre half bolus half - TR 1.5sec	{'MR', nan}	{'TCIA-gbm-dsc-mri-dro', 'IDC-IDC_gbm_dsc_mri_dro'}	{'IDC', 'TCIA'}	2
-GBM DSC DRO b0 3T CA pre half bolus half - TR 1sec	{'MR', nan}	{'TCIA-gbm-dsc-mri-dro', 'IDC-IDC_gbm_dsc_mri_dro'}	{'IDC', 'TCIA'}	2
-GBM DSC DRO b0 3T CA pre half bolus half - TR 2sec	{'MR', nan}	{'TCIA-gbm-dsc-mri-dro', 'IDC-IDC_gbm_dsc_mri_dro'}	{'IDC', 'TCIA'}	2
-GBM DSC DRO b0 3T CA pre none bolus full - TR 1.5sec	{'MR', nan}	{'TCIA-gbm-dsc-mri-dro', 'IDC-IDC_gbm_dsc_mri_dro'}	{'IDC', 'TCIA'}	2
-GBM DSC DRO b0 3T CA pre none bolus full - TR 1sec	{'MR', nan}	{'TCIA-gbm-dsc-mri-dro', 'IDC-IDC_gbm_dsc_mri_dro'}	{'IDC', 'TCIA'}	2
-GBM DSC DRO b0 1.5T CA pre none bolus full - TR 2sec	{'MR', nan}	{'TCIA-gbm-dsc-mri-dro', 'IDC-IDC_gbm_dsc_mri_dro'}	{'IDC', 'TCIA'}	2
-GBM DSC DRO b0 1.5T CA pre none bolus full - TR 1.5sec	{'MR', nan}	{'TCIA-gbm-dsc-mri-dro', 'IDC-IDC_gbm_dsc_mri_dro'}	{'IDC', 'TCIA'}	2
-FOREARM^ROUTINE	{'MR', nan}	{'IDC-IDC_cptac_sar', 'TCIA-cptac-sar'}	{'IDC', 'TCIA'}	2
-FORFILE MR ABDO AND/OR PEL - CD	{'MR', nan}	{'IDC-IDC_tcga_blca', 'TCIA-tcga-blca'}	{'IDC', 'TCIA'}	2
-CHEST,ABDOMEN,  PELVIS W CONT	{'CT', nan}	{'TCIA-tcga-ucec', 'IDC-IDC_tcga_ucec'}	{'IDC', 'TCIA'}	2
-FOREIGN CT CH/ABD/PELV - CD	{'CT', nan}	{'TCIA-tcga-ov', 'IDC-IDC_tcga_ov'}	{'IDC', 'TCIA'}	2
-FOREIGN CT CH/ABD/PELV - FILM	{'CT', nan}	{'TCIA-tcga-ov', 'IDC-IDC_tcga_ov'}	{'IDC', 'TCIA'}	2
-CHEST, TWO VIEWS	{'CR'}	{'MIDRC-Open-R1'}	{'MIDRC'}	2
-CHEST, CHEST PA	{'CR', nan}	{'IDC-IDC_tcga_blca', 'TCIA-tcga-blca'}	{'IDC', 'TCIA'}	2
-FORFILE CT CH/AB/PEL - CD for 8155012288	{'CT', nan}	{'IDC-IDC_pseudo_phi_dicom_data', 'TCIA-pseudo-phi-dicom-data'}	{'IDC', 'TCIA'}	2
-FORFILE MR ABDOMEN	{'MR', nan}	{'TCIA-tcga-kirc', 'IDC-IDC_tcga_kirc'}	{'IDC', 'TCIA'}	2
-GBM DSC DRO b0 1.5T CA pre half bolus half - TR 2sec	{'MR', nan}	{'TCIA-gbm-dsc-mri-dro', 'IDC-IDC_gbm_dsc_mri_dro'}	{'IDC', 'TCIA'}	2
-FR PERMANENT FILE COPY=	{'RTSTRUCT', nan}	{'TCIA-cptac-pda', 'IDC-IDC_cptac_pda'}	{'IDC', 'TCIA'}	2
-GBM DSC DRO b0 1.5T CA pre Full bolus Full  - TR 1.5sec	{'MR', nan}	{'TCIA-gbm-dsc-mri-dro', 'IDC-IDC_gbm_dsc_mri_dro'}	{'IDC', 'TCIA'}	2
-GBM DSC DRO b0 1.5T CA pre Full bolus Full  - TR 1sec	{'MR', nan}	{'TCIA-gbm-dsc-mri-dro', 'IDC-IDC_gbm_dsc_mri_dro'}	{'IDC', 'TCIA'}	2
-GBM DSC DRO b0 1.5T CA pre Full bolus Full  - TR 2sec	{'MR', nan}	{'TCIA-gbm-dsc-mri-dro', 'IDC-IDC_gbm_dsc_mri_dro'}	{'IDC', 'TCIA'}	2
-GBM DSC DRO b0 1.5T CA pre half bolus half - TR 1.5sec	{'MR', nan}	{'TCIA-gbm-dsc-mri-dro', 'IDC-IDC_gbm_dsc_mri_dro'}	{'IDC', 'TCIA'}	2
-GBM DSC DRO b0 1.5T CA pre half bolus half - TR 1sec	{'MR', nan}	{'TCIA-gbm-dsc-mri-dro', 'IDC-IDC_gbm_dsc_mri_dro'}	{'IDC', 'TCIA'}	2
-CT ABD/PELVIS(LIVER)	{'SEG', nan}	{'IDC-IDC_hcc_tace_seg', 'TCIA-hcc-tace-seg'}	{'IDC', 'TCIA'}	2
-CT UPPER ABD W+WO CONT	{'SEG', nan}	{'TCIA-tcga-lihc', 'IDC-IDC_tcga_lihc'}	{'IDC', 'TCIA'}	2
-CH CH.3D	{'CT', nan}	{'IDC-IDC_lung_pet_ct_dx', 'TCIA-lung-pet-ct-dx'}	{'IDC', 'TCIA'}	2
-CT Abdomen Nonenh & Enhanced-BODY	{'SEG', nan}	{'TCIA-tcga-lihc', 'IDC-IDC_tcga_lihc'}	{'IDC', 'TCIA'}	2
-CT Abdomen/Pelvis With	{'CT', nan}	{'TCIA-acrin-nsclc-fdg-pet', 'IDC-IDC_acrin_nsclc_fdg_pet'}	{'IDC', 'TCIA'}	2
-CT CHEST WO CONTRAST IP	{'CT'}	{'MIDRC-Open-R1'}	{'MIDRC'}	2
-CT CHEST WO CONTRAST OP	{'CT'}	{'MIDRC-Open-R1'}	{'MIDRC'}	2
-CT Abdomen wwo	{'CT', nan}	{'IDC-IDC_tcga_prad', 'TCIA-tcga-prad'}	{'IDC', 'TCIA'}	2
-CT Abdomen wo+w + Pelvis wo+w	{'CT', nan}	{'TCIA-tcga-ucec', 'IDC-IDC_tcga_ucec'}	{'IDC', 'TCIA'}	2
-CT CHEST WO IV CONTRAST LUNG CANCER SCREENING	{'CT'}	{'AIMI-COCA'}	{'AIMI'}	2
-CT Abdomen without con	{'CT', nan}	{'TCIA-tcga-ucec', 'IDC-IDC_tcga_ucec'}	{'IDC', 'TCIA'}	2
-CT Abdomen with contrast	{'CT', nan}	{'TCIA-tcga-ucec', 'IDC-IDC_tcga_ucec'}	{'IDC', 'TCIA'}	2
-CT Abdomen w/o	{'CT', nan}	{'TCIA-tcga-ucec', 'IDC-IDC_tcga_ucec'}	{'IDC', 'TCIA'}	2
-CT Abdomen and Pelvis Without Contrast	{'RTSTRUCT', nan}	{'IDC-IDC_cptac_ucec', 'TCIA-cptac-ucec'}	{'IDC', 'TCIA'}	2
-CT Abdomen and Pelvis W/O Contrast	{'CT'}	{'MIDRC-Open-A1_PETAL_BLUECORAL'}	{'MIDRC'}	2
-CT Abdomen W/Contrast	{'CT', nan}	{'TCIA-tcga-ucec', 'IDC-IDC_tcga_ucec'}	{'IDC', 'TCIA'}	2
-CT Abdomen Pelvis W/ Contrast	{'CT', nan}	{'IDC-IDC_tcga_blca', 'TCIA-tcga-blca'}	{'IDC', 'TCIA'}	2
-CT CHEST+ABD+PELVIS AUGMENT=CH	{'RTSTRUCT', nan}	{'TCIA-cptac-pda', 'IDC-IDC_cptac_pda'}	{'IDC', 'TCIA'}	2
-CT CHEST+ABDOMEN+PELVIS W CONTRAST	{'CT', nan}	{'IDC-IDC_cptac_cm', 'TCIA-cptac-cm'}	{'IDC', 'TCIA'}	2
-CT Abdomen/Pelvis w/o & w contrast	{'CT', nan}	{'TCIA-tcga-ucec', 'IDC-IDC_tcga_ucec'}	{'IDC', 'TCIA'}	2
-CT Adrenal Mass	{'RTSTRUCT', nan}	{'TCIA-cptac-ccrcc', 'IDC-IDC_cptac_ccrcc'}	{'IDC', 'TCIA'}	2
-CT CHEST WITHOUT CONTRAST (PETCT)	{'CT'}	{'MIDRC-Open-R1'}	{'MIDRC'}	2
-CT CHEST W/WO CONTRAST	{'CT', nan}	{'TCIA-tcga-lusc', 'IDC-IDC_tcga_lusc'}	{'IDC', 'TCIA'}	2
-CT CHEST W/O CONT	{'SEG', nan}	{'IDC-IDC_nsclc_radiogenomics', 'TCIA-nsclc-radiogenomics'}	{'IDC', 'TCIA'}	2
-CT Biopsy Bone Marrow	{'CT', nan}	{'IDC-IDC_cmb_mml', 'TCIA-cmb-mml'}	{'IDC', 'TCIA'}	2
-CT BRAIN W CONT	{'CT', nan}	{'TCIA-acrin-nsclc-fdg-pet', 'IDC-IDC_acrin_nsclc_fdg_pet'}	{'IDC', 'TCIA'}	2
-CT CHEST W/O- LOW DOSE (LUNG CANCER SCREENING)	{'CT'}	{'MIDRC-Open-A1'}	{'MIDRC'}	2
-CT CHEST W/OUT	{'SEG', nan}	{'IDC-IDC_nsclc_radiogenomics', 'TCIA-nsclc-radiogenomics'}	{'IDC', 'TCIA'}	2
-CT CHEST W/WO	{'CT', nan}	{'TCIA-acrin-nsclc-fdg-pet', 'IDC-IDC_acrin_nsclc_fdg_pet'}	{'IDC', 'TCIA'}	2
-CT BODY OUTSIDE IMAGE	{'CT'}	{'MIDRC-Open-A1'}	{'MIDRC'}	2
-CT Aspiration	{'CT', nan}	{'TCIA-tcga-ucec', 'IDC-IDC_tcga_ucec'}	{'IDC', 'TCIA'}	2
-CT CHEST WITH :	{'CT', nan}	{'TCIA-acrin-nsclc-fdg-pet', 'IDC-IDC_acrin_nsclc_fdg_pet'}	{'IDC', 'TCIA'}	2
-CT BIOPSY ST MASS	{'CT', nan}	{'IDC-IDC_cptac_sar', 'TCIA-cptac-sar'}	{'IDC', 'TCIA'}	2
-CT BIOPSY MUSCLE	{'CT', nan}	{'IDC-IDC_cptac_sar', 'TCIA-cptac-sar'}	{'IDC', 'TCIA'}	2
-CT BIOPSY LIVER	{'CT', nan}	{'TCIA-tcga-lihc', 'IDC-IDC_tcga_lihc'}	{'IDC', 'TCIA'}	2
-CT CHEST WITH CONTRAST - PE PROTOCOL	{'CT'}	{'MIDRC-Open-A1_PETAL_BLUECORAL'}	{'MIDRC'}	2
-CT BIOPSY BONE DEEP/NE	{'CT', nan}	{'IDC-IDC_cptac_sar', 'TCIA-cptac-sar'}	{'IDC', 'TCIA'}	2
-CT CHEST, ENHANCED-CHEST	{'CT', nan}	{'TCIA-acrin-nsclc-fdg-pet', 'IDC-IDC_acrin_nsclc_fdg_pet'}	{'IDC', 'TCIA'}	2
-CT CHEST/ ABDOMEN GE	{'CT', nan}	{'TCIA-acrin-nsclc-fdg-pet', 'IDC-IDC_acrin_nsclc_fdg_pet'}	{'IDC', 'TCIA'}	2
-CT UPPER ABD W CONT	{'CT', nan}	{'TCIA-tcga-lihc', 'IDC-IDC_tcga_lihc'}	{'IDC', 'TCIA'}	2
-CT CHEST/AB/PEL (LIVER	{'SEG', nan}	{'IDC-IDC_hcc_tace_seg', 'TCIA-hcc-tace-seg'}	{'IDC', 'TCIA'}	2
-CT Abd and Pelvis wo cont	{'CT', nan}	{'IDC-IDC_tcga_prad', 'TCIA-tcga-prad'}	{'IDC', 'TCIA'}	2
-CT AP W/WO CONTRAST	{'SEG', nan}	{'TCIA-tcga-kirc', 'IDC-IDC_tcga_kirc'}	{'IDC', 'TCIA'}	2
-CT AP UROGRAM	{'CT', nan}	{'IDC-IDC_tcga_blca', 'TCIA-tcga-blca'}	{'IDC', 'TCIA'}	2
-CT AP RENAL	{'SEG', nan}	{'TCIA-tcga-kirc', 'IDC-IDC_tcga_kirc'}	{'IDC', 'TCIA'}	2
-CT AP	{'CT', nan}	{'TCIA-tcga-ov', 'IDC-IDC_tcga_ov'}	{'IDC', 'TCIA'}	2
-CT ANGIOGRAPHY, CHEST	{'SEG', nan}	{'IDC-IDC_nsclc_radiogenomics', 'TCIA-nsclc-radiogenomics'}	{'IDC', 'TCIA'}	2
-CT ANGIOGRAPHY PELVIS W/WO CON	{'CT', nan}	{'IDC-IDC_tcga_sarc', 'TCIA-tcga-sarc'}	{'IDC', 'TCIA'}	2
-CT CT-ANGIOGRAPHY CHEST W/WO	{'CT'}	{'MIDRC-Open-A1_PETAL_REDCORAL'}	{'MIDRC'}	2
-CT ANGIOGRAPHY CHEST WITH CONTRAST	{'CT'}	{'MIDRC-Open-A1_PETAL_REDCORAL'}	{'MIDRC'}	2
-CT CT-Thorax (W/O Contrast)	{'CT'}	{'MIDRC-Open-A1_PETAL_REDCORAL'}	{'MIDRC'}	2
-CT ANGIOGRAPHY CHEST W/WO CON	{'CT', nan}	{'TCIA-tcga-lusc', 'IDC-IDC_tcga_lusc'}	{'IDC', 'TCIA'}	2
-CT CTA CHEST W CONTRAST	{'CT'}	{'MIDRC-Open-A1_PETAL_BLUECORAL'}	{'MIDRC'}	2
-CT ANGIOGRAM PULMONARY ABDOMEN AND PELVIS W CONTRAST	{'CT'}	{'MIDRC-Open-A1_PETAL_BLUECORAL'}	{'MIDRC'}	2
-CT Chest +C	{'CT', nan}	{'IDC-IDC_ctpred_sunitinib_pannet', 'TCIA-ctpred-sunitinib-pannet'}	{'IDC', 'TCIA'}	2
-CT Chest Abd Pelvis Reference Only	{'SEG', nan}	{'IDC-IDC_nsclc_radiogenomics', 'TCIA-nsclc-radiogenomics'}	{'IDC', 'TCIA'}	2
-CT COLONGRAGHY	{'CT', nan}	{'TCIA-ct-colonography', 'IDC-IDC_ct_colonography'}	{'IDC', 'TCIA'}	2
-CT COLON OGRAPHY	{'CT', nan}	{'TCIA-ct-colonography', 'IDC-IDC_ct_colonography'}	{'IDC', 'TCIA'}	2
-CT COLOLNOGRAPHY	{'CT', nan}	{'TCIA-ct-colonography', 'IDC-IDC_ct_colonography'}	{'IDC', 'TCIA'}	2
-CT Abd/Pelvis w/o Cont	{'RTSTRUCT', nan}	{'TCIA-cptac-ccrcc', 'IDC-IDC_cptac_ccrcc'}	{'IDC', 'TCIA'}	2
-CT Abdomen & Pelvis	{'CT', nan}	{'TCIA-adrenal-acc-ki67-seg', 'IDC-IDC_adrenal_acc_ki67_seg'}	{'IDC', 'TCIA'}	2
-CT CHEST/ABD/PEL EXTERNAL IMAGING	{'RTSTRUCT', nan}	{'TCIA-cptac-pda', 'IDC-IDC_cptac_pda'}	{'IDC', 'TCIA'}	2
-CT Abdo UnEnhan	{'CT', nan}	{'TCIA-tcga-ov', 'IDC-IDC_tcga_ov'}	{'IDC', 'TCIA'}	2
-CT CHEST/ABD/PEL RENAL	{'SEG', nan}	{'TCIA-tcga-kirc', 'IDC-IDC_tcga_kirc'}	{'IDC', 'TCIA'}	2
-CT Abdo Enhan	{'CT', nan}	{'TCIA-tcga-ov', 'IDC-IDC_tcga_ov'}	{'IDC', 'TCIA'}	2
-CT CHEST/ABD/PELV WO CONTRAST	{'CT'}	{'MIDRC-Open-A1_PETAL_BLUECORAL'}	{'MIDRC'}	2
-CT CHEST/ABD/PELVIS W/O CONTRAST	{'CT', nan}	{'TCIA-cmb-crc', 'IDC-IDC_cmb_crc'}	{'IDC', 'TCIA'}	2
-CT Abd/PELVIS	{'CT', nan}	{'TCIA-cmb-crc', 'IDC-IDC_cmb_crc'}	{'IDC', 'TCIA'}	2
-CT CHEST/ABD/[PEL W/	{'SEG', nan}	{'IDC-IDC_nsclc_radiogenomics', 'TCIA-nsclc-radiogenomics'}	{'IDC', 'TCIA'}	2
-CT CHEST/ABDOMEN	{'CT', nan}	{'TCIA-acrin-nsclc-fdg-pet', 'IDC-IDC_acrin_nsclc_fdg_pet'}	{'IDC', 'TCIA'}	2
-CT CHEST/ABDOMEN W/	{'CT', nan}	{'TCIA-acrin-nsclc-fdg-pet', 'IDC-IDC_acrin_nsclc_fdg_pet'}	{'IDC', 'TCIA'}	2
-CT Abd/Pelvis w/ Contrast	{'SEG', nan}	{'TCIA-cptac-ccrcc', 'IDC-IDC_cptac_ccrcc'}	{'IDC', 'TCIA'}	2
-CT CHEST/ABDOMEN/PELVI	{'CT', nan}	{'TCIA-acrin-nsclc-fdg-pet', 'IDC-IDC_acrin_nsclc_fdg_pet'}	{'IDC', 'TCIA'}	2
-CT CHEST/RENAL MASS	{'SEG', nan}	{'IDC-IDC_nsclc_radiogenomics', 'TCIA-nsclc-radiogenomics'}	{'IDC', 'TCIA'}	2
-CT Biopsy Liver	{'CT', nan}	{'TCIA-cmb-crc', 'IDC-IDC_cmb_crc'}	{'IDC', 'TCIA'}	2
-CT CHEST W/O CM	{'CT'}	{'MIDRC-Open-A1'}	{'MIDRC'}	2
-CT Biopsy Lung Procedu	{'SEG', nan}	{'IDC-IDC_nsclc_radiogenomics', 'TCIA-nsclc-radiogenomics'}	{'IDC', 'TCIA'}	2
-CT Body Outside Consultation With Formal Dictation	{'CT', nan}	{'TCIA-cptac-lscc', 'IDC-IDC_cptac_lscc'}	{'IDC', 'TCIA'}	2
-CT CH/AB W/ CONTRAST	{'SEG', nan}	{'TCIA-colorectal-liver-metastases', 'IDC-IDC_colorectal_liver_metastases'}	{'IDC', 'TCIA'}	2
-CT CH/AB W & W/O CONTRAST	{'CT', nan}	{'TCIA-tcga-kirc', 'IDC-IDC_tcga_kirc'}	{'IDC', 'TCIA'}	2
-CT CHEST ABDOMEN PELVIS W/O IV CONTRAST	{'RTSTRUCT', nan}	{'IDC-IDC_cptac_ucec', 'TCIA-cptac-ucec'}	{'IDC', 'TCIA'}	2
-CT CH-ABD-PEL (LIVER)	{'SEG', nan}	{'IDC-IDC_hcc_tace_seg', 'TCIA-hcc-tace-seg'}	{'IDC', 'TCIA'}	2
-CT CBD/PEL LIV	{'SEG', nan}	{'IDC-IDC_hcc_tace_seg', 'TCIA-hcc-tace-seg'}	{'IDC', 'TCIA'}	2
-CT CARDIAC W	{'CT'}	{'MIDRC-Open-A1'}	{'MIDRC'}	2
-CT CARDIAC CTA CORONAR	{'CT', nan}	{'IDC-IDC_rider_lung_pet_ct', 'TCIA-rider-lung-pet-ct'}	{'IDC', 'TCIA'}	2
-CT CHEST AND ABDOMEN AND PELVIS WWO CONTRAST	{'CT'}	{'MIDRC-Open-A1'}	{'MIDRC'}	2
-CT CARDIAC CONGENTIAL	{'CT', nan}	{'IDC-IDC_rider_lung_pet_ct', 'TCIA-rider-lung-pet-ct'}	{'IDC', 'TCIA'}	2
-CT CARD W/CON CORONARY ARTRY/VEIN CTA	{'CT'}	{'MIDRC-Open-A1'}	{'MIDRC'}	2
-CT CAPW	{'RTSTRUCT', nan}	{'TCIA-cptac-ccrcc', 'IDC-IDC_cptac_ccrcc'}	{'IDC', 'TCIA'}	2
-CT CAP WO/W	{'SEG', nan}	{'IDC-IDC_hcc_tace_seg', 'TCIA-hcc-tace-seg'}	{'IDC', 'TCIA'}	2
-CT CAP WITH	{'RTSTRUCT', nan}	{'IDC-IDC_cptac_ucec', 'TCIA-cptac-ucec'}	{'IDC', 'TCIA'}	2
-CT CHEST C+	{'CT', nan}	{'TCIA-acrin-nsclc-fdg-pet', 'IDC-IDC_acrin_nsclc_fdg_pet'}	{'IDC', 'TCIA'}	2
-CT CAP W/IV	{'CT', nan}	{'IDC-IDC_rider_lung_pet_ct', 'TCIA-rider-lung-pet-ct'}	{'IDC', 'TCIA'}	2
-CT CH/AB/PEL W/O	{'SEG', nan}	{'TCIA-lidc-idri', 'IDC-IDC_lidc_idri'}	{'IDC', 'TCIA'}	2
-CT CHEST ABDOMEN PELVIS W CONTRAST (S)	{'CT'}	{'MIDRC-Open-R1'}	{'MIDRC'}	2
-CT CH/AB/PEL-LIVER	{'SEG', nan}	{'IDC-IDC_hcc_tace_seg', 'TCIA-hcc-tace-seg'}	{'IDC', 'TCIA'}	2
-CT CH/ABD/PELVIS	{'SEG', nan}	{'TCIA-lidc-idri', 'IDC-IDC_lidc_idri'}	{'IDC', 'TCIA'}	2
-CT CHEST  W CON	{'CT', nan}	{'TCIA-tcga-ov', 'IDC-IDC_tcga_ov'}	{'IDC', 'TCIA'}	2
-CT CHEST & ABDOMEN W/C	{'CT', nan}	{'TCIA-acrin-nsclc-fdg-pet', 'IDC-IDC_acrin_nsclc_fdg_pet'}	{'IDC', 'TCIA'}	2
-CT CHE/ABD	{'CT', nan}	{'TCIA-acrin-nsclc-fdg-pet', 'IDC-IDC_acrin_nsclc_fdg_pet'}	{'IDC', 'TCIA'}	2
-CT CHE./ABD/PEL-LIVER	{'SEG', nan}	{'TCIA-lidc-idri', 'IDC-IDC_lidc_idri'}	{'IDC', 'TCIA'}	2
-CT CHEST ABD PEL. LIVE	{'SEG', nan}	{'IDC-IDC_hcc_tace_seg', 'TCIA-hcc-tace-seg'}	{'IDC', 'TCIA'}	2
-CT CHEST ABD PELVIS REFERENCE ONLY	{'CT'}	{'AIMI-COCA'}	{'AIMI'}	2
-CT CH/ABD/PELV	{'CT', nan}	{'TCIA-tcga-ov', 'IDC-IDC_tcga_ov'}	{'IDC', 'TCIA'}	2
-CT CH/ABD  LIVER	{'SEG', nan}	{'IDC-IDC_hcc_tace_seg', 'TCIA-hcc-tace-seg'}	{'IDC', 'TCIA'}	2
-CT CHEST ABD W/ CONTRAST	{'CT', nan}	{'TCIA-tcga-lusc', 'IDC-IDC_tcga_lusc'}	{'IDC', 'TCIA'}	2
-CT CH/ABD/PEL  LIVER	{'SEG', nan}	{'IDC-IDC_hcc_tace_seg', 'TCIA-hcc-tace-seg'}	{'IDC', 'TCIA'}	2
-CT CHEST ABDOMEN ANGIOGRAM WITH IV CONTRAST	{'CT'}	{'MIDRC-Open-A1_SCCM_VIRUS'}	{'MIDRC'}	2
-CT CH/ABD/PEL   LIVER	{'SEG', nan}	{'IDC-IDC_hcc_tace_seg', 'TCIA-hcc-tace-seg'}	{'IDC', 'TCIA'}	2
-CT CH/ABD/PEL	{'CT', nan}	{'TCIA-acrin-nsclc-fdg-pet', 'IDC-IDC_acrin_nsclc_fdg_pet'}	{'IDC', 'TCIA'}	2
-CT CH/ABD LIVER PROTO	{'SEG', nan}	{'IDC-IDC_hcc_tace_seg', 'TCIA-hcc-tace-seg'}	{'IDC', 'TCIA'}	2
-CT CHEST HIGH RESOLUTION WITHOUT CONTRAST	{'CT'}	{'MIDRC-Open-A1', 'MIDRC-Open-A1_PETAL_REDCORAL'}	{'MIDRC'}	2
-CT CAP W/CONTRAST	{'SEG', nan}	{'TCIA-lidc-idri', 'IDC-IDC_lidc_idri'}	{'IDC', 'TCIA'}	2
-CT CHEST N/C	{'CT', nan}	{'TCIA-tcga-luad', 'IDC-IDC_tcga_luad'}	{'IDC', 'TCIA'}	2
-CT C/A/ P W/O WITH	{'SEG', nan}	{'TCIA-tcga-kirc', 'IDC-IDC_tcga_kirc'}	{'IDC', 'TCIA'}	2
-CT C/A/P PRE/POST	{'CT', nan}	{'TCIA-tcga-kirc', 'IDC-IDC_tcga_kirc'}	{'IDC', 'TCIA'}	2
-CT CHEST W IV CONTRAST PULMONARY EMBOLUS	{'CT'}	{'MIDRC-Open-A1'}	{'MIDRC'}	2
-CT C/A/P LIVER PR	{'SEG', nan}	{'IDC-IDC_hcc_tace_seg', 'TCIA-hcc-tace-seg'}	{'IDC', 'TCIA'}	2
-CT C/A/P LIVER	{'SEG', nan}	{'IDC-IDC_hcc_tace_seg', 'TCIA-hcc-tace-seg'}	{'IDC', 'TCIA'}	2
-CT C/A/P  RENAL	{'SEG', nan}	{'TCIA-tcga-kirc', 'IDC-IDC_tcga_kirc'}	{'IDC', 'TCIA'}	2
-CT CHEST W+WO CONT	{'CT', nan}	{'TCIA-acrin-nsclc-fdg-pet', 'IDC-IDC_acrin_nsclc_fdg_pet'}	{'IDC', 'TCIA'}	2
-CT C/A LIVER PROT	{'CT', nan}	{'IDC-IDC_hcc_tace_seg', 'TCIA-hcc-tace-seg'}	{'IDC', 'TCIA'}	2
-CT C/A/P W-WO PE	{'CT', nan}	{'TCIA-rider-pilot', 'IDC-IDC_rider_pilot'}	{'IDC', 'TCIA'}	2
-CT C-A-P RENAL-3D	{'SEG', nan}	{'TCIA-tcga-kirc', 'IDC-IDC_tcga_kirc'}	{'IDC', 'TCIA'}	2
-CT CHEST W/ CON.	{'CT', nan}	{'TCIA-acrin-nsclc-fdg-pet', 'IDC-IDC_acrin_nsclc_fdg_pet'}	{'IDC', 'TCIA'}	2
-CT C Spine	{'CT', nan}	{'IDC-IDC_cmb_mel', 'TCIA-cmb-mel'}	{'IDC', 'TCIA'}	2
-CT Bone Marrow	{'CT', nan}	{'IDC-IDC_cmb_mml', 'TCIA-cmb-mml'}	{'IDC', 'TCIA'}	2
-CT CHEST W/ CONTRAST:	{'CT', nan}	{'TCIA-acrin-nsclc-fdg-pet', 'IDC-IDC_acrin_nsclc_fdg_pet'}	{'IDC', 'TCIA'}	2
-CT CHEST W/C-DESCENDAN	{'SEG', nan}	{'IDC-IDC_nsclc_radiogenomics', 'TCIA-nsclc-radiogenomics'}	{'IDC', 'TCIA'}	2
-CT CHEST W CONTRAST IP	{'CT'}	{'MIDRC-Open-R1'}	{'MIDRC'}	2
-CT C/A/P(LIVER)	{'SEG', nan}	{'IDC-IDC_hcc_tace_seg', 'TCIA-hcc-tace-seg'}	{'IDC', 'TCIA'}	2
-CT CAP W/ CONTRAST	{'SEG', nan}	{'IDC-IDC_anti_pd_1_lung', 'TCIA-anti-pd-1_lung'}	{'IDC', 'TCIA'}	2
-CT CAP LIVER PROT.	{'SEG', nan}	{'IDC-IDC_hcc_tace_seg', 'TCIA-hcc-tace-seg'}	{'IDC', 'TCIA'}	2
-CT CAP W/	{'CT', nan}	{'TCIA-acrin-nsclc-fdg-pet', 'IDC-IDC_acrin_nsclc_fdg_pet'}	{'IDC', 'TCIA'}	2
-CT CAP RENAL	{'SEG', nan}	{'TCIA-tcga-kirc', 'IDC-IDC_tcga_kirc'}	{'IDC', 'TCIA'}	2
-CT CHEST PE STUDY	{'CT'}	{'MIDRC-Open-A1_SCCM_VIRUS'}	{'MIDRC'}	2
-CT CAP NO IV	{'CT', nan}	{'IDC-IDC_tcga_blca', 'TCIA-tcga-blca'}	{'IDC', 'TCIA'}	2
-CT CAP LYMPH	{'CT', nan}	{'TCIA-lidc-idri', 'IDC-IDC_lidc_idri'}	{'IDC', 'TCIA'}	2
-CT CHEST PULMONARY ANGIOGRAM	{'CT'}	{'MIDRC-Open-A1_PETAL_BLUECORAL'}	{'MIDRC'}	2
-CT CAP LIVER PROT	{'SEG', nan}	{'IDC-IDC_hcc_tace_seg', 'TCIA-hcc-tace-seg'}	{'IDC', 'TCIA'}	2
-CT CHEST W ABDOMEN W/WO	{'CT', nan}	{'TCIA-acrin-nsclc-fdg-pet', 'IDC-IDC_acrin_nsclc_fdg_pet'}	{'IDC', 'TCIA'}	2
-CT CAP LIVER PR.	{'SEG', nan}	{'IDC-IDC_hcc_tace_seg', 'TCIA-hcc-tace-seg'}	{'IDC', 'TCIA'}	2
-CT CAP LIV PRO	{'SEG', nan}	{'IDC-IDC_hcc_tace_seg', 'TCIA-hcc-tace-seg'}	{'IDC', 'TCIA'}	2
-CT CHEST PULMONARY EMBOLUS PE ABDOMEN PELVIS W	{'CT', nan}	{'TCIA-tcga-ucec', 'IDC-IDC_tcga_ucec'}	{'IDC', 'TCIA'}	2
-CT CHEST R/O P	{'CT', nan}	{'TCIA-acrin-nsclc-fdg-pet', 'IDC-IDC_acrin_nsclc_fdg_pet'}	{'IDC', 'TCIA'}	2
-CT CAP LI VER	{'SEG', nan}	{'IDC-IDC_hcc_tace_seg', 'TCIA-hcc-tace-seg'}	{'IDC', 'TCIA'}	2
-CT CHEST W & ABDOMEN W	{'SEG', nan}	{'TCIA-tcga-kirc', 'IDC-IDC_tcga_kirc'}	{'IDC', 'TCIA'}	2
-CT Chest Abdomen and P	{'SEG', nan}	{'IDC-IDC_nsclc_radiogenomics', 'TCIA-nsclc-radiogenomics'}	{'IDC', 'TCIA'}	2
-CT ANGIOGRAM HEAD NECK W CONTRAST	{'CT'}	{'MIDRC-Open-R1'}	{'MIDRC'}	2
-CT Chest Thorax W Cont 71260	{'CT', nan}	{'TCIA-acrin-nsclc-fdg-pet', 'IDC-IDC_acrin_nsclc_fdg_pet'}	{'IDC', 'TCIA'}	2
-CT NECK W/ CONTRAST, CT CHEST W/ CONTRAST	{'CT', nan}	{'TCIA-tcga-thca', 'IDC-IDC_tcga_thca'}	{'IDC', 'TCIA'}	2
-CT ABDOMEN W CNTRST	{'CT', nan}	{'TCIA-acrin-nsclc-fdg-pet', 'IDC-IDC_acrin_nsclc_fdg_pet'}	{'IDC', 'TCIA'}	2
-CT Pelvis With Contrast	{'CT', nan}	{'TCIA-tcga-lihc', 'IDC-IDC_tcga_lihc'}	{'IDC', 'TCIA'}	2
-CT ABDOMEN W AND W/O IV CONTRAST	{'RTSTRUCT', nan}	{'TCIA-cptac-ccrcc', 'IDC-IDC_cptac_ccrcc'}	{'IDC', 'TCIA'}	2
-CT ABDOMEN W AND W/O AND CHEST/PELVIS W IV CONTRAST	{'RTSTRUCT', nan}	{'IDC-IDC_cptac_ucec', 'TCIA-cptac-ucec'}	{'IDC', 'TCIA'}	2
-CT Pelvis with contrast	{'CT', nan}	{'TCIA-tcga-ucec', 'IDC-IDC_tcga_ucec'}	{'IDC', 'TCIA'}	2
-CT RAD THERAPY EXAM ONLY	{'CT', nan}	{'TCIA-acrin-nsclc-fdg-pet', 'IDC-IDC_acrin_nsclc_fdg_pet'}	{'IDC', 'TCIA'}	2
-CT RENAL MASS W/Pelvis	{'CT', nan}	{'TCIA-tcga-kirc', 'IDC-IDC_tcga_kirc'}	{'IDC', 'TCIA'}	2
-CT RENAL MASS-CT ABDOM	{'RTSTRUCT', nan}	{'IDC-IDC_cptac_ucec', 'TCIA-cptac-ucec'}	{'IDC', 'TCIA'}	2
-CT ABDOMEN W  PELVIS W CONT	{'SEG', nan}	{'TCIA-adrenal-acc-ki67-seg', 'IDC-IDC_adrenal_acc_ki67_seg'}	{'IDC', 'TCIA'}	2
-CT RT UPPER EXTREMITY W/O CONTRAST	{'CT'}	{'MIDRC-Open-A1'}	{'MIDRC'}	2
-CT SINUSES WITHOUT CONTRAST	{'CT'}	{'MIDRC-Open-R1'}	{'MIDRC'}	2
-CT ST THIGH BIOPSY	{'CT', nan}	{'IDC-IDC_cptac_sar', 'TCIA-cptac-sar'}	{'IDC', 'TCIA'}	2
-CT Specials	{'CT', nan}	{'IDC-IDC_cmb_mel', 'TCIA-cmb-mel'}	{'IDC', 'TCIA'}	2
-CT Spine	{'CT', nan}	{'IDC-IDC_cmb_mel', 'TCIA-cmb-mel'}	{'IDC', 'TCIA'}	2
-CT T-SPINE W/O IV CONTRAST	{'CT'}	{'MIDRC-Open-A1'}	{'MIDRC'}	2
-CT PULMONARY ANGIOGRAM	{'CT', nan}	{'TCIA-cptac-luad', 'IDC-IDC_cptac_luad'}	{'IDC', 'TCIA'}	2
-CT PLAN	{'CT', nan}	{'TCIA-acrin-nsclc-fdg-pet', 'IDC-IDC_acrin_nsclc_fdg_pet'}	{'IDC', 'TCIA'}	2
-CT ABDOMEN W CONTRAST (PANCREAS)	{'CT'}	{'MIDRC-Open-A1'}	{'MIDRC'}	2
-CT PELVIS W CONT	{'CT', nan}	{'TCIA-acrin-nsclc-fdg-pet', 'IDC-IDC_acrin_nsclc_fdg_pet'}	{'IDC', 'TCIA'}	2
-CT ABDOMEN WITH AND WITHOUT CONTRAST	{'CT', nan}	{'TCIA-cptac-ccrcc', 'IDC-IDC_cptac_ccrcc'}	{'IDC', 'TCIA'}	2
-CT ABDOMEN WITH	{'CT', nan}	{'TCIA-acrin-nsclc-fdg-pet', 'IDC-IDC_acrin_nsclc_fdg_pet'}	{'IDC', 'TCIA'}	2
-CT Outside Images Reference only	{'CT', nan}	{'TCIA-cptac-lscc', 'IDC-IDC_cptac_lscc'}	{'IDC', 'TCIA'}	2
-CT ABDOMEN W/O (RENAL	{'CT', nan}	{'TCIA-tcga-kirc', 'IDC-IDC_tcga_kirc'}	{'IDC', 'TCIA'}	2
-CT PANCREATIC MASS CT	{'RTSTRUCT', nan}	{'TCIA-cptac-pda', 'IDC-IDC_cptac_pda'}	{'IDC', 'TCIA'}	2
-CT ABDOMEN W/CONTRAST	{'CT', nan}	{'IDC-IDC_tcga_kich', 'TCIA-tcga-kich'}	{'IDC', 'TCIA'}	2
-CT ABDOMEN W/ & W/O CONTRAST	{'CT', nan}	{'TCIA-tcga-kirc', 'IDC-IDC_tcga_kirc'}	{'IDC', 'TCIA'}	2
-CT PELVIS wo	{'CT', nan}	{'TCIA-tcga-ov', 'IDC-IDC_tcga_ov'}	{'IDC', 'TCIA'}	2
-CT PELVIS W IV CONTRAST	{'RTSTRUCT', nan}	{'IDC-IDC_cptac_ucec', 'TCIA-cptac-ucec'}	{'IDC', 'TCIA'}	2
-CT PELVIS W/ CONTRAST	{'CT', nan}	{'TCIA-tcga-coad', 'IDC-IDC_tcga_coad'}	{'IDC', 'TCIA'}	2
-CT PELVIS WITH CONTRAST	{'CT'}	{'MIDRC-Open-A1'}	{'MIDRC'}	2
-CT PELVIS WITH IV CONT	{'CT', nan}	{'TCIA-acrin-nsclc-fdg-pet', 'IDC-IDC_acrin_nsclc_fdg_pet'}	{'IDC', 'TCIA'}	2
-CT ABDOMEN W WO CONTRAST	{'CT', nan}	{'TCIA-adrenal-acc-ki67-seg', 'IDC-IDC_adrenal_acc_ki67_seg'}	{'IDC', 'TCIA'}	2
-CT ABDOMEN W PELVIS W	{'CT', nan}	{'TCIA-tcga-ucec', 'IDC-IDC_tcga_ucec'}	{'IDC', 'TCIA'}	2
-CT THORACIC AND LUMBAR SPINE WITHOUT IV CONTRAST	{'CT'}	{'MIDRC-Open-A1_SCCM_VIRUS'}	{'MIDRC'}	2
-CT ABDOMEN PELVIS W/WO CONTRAST	{'CT', nan}	{'IDC-IDC_tcga_kirp', 'TCIA-tcga-kirp'}	{'IDC', 'TCIA'}	2
-CT ABDOMEN PELVIS W/O AND W	{'SEG', nan}	{'TCIA-cptac-ccrcc', 'IDC-IDC_cptac_ccrcc'}	{'IDC', 'TCIA'}	2
-CT ABDOMEN & PELVIS-BODY	{'CT', nan}	{'TCIA-tcga-lihc', 'IDC-IDC_tcga_lihc'}	{'IDC', 'TCIA'}	2
-CT THORAX/ABDOMENW/	{'CT', nan}	{'TCIA-acrin-nsclc-fdg-pet', 'IDC-IDC_acrin_nsclc_fdg_pet'}	{'IDC', 'TCIA'}	2
-CT TRAUMA CHEST ABDOMEN PELVIS W IV CONTRAST	{'RTSTRUCT', nan}	{'TCIA-cptac-ccrcc', 'IDC-IDC_cptac_ccrcc'}	{'IDC', 'TCIA'}	2
-CT ABDOMEN (LIVER)	{'CT', nan}	{'IDC-IDC_hcc_tace_seg', 'TCIA-hcc-tace-seg'}	{'IDC', 'TCIA'}	2
-CT TREATMENT P	{'CT', nan}	{'TCIA-acrin-nsclc-fdg-pet', 'IDC-IDC_acrin_nsclc_fdg_pet'}	{'IDC', 'TCIA'}	2
-CT TRUNK	{'CT', nan}	{'TCIA-acrin-nsclc-fdg-pet', 'IDC-IDC_acrin_nsclc_fdg_pet'}	{'IDC', 'TCIA'}	2
-CT ABDOMEN & PELVIS=AB	{'RTSTRUCT', nan}	{'TCIA-cptac-pda', 'IDC-IDC_cptac_pda'}	{'IDC', 'TCIA'}	2
-CT Thorax W/Contrast	{'CT', nan}	{'TCIA-tcga-lihc', 'IDC-IDC_tcga_lihc'}	{'IDC', 'TCIA'}	2
-CT ABDOMEN AND PELVIS W CONT	{'CT'}	{'MIDRC-Open-A1_PETAL_BLUECORAL', 'MIDRC-Open-A1_PETAL_REDCORAL'}	{'MIDRC'}	2
-CT ABDOMEN & PELVIS W&WO IV CONTRAST	{'CT', nan}	{'IDC-IDC_tcga_blca', 'TCIA-tcga-blca'}	{'IDC', 'TCIA'}	2
-CT ABDOMEN & PELVIS NONENH & ENHANCED=AB	{'RTSTRUCT', nan}	{'TCIA-cptac-pda', 'IDC-IDC_cptac_pda'}	{'IDC', 'TCIA'}	2
-CT ABDOMEN & PELVIS NONENH & ENHANCED-BODY	{'SEG', nan}	{'TCIA-tcga-lihc', 'IDC-IDC_tcga_lihc'}	{'IDC', 'TCIA'}	2
-CT Thorax with Contras	{'SEG', nan}	{'IDC-IDC_nsclc_radiogenomics', 'TCIA-nsclc-radiogenomics'}	{'IDC', 'TCIA'}	2
-CT ABDO  FILMS	{'CT', nan}	{'TCIA-tcga-ov', 'IDC-IDC_tcga_ov'}	{'IDC', 'TCIA'}	2
-CT ABD/PELVIS-W	{'SEG', nan}	{'TCIA-adrenal-acc-ki67-seg', 'IDC-IDC_adrenal_acc_ki67_seg'}	{'IDC', 'TCIA'}	2
-CT THORAX, W	{'CT', nan}	{'TCIA-acrin-nsclc-fdg-pet', 'IDC-IDC_acrin_nsclc_fdg_pet'}	{'IDC', 'TCIA'}	2
-CT ABDOMEN AND PELVIS WO/W CONTRAST	{'CT'}	{'MIDRC-Open-A1'}	{'MIDRC'}	2
-CT THORAX  WITH CONTRAST	{'RTSTRUCT', nan}	{'TCIA-cptac-ccrcc', 'IDC-IDC_cptac_ccrcc'}	{'IDC', 'TCIA'}	2
-CT THORAX W CON	{'CT', nan}	{'TCIA-acrin-nsclc-fdg-pet', 'IDC-IDC_acrin_nsclc_fdg_pet'}	{'IDC', 'TCIA'}	2
-CT ABDOMEN PELVIS W/CO	{'CT', nan}	{'IDC-IDC_tcga_blca', 'TCIA-tcga-blca'}	{'IDC', 'TCIA'}	2
-CT THORAX ENHANCE	{'CT', nan}	{'TCIA-acrin-nsclc-fdg-pet', 'IDC-IDC_acrin_nsclc_fdg_pet'}	{'IDC', 'TCIA'}	2
-CT ABDOMEN PELVIS W WO IV CONTRAST	{'RTSTRUCT', nan}	{'TCIA-cptac-ccrcc', 'IDC-IDC_cptac_ccrcc'}	{'IDC', 'TCIA'}	2
-CT THORAX UNENHAN	{'CT', nan}	{'TCIA-acrin-nsclc-fdg-pet', 'IDC-IDC_acrin_nsclc_fdg_pet'}	{'IDC', 'TCIA'}	2
-CT THORAX UNENHANCED	{'CT', nan}	{'TCIA-acrin-nsclc-fdg-pet', 'IDC-IDC_acrin_nsclc_fdg_pet'}	{'IDC', 'TCIA'}	2
-CT THORAX W	{'CT', nan}	{'TCIA-acrin-nsclc-fdg-pet', 'IDC-IDC_acrin_nsclc_fdg_pet'}	{'IDC', 'TCIA'}	2
-CT ABDOMEN PELVIS W CON	{'CT', nan}	{'TCIA-tcga-ov', 'IDC-IDC_tcga_ov'}	{'IDC', 'TCIA'}	2
-CT ABDOMEN ENHANC	{'CT', nan}	{'TCIA-acrin-nsclc-fdg-pet', 'IDC-IDC_acrin_nsclc_fdg_pet'}	{'IDC', 'TCIA'}	2
-CT ABDOMEN PELVIS W CO	{'CT'}	{'MIDRC-Open-A1', 'MIDRC-Open-R1'}	{'MIDRC'}	2
-CT THORAX W/	{'CT', nan}	{'TCIA-acrin-nsclc-fdg-pet', 'IDC-IDC_acrin_nsclc_fdg_pet'}	{'IDC', 'TCIA'}	2
-CT ABDOMEN NO IV CONTRAST	{'CT', nan}	{'TCIA-acrin-nsclc-fdg-pet', 'IDC-IDC_acrin_nsclc_fdg_pet'}	{'IDC', 'TCIA'}	2
-CT ABDOMEN IV CONTRAST	{'CT', nan}	{'TCIA-acrin-nsclc-fdg-pet', 'IDC-IDC_acrin_nsclc_fdg_pet'}	{'IDC', 'TCIA'}	2
-CT ABDOMEN EXTERNAL IMAGING	{'RTSTRUCT', nan}	{'TCIA-cptac-pda', 'IDC-IDC_cptac_pda'}	{'IDC', 'TCIA'}	2
-CT ABDOMEN ENHANCED	{'CT', nan}	{'TCIA-acrin-nsclc-fdg-pet', 'IDC-IDC_acrin_nsclc_fdg_pet'}	{'IDC', 'TCIA'}	2
-CT ABDOMEN WITH CONTRAST	{'CT', nan}	{'TCIA-tcga-ucec', 'IDC-IDC_tcga_ucec'}	{'IDC', 'TCIA'}	2
-CT NECK W/ CONTRAST	{'CT', nan}	{'TCIA-tcga-thca', 'IDC-IDC_tcga_thca'}	{'IDC', 'TCIA'}	2
-CT Chest W/CST	{'CT', nan}	{'TCIA-acrin-nsclc-fdg-pet', 'IDC-IDC_acrin_nsclc_fdg_pet'}	{'IDC', 'TCIA'}	2
-CT NECK SOFT TISSUE CO	{'CT', nan}	{'TCIA-acrin-nsclc-fdg-pet', 'IDC-IDC_acrin_nsclc_fdg_pet'}	{'IDC', 'TCIA'}	2
-CT Drain	{'CT', nan}	{'TCIA-tcga-ucec', 'IDC-IDC_tcga_ucec'}	{'IDC', 'TCIA'}	2
-CT ANGIO ABD/PELVIS W RUNOFFS	{'SEG', nan}	{'TCIA-tcga-lihc', 'IDC-IDC_tcga_lihc'}	{'IDC', 'TCIA'}	2
-CT ENTEROGRAPHY	{'CT', nan}	{'IDC-IDC_cmb_pca', 'TCIA-cmb-pca'}	{'IDC', 'TCIA'}	2
-CT ENTEROGRAPHY WITH CONTRAST	{'CT'}	{'MIDRC-Open-A1'}	{'MIDRC'}	2
-CT ANGIO AB W/WO AND CH/PEL W/	{'CT', nan}	{'TCIA-tcga-kirc', 'IDC-IDC_tcga_kirc'}	{'IDC', 'TCIA'}	2
-CT Extremity	{'CT', nan}	{'TCIA-cmb-lca', 'IDC-IDC_cmb_lca'}	{'IDC', 'TCIA'}	2
-CT Extremity (R Foot)	{'CT', nan}	{'IDC-IDC_cmb_mel', 'TCIA-cmb-mel'}	{'IDC', 'TCIA'}	2
-CT FACE/SINUSES + NECK (H AND N CANCER) W CONTRAST*	{'CT'}	{'MIDRC-Open-A1'}	{'MIDRC'}	2
-CT FNA RT + LT LUNG	{'SEG', nan}	{'TCIA-tcga-lusc', 'IDC-IDC_tcga_lusc'}	{'IDC', 'TCIA'}	2
-CT FOREIGN IMAGES	{'CT', nan}	{'TCIA-cptac-ccrcc', 'IDC-IDC_cptac_ccrcc'}	{'IDC', 'TCIA'}	2
-CT ABDOMEN/PELVIS WITHOUT CONTRAST (PETCT)	{'CT'}	{'MIDRC-Open-R1'}	{'MIDRC'}	2
-CT GUIDED BIOPSY:  LUNG	{'CT', nan}	{'TCIA-cptac-luad', 'IDC-IDC_cptac_luad'}	{'IDC', 'TCIA'}	2
-CT GUIDED BIOPSY:PANCREAS	{'RTSTRUCT', nan}	{'TCIA-cptac-pda', 'IDC-IDC_cptac_pda'}	{'IDC', 'TCIA'}	2
-CT GUIDED NEEDLE INJ,B	{'CT', nan}	{'TCIA-acrin-nsclc-fdg-pet', 'IDC-IDC_acrin_nsclc_fdg_pet'}	{'IDC', 'TCIA'}	2
-CT GUIDED NEEDLE PLACEMENT	{'CT', nan}	{'TCIA-tcga-lihc', 'IDC-IDC_tcga_lihc'}	{'IDC', 'TCIA'}	2
-CT D.E. 3 PHASE, & CH	{'CT', nan}	{'IDC-IDC_rider_lung_pet_ct', 'TCIA-rider-lung-pet-ct'}	{'IDC', 'TCIA'}	2
-CT Colonography Screen	{'CT'}	{'IDC-IDC_ct_colonography'}	{'IDC'}	2
-CT ChestAbd	{'CT', nan}	{'TCIA-cmb-lca', 'IDC-IDC_cmb_lca'}	{'IDC', 'TCIA'}	2
-CT ANGIO KIDNEY ONLY	{'CT', nan}	{'TCIA-tcga-kirc', 'IDC-IDC_tcga_kirc'}	{'IDC', 'TCIA'}	2
-CT ANGIOGRAM CHEST FOR PULMONARY HYPE	{'CT'}	{'MIDRC-Open-R1'}	{'MIDRC'}	2
-CT ANGIO THORAX	{'CT', nan}	{'IDC-IDC_nsclc_radiogenomics', 'TCIA-nsclc-radiogenomics'}	{'IDC', 'TCIA'}	2
-CT ANGIO LIVER WITH CH	{'SEG', nan}	{'TCIA-colorectal-liver-metastases', 'IDC-IDC_colorectal_liver_metastases'}	{'IDC', 'TCIA'}	2
-CT Chest w/ Contrast	{'SEG', nan}	{'TCIA-cptac-ccrcc', 'IDC-IDC_cptac_ccrcc'}	{'IDC', 'TCIA'}	2
-CT Chest w/ contrast	{'CT', nan}	{'TCIA-tcga-ucec', 'IDC-IDC_tcga_ucec'}	{'IDC', 'TCIA'}	2
-CT Chest w/o	{'CT', nan}	{'TCIA-acrin-nsclc-fdg-pet', 'IDC-IDC_acrin_nsclc_fdg_pet'}	{'IDC', 'TCIA'}	2
-CT Chest withBH	{'CT', nan}	{'TCIA-tcga-ov', 'IDC-IDC_tcga_ov'}	{'IDC', 'TCIA'}	2
-CT Chest/Neck	{'CT', nan}	{'IDC-IDC_cmb_mel', 'TCIA-cmb-mel'}	{'IDC', 'TCIA'}	2
-CT Chest without Contrast - Routine	{'CT'}	{'MIDRC-Open-A1_PETAL_REDCORAL'}	{'MIDRC'}	2
-CT ANGIO CHEST/ABDOMEN/PELVIS-BODY	{'CT', nan}	{'TCIA-tcga-lihc', 'IDC-IDC_tcga_lihc'}	{'IDC', 'TCIA'}	2
-CT ANGIO CHEST WITH AND WITHOUT CONTRAST	{'CT'}	{'MIDRC-Open-A1_PETAL_BLUECORAL', 'MIDRC-Open-A1_PETAL_REDCORAL'}	{'MIDRC'}	2
-CT Chest-w/wo Contrast	{'CT', nan}	{'TCIA-acrin-nsclc-fdg-pet', 'IDC-IDC_acrin_nsclc_fdg_pet'}	{'IDC', 'TCIA'}	2
-CT Chest/Abdomen W/ Co	{'CT', nan}	{'TCIA-acrin-nsclc-fdg-pet', 'IDC-IDC_acrin_nsclc_fdg_pet'}	{'IDC', 'TCIA'}	2
-CT ANGIO BRAIN/NECK FOR STROKE (INC 3D POST-PROCESSING AND PERF)	{'CT'}	{'MIDRC-Open-R1'}	{'MIDRC'}	2
-CT HEAD (BRAIN LAB) WO CONTRAST POST OP	{'CT'}	{'MIDRC-Open-A1'}	{'MIDRC'}	2
-CT ABDOMEN/PELVIS WITH AND WITHOUT CONTRAST (S)	{'CT'}	{'MIDRC-Open-R1'}	{'MIDRC'}	2
-CT HEAD W CON	{'CT', nan}	{'TCIA-acrin-nsclc-fdg-pet', 'IDC-IDC_acrin_nsclc_fdg_pet'}	{'IDC', 'TCIA'}	2
-CT LOWER EXTREMITY WITH CONTRAST RIGHT	{'CT', nan}	{'IDC-IDC_cptac_sar', 'TCIA-cptac-sar'}	{'IDC', 'TCIA'}	2
-CT LIMITED OR LOCALIZE	{'SEG', nan}	{'TCIA-tcga-luad', 'IDC-IDC_tcga_luad'}	{'IDC', 'TCIA'}	2
-CT LIMITED OR LOCALIZED F/U	{'CT', nan}	{'TCIA-tcga-lusc', 'IDC-IDC_tcga_lusc'}	{'IDC', 'TCIA'}	2
-CT LIVER CAP	{'SEG', nan}	{'IDC-IDC_hcc_tace_seg', 'TCIA-hcc-tace-seg'}	{'IDC', 'TCIA'}	2
-CT LOCALIZATION WITH BIOPSY	{'CT', nan}	{'TCIA-tcga-lihc', 'IDC-IDC_tcga_lihc'}	{'IDC', 'TCIA'}	2
-CT LOW-DOSE LUNG CANCER SCREEN	{'CT'}	{'MIDRC-Open-R1'}	{'MIDRC'}	2
-CT LOWER EXTREMITY WITH CONTRAST LEFT	{'CT', nan}	{'IDC-IDC_cptac_sar', 'TCIA-cptac-sar'}	{'IDC', 'TCIA'}	2
-CT LT LOWER EXTREMITY WITH IV CONTRAST	{'CT'}	{'MIDRC-Open-A1'}	{'MIDRC'}	2
-CT LEVEL 1-2 SPINE THORACIC LUMBAR REFORMATS W ED TRAUMA	{'CT'}	{'MIDRC-Open-A1'}	{'MIDRC'}	2
-CT LUMBAR SPINE NERVE BLOCK MULTI LEVEL	{'CT'}	{'MIDRC-Open-R1'}	{'MIDRC'}	2
-CT LUMBAR SPINE WO IV CONTRAST	{'CT'}	{'MIDRC-Open-A1'}	{'MIDRC'}	2
-CT ABDOMEN WO+W CONTRAST	{'RTSTRUCT', nan}	{'TCIA-cptac-pda', 'IDC-IDC_cptac_pda'}	{'IDC', 'TCIA'}	2
-CT ABDOMEN WO CONTR	{'CT', nan}	{'TCIA-tcga-kirc', 'IDC-IDC_tcga_kirc'}	{'IDC', 'TCIA'}	2
-CT MAXILLOFACIAL WITHOUT CONTRAST	{'CT'}	{'MIDRC-Open-R1'}	{'MIDRC'}	2
-CT NECK ,THORAX	{'CT', nan}	{'TCIA-acrin-nsclc-fdg-pet', 'IDC-IDC_acrin_nsclc_fdg_pet'}	{'IDC', 'TCIA'}	2
-CT ABDOMEN WWO CONTRAST (ADRENALS)	{'CT'}	{'MIDRC-Open-A1'}	{'MIDRC'}	2
-CT LEVEL 1-2 HEAD WO ED TRAUMA	{'CT'}	{'MIDRC-Open-A1'}	{'MIDRC'}	2
-CT ABDOMEN/PELVIS WITH AND WITHOUT CONTRAST	{'CT'}	{'MIDRC-Open-R1'}	{'MIDRC'}	2
-CT HEART W CONTRAST- LEFT ATRIUM AND PULMONARY VEINS	{'CT'}	{'MIDRC-Open-A1'}	{'MIDRC'}	2
-CT ABDOMEN/PELVIS WC	{'CT', nan}	{'TCIA-tcga-ucec', 'IDC-IDC_tcga_ucec'}	{'IDC', 'TCIA'}	2
-CT HEAD WITH I	{'CT', nan}	{'TCIA-acrin-nsclc-fdg-pet', 'IDC-IDC_acrin_nsclc_fdg_pet'}	{'IDC', 'TCIA'}	2
-CT ABDOMEN/PELVIS W IV AND ORAL CONTRAST	{'RTSTRUCT', nan}	{'IDC-IDC_cptac_ucec', 'TCIA-cptac-ucec'}	{'IDC', 'TCIA'}	2
-CT ABDOMEN/PELVIS	{'CT', nan}	{'TCIA-tcga-ov', 'IDC-IDC_tcga_ov'}	{'IDC', 'TCIA'}	2
-CT ABDOMEN-PELVIS WITH CONTRAST	{'CT', nan}	{'TCIA-adrenal-acc-ki67-seg', 'IDC-IDC_adrenal_acc_ki67_seg'}	{'IDC', 'TCIA'}	2
-CT HEART W CONTRAST 3D CONGENITAL HEART DISEASE	{'CT'}	{'MIDRC-Open-R1'}	{'MIDRC'}	2
-CT ABDOMEN, W	{'CT', nan}	{'TCIA-acrin-nsclc-fdg-pet', 'IDC-IDC_acrin_nsclc_fdg_pet'}	{'IDC', 'TCIA'}	2
-CT LEVEL 1-2 CERVICAL SPINE WO ED TRAUMA	{'CT'}	{'MIDRC-Open-A1'}	{'MIDRC'}	2
-CT ABDOMEN+PELVIS WO+W CONTRAST	{'RTSTRUCT', nan}	{'TCIA-cptac-ccrcc', 'IDC-IDC_cptac_ccrcc'}	{'IDC', 'TCIA'}	2
-CT Head	{'CT', nan}	{'IDC-IDC_cmb_mel', 'TCIA-cmb-mel'}	{'IDC', 'TCIA'}	2
-CT ABDOMEN+PELVIS W CONTRAST	{'RTSTRUCT', nan}	{'TCIA-cptac-ccrcc', 'IDC-IDC_cptac_ccrcc'}	{'IDC', 'TCIA'}	2
-CT ABDOMEN wo Lmtd	{'CT', nan}	{'TCIA-tcga-ucec', 'IDC-IDC_tcga_ucec'}	{'IDC', 'TCIA'}	2
-CT L-SPINE W/O IV CONTRAST	{'CT'}	{'MIDRC-Open-A1'}	{'MIDRC'}	2
-CT LEFT FEMUR WITH	{'CT', nan}	{'IDC-IDC_cptac_sar', 'TCIA-cptac-sar'}	{'IDC', 'TCIA'}	2
-JHN CHEST PE OP	{'CT'}	{'MIDRC-Open-R1'}	{'MIDRC'}	2
-FDG5AFOV TORSO	{'SEG', nan}	{'IDC-IDC_rider_lung_pet_ct', 'TCIA-rider-lung-pet-ct'}	{'IDC', 'TCIA'}	2
-MR BREAST BIL W AND WO GAD	{'MR'}	{'ACRdart-EA1141Restricted', 'IDC-IDC_ea1141'}	{'ACRdart', 'IDC'}	2
-LT.  BREAST	{'MR', nan}	{'IDC-IDC_acrin_contralateral_breast_mr', 'TCIA-acrin-contralateral-breast-mr'}	{'IDC', 'TCIA'}	2
-LUNF	{'SEG', nan}	{'TCIA-acrin-nsclc-fdg-pet', 'IDC-IDC_acrin_nsclc_fdg_pet'}	{'IDC', 'TCIA'}	2
-MR PEDIATRIC RAPID BRAIN WITHOUT CONTRAST	{'MR'}	{'MIDRC-Open-R1'}	{'MIDRC'}	2
-MG Tomo Mammo Digital Screening Bilat	{'MG'}	{'ACRdart-EA1141Restricted', 'IDC-IDC_ea1141'}	{'ACRdart', 'IDC'}	2
-B CT NON-INFUSED CHEST	{'SEG', nan}	{'IDC-IDC_spie_aapm_lung_ct_challenge', 'TCIA-spie-aapm-lung-ct-challenge'}	{'IDC', 'TCIA'}	2
-CAP/LIVER	{'CT', nan}	{'IDC-IDC_hcc_tace_seg', 'TCIA-hcc-tace-seg'}	{'IDC', 'TCIA'}	2
-B  MRI THIGH C- LEFT	{'MR', nan}	{'IDC-IDC_soft_tissue_sarcoma', 'TCIA-soft-tissue-sarcoma'}	{'IDC', 'TCIA'}	2
-LT. BREAST	{'MR', nan}	{'IDC-IDC_acrin_contralateral_breast_mr', 'TCIA-acrin-contralateral-breast-mr'}	{'IDC', 'TCIA'}	2
-All Other Initial Soli	{'SEG', nan}	{'IDC-IDC_nsclc_radiogenomics', 'TCIA-nsclc-radiogenomics'}	{'IDC', 'TCIA'}	2
-BREST/PRONE	{'SEG', nan}	{'IDC-IDC_qin_breast', 'TCIA-qin-breast'}	{'IDC', 'TCIA'}	2
-AgilityN Treatme:Tx Plan	{'CT', nan}	{'IDC-IDC_pelvic_reference_data', 'TCIA-pelvic-reference-data'}	{'IDC', 'TCIA'}	2
-MR PELVIS WITH CONTRAST	{'RTSTRUCT', nan}	{'IDC-IDC_cptac_ucec', 'TCIA-cptac-ucec'}	{'IDC', 'TCIA'}	2
-MR PELVIS WITH INTRACAVITY COIL WITHOUT CONTRAST	{'MR', nan}	{'IDC-IDC_tcga_prad', 'TCIA-tcga-prad'}	{'IDC', 'TCIA'}	2
-BREAST^lesion evaluation	{'SEG', nan}	{'TCIA-duke-breast-cancer-mri', 'IDC-IDC_duke_breast_cancer_mri'}	{'IDC', 'TCIA'}	2
-Abdomen^UROGRAM (Adult)	{'CT', nan}	{'IDC-IDC_tcga_blca', 'TCIA-tcga-blca'}	{'IDC', 'TCIA'}	2
-MR Prostate	{'MR', nan}	{'IDC-IDC_prostate_mri', 'TCIA-prostate-mri'}	{'IDC', 'TCIA'}	2
-LT LUNG	{'CT'}	{'IDC-IDC_lctsc'}	{'IDC'}	2
-LUNG BX	{'CT', nan}	{'TCIA-tcga-luad', 'IDC-IDC_tcga_luad'}	{'IDC', 'TCIA'}	2
-MG Screen Bilat w/Tomo/CAD Stnd Protocol	{'MG'}	{'ACRdart-EA1141Restricted'}	{'ACRdart'}	2
-MR jamy brzusznej	{'RTSTRUCT', nan}	{'TCIA-cptac-pda', 'IDC-IDC_cptac_pda'}	{'IDC', 'TCIA'}	2
-MR BREAST WO/W CONT #6657	{'MR', 'SEG'}	{'IDC-IDC_ispy1'}	{'IDC'}	2
-LUNG RESTG	{'SEG', nan}	{'TCIA-acrin-nsclc-fdg-pet', 'IDC-IDC_acrin_nsclc_fdg_pet'}	{'IDC', 'TCIA'}	2
-MBUI	{'MR'}	{'IDC-IDC_ispy1'}	{'IDC'}	2
-LUNG RESTAG	{'SEG', nan}	{'TCIA-acrin-nsclc-fdg-pet', 'IDC-IDC_acrin_nsclc_fdg_pet'}	{'IDC', 'TCIA'}	2
-BRST UNI RT SCREENING MAMMO W/ TOMO	{'MG'}	{'ACRdart-EA1141Restricted'}	{'ACRdart'}	2
-MR LT BREAST 6667	{'MR', nan}	{'IDC-IDC_acrin_contralateral_breast_mr', 'TCIA-acrin-contralateral-breast-mr'}	{'IDC', 'TCIA'}	2
-B MRI-LT THIGH	{'RTSTRUCT', nan}	{'IDC-IDC_soft_tissue_sarcoma', 'TCIA-soft-tissue-sarcoma'}	{'IDC', 'TCIA'}	2
-CAP W/CON	{'SEG', nan}	{'TCIA-lidc-idri', 'IDC-IDC_lidc_idri'}	{'IDC', 'TCIA'}	2
-B MRI-LT KNEE	{'RTSTRUCT', nan}	{'IDC-IDC_soft_tissue_sarcoma', 'TCIA-soft-tissue-sarcoma'}	{'IDC', 'TCIA'}	2
-B KNEE RT	{'MR', nan}	{'IDC-IDC_soft_tissue_sarcoma', 'TCIA-soft-tissue-sarcoma'}	{'IDC', 'TCIA'}	2
-MR LT BREAST WO/W CONT/6667	{'MR', nan}	{'IDC-IDC_acrin_contralateral_breast_mr', 'TCIA-acrin-contralateral-breast-mr'}	{'IDC', 'TCIA'}	2
-MR LUMBAR SPINE WITH AND WITHOUT CONTRAST	{'MR'}	{'MIDRC-Open-R1'}	{'MIDRC'}	2
-CAP W/WO CON	{'CT', nan}	{'TCIA-tcga-ucec', 'IDC-IDC_tcga_ucec'}	{'IDC', 'TCIA'}	2
-B MRI THIGH C+- LEFT	{'MR', nan}	{'IDC-IDC_soft_tissue_sarcoma', 'TCIA-soft-tissue-sarcoma'}	{'IDC', 'TCIA'}	2
-CAP WITH CONTRAST	{'SEG', nan}	{'IDC-IDC_anti_pd_1_lung', 'TCIA-anti-pd-1_lung'}	{'IDC', 'TCIA'}	2
-MR LUMBAR SPINE WITHOUT CONTRAST (S)	{'MR'}	{'MIDRC-Open-R1'}	{'MIDRC'}	2
-LUNG CA  ACRIN	{'PT', nan}	{'TCIA-acrin-nsclc-fdg-pet', 'IDC-IDC_acrin_nsclc_fdg_pet'}	{'IDC', 'TCIA'}	2
-LT FLANK PAIN	{'CT', nan}	{'TCIA-tcga-ucec', 'IDC-IDC_tcga_ucec'}	{'IDC', 'TCIA'}	2
-LT BRST STUDY	{'MR', nan}	{'IDC-IDC_acrin_contralateral_breast_mr', 'TCIA-acrin-contralateral-breast-mr'}	{'IDC', 'TCIA'}	2
-MG-POST PROCEDURE MAMMO	{'MG'}	{'ACRdart-EA1141Restricted', 'IDC-IDC_ea1141'}	{'ACRdart', 'IDC'}	2
-Abdomen^STONES (Adult)	{'CT', nan}	{'TCIA-tcga-kirc', 'IDC-IDC_tcga_kirc'}	{'IDC', 'TCIA'}	2
-LEFT   BREAST	{'MR', nan}	{'IDC-IDC_acrin_contralateral_breast_mr', 'TCIA-acrin-contralateral-breast-mr'}	{'IDC', 'TCIA'}	2
-BREAST^CE BREAST	{'MR', nan}	{'IDC-IDC_acrin_contralateral_breast_mr', 'TCIA-acrin-contralateral-breast-mr'}	{'IDC', 'TCIA'}	2
-MR - JB I PRZ. Z	{'RTSTRUCT', nan}	{'TCIA-cptac-pda', 'IDC-IDC_cptac_pda'}	{'IDC', 'TCIA'}	2
-L5	{'CT', nan}	{'TCIA-spine-mets-ct-seg', 'IDC-IDC_spine_mets_ct_seg'}	{'IDC', 'TCIA'}	2
-L4	{'CT', nan}	{'TCIA-spine-mets-ct-seg', 'IDC-IDC_spine_mets_ct_seg'}	{'IDC', 'TCIA'}	2
-L2	{'SEG', nan}	{'TCIA-spine-mets-ct-seg', 'IDC-IDC_spine_mets_ct_seg'}	{'IDC', 'TCIA'}	2
-L1	{'CT', nan}	{'TCIA-spine-mets-ct-seg', 'IDC-IDC_spine_mets_ct_seg'}	{'IDC', 'TCIA'}	2
-MR 6667 BREAST W/WO CONTRAST	{'MR', nan}	{'IDC-IDC_acrin_contralateral_breast_mr', 'TCIA-acrin-contralateral-breast-mr'}	{'IDC', 'TCIA'}	2
-LSSPINE	{'SEG', nan}	{'TCIA-spine-mets-ct-seg', 'IDC-IDC_spine_mets_ct_seg'}	{'IDC', 'TCIA'}	2
-L-SPINE^ROUTINE	{'MR'}	{'MIDRC-Open-A1'}	{'MIDRC'}	2
-BREAST^BIOPSY BREAST	{'MR', nan}	{'IDC-IDC_acrin_contralateral_breast_mr', 'TCIA-acrin-contralateral-breast-mr'}	{'IDC', 'TCIA'}	2
-MR SHOULDER RIGHT WO CONTRAST	{'MR'}	{'MIDRC-Open-A1'}	{'MIDRC'}	2
-MR AB ANGIO	{'MR', nan}	{'TCIA-tcga-kirc', 'IDC-IDC_tcga_kirc'}	{'IDC', 'TCIA'}	2
-CARDIAC TRIPLE RULE OUT OP	{'CT'}	{'MIDRC-Open-R1'}	{'MIDRC'}	2
-KT miednicy mniejszej - bad z kontrastem	{'RTSTRUCT', nan}	{'TCIA-cptac-ccrcc', 'IDC-IDC_cptac_ccrcc'}	{'IDC', 'TCIA'}	2
-MR TOTAL SPINE WITHOUT CONTRAST	{'MR'}	{'MIDRC-Open-R1'}	{'MIDRC'}	2
-MM US LT BREAST	{'US'}	{'ACRdart-ACRIN_6666'}	{'ACRdart'}	2
-MR RT BREAST WO/W CONT/6667	{'MR', nan}	{'IDC-IDC_acrin_contralateral_breast_mr', 'TCIA-acrin-contralateral-breast-mr'}	{'IDC', 'TCIA'}	2
-BREAST^RESEARCH	{'MR'}	{'ACRdart-EA1141Restricted'}	{'ACRdart'}	2
-MR RT BREAST WO/W CONT 6667	{'MR', nan}	{'IDC-IDC_acrin_contralateral_breast_mr', 'TCIA-acrin-contralateral-breast-mr'}	{'IDC', 'TCIA'}	2
-LIVER/PELVIS	{'SEG', nan}	{'IDC-IDC_hcc_tace_seg', 'TCIA-hcc-tace-seg'}	{'IDC', 'TCIA'}	2
-LIVER/C AP	{'SEG', nan}	{'IDC-IDC_hcc_tace_seg', 'TCIA-hcc-tace-seg'}	{'IDC', 'TCIA'}	2
-LIVER/C A P	{'SEG', nan}	{'IDC-IDC_hcc_tace_seg', 'TCIA-hcc-tace-seg'}	{'IDC', 'TCIA'}	2
-LIVER/C A  P	{'SEG', nan}	{'IDC-IDC_hcc_tace_seg', 'TCIA-hcc-tace-seg'}	{'IDC', 'TCIA'}	2
-LIVER//CHEST	{'SEG', nan}	{'IDC-IDC_hcc_tace_seg', 'TCIA-hcc-tace-seg'}	{'IDC', 'TCIA'}	2
-MR RECTUM (SCH)	{'SEG', nan}	{'IDC-IDC_qin_prostate_repeatability', 'TCIA-qin-prostate-repeatability'}	{'IDC', 'TCIA'}	2
-LIVER// C A P	{'SEG', nan}	{'IDC-IDC_hcc_tace_seg', 'TCIA-hcc-tace-seg'}	{'IDC', 'TCIA'}	2
-MR RENAL PROTOCOL W/O CONTRAST	{'MR', nan}	{'TCIA-tcga-kirc', 'IDC-IDC_tcga_kirc'}	{'IDC', 'TCIA'}	2
-MR RT BREAST BOLD	{'MR', nan}	{'IDC-IDC_acrin_contralateral_breast_mr', 'TCIA-acrin-contralateral-breast-mr'}	{'IDC', 'TCIA'}	2
-LIMITED EOVIST MRI HCC	{'MR'}	{'MIDRC-Open-A1'}	{'MIDRC'}	2
-MM Mammogram Diagnostic DDI Bilat	{'MG'}	{'ACRdart-EA1141Restricted', 'IDC-IDC_ea1141'}	{'ACRdart', 'IDC'}	2
-MR RT BREAST WO/W CONT	{'MR', nan}	{'IDC-IDC_acrin_contralateral_breast_mr', 'TCIA-acrin-contralateral-breast-mr'}	{'IDC', 'TCIA'}	2
-LEFT MAMMO DIGITAL DIAGNOSTIC	{'MG'}	{'ACRdart-EA1141Restricted', 'IDC-IDC_ea1141'}	{'ACRdart', 'IDC'}	2
-LEFT LUNG	{'RTSTRUCT', 'CT'}	{'IDC-IDC_lctsc'}	{'IDC'}	2
-LEFT KNEE/FEMUR	{'MR', nan}	{'IDC-IDC_soft_tissue_sarcoma', 'TCIA-soft-tissue-sarcoma'}	{'IDC', 'TCIA'}	2
-LUNG SCAN QUANT PERFUSION	{'NM', nan}	{'TCIA-tcga-luad', 'IDC-IDC_tcga_luad'}	{'IDC', 'TCIA'}	2
-BRZUCH TRZUSTKA	{'RTSTRUCT', nan}	{'TCIA-cptac-pda', 'IDC-IDC_cptac_pda'}	{'IDC', 'TCIA'}	2
-MR LOWER EXTREMITY ANY JOINT WITH AND WITHOUT CONTRAST RIGHT	{'MR', nan}	{'IDC-IDC_cptac_sar', 'TCIA-cptac-sar'}	{'IDC', 'TCIA'}	2
-BILAT BREAT	{'MR', nan}	{'IDC-IDC_acrin_contralateral_breast_mr', 'TCIA-acrin-contralateral-breast-mr'}	{'IDC', 'TCIA'}	2
-MAMMO TOMOGRAM DIAGNOSTIC  RIGHT	{'MG'}	{'ACRdart-EA1141Restricted'}	{'ACRdart'}	2
-BILAT BRST	{'MR', nan}	{'IDC-IDC_acrin_contralateral_breast_mr', 'TCIA-acrin-contralateral-breast-mr'}	{'IDC', 'TCIA'}	2
-MAMMO DIAGNOSTIC BREAST TOMOSYNTHESIS LEFT	{'MG', nan}	{'TCIA-breast-cancer-screening-dbt', 'IDC-IDC_breast_cancer_screening_dbt'}	{'IDC', 'TCIA'}	2
-MAMMO TOMOGRAPHY DIAGNOSTIC  RIGHT	{'MG'}	{'ACRdart-EA1141Restricted', 'IDC-IDC_ea1141'}	{'ACRdart', 'IDC'}	2
-MR Breast Bilat Implant WWO Contrast	{'MR'}	{'ACRdart-EA1141Restricted'}	{'ACRdart'}	2
-MR CholangoPancreagram with without Contrast	{'RTSTRUCT', nan}	{'TCIA-cptac-ccrcc', 'IDC-IDC_cptac_ccrcc'}	{'IDC', 'TCIA'}	2
-MAMMO US GUIDED BREAST BX LT	{'MG'}	{'ACRdart-EA1141Restricted', 'IDC-IDC_ea1141'}	{'ACRdart', 'IDC'}	2
-MAMMO US GUIDED BREAST BX RT	{'MG'}	{'ACRdart-EA1141Restricted', 'IDC-IDC_ea1141'}	{'ACRdart', 'IDC'}	2
-MAMMAE	{'MR', nan}	{'IDC-IDC_acrin_contralateral_breast_mr', 'TCIA-acrin-contralateral-breast-mr'}	{'IDC', 'TCIA'}	2
-CALCIUM SCORING HI HR(Adult)	{'CT'}	{'MIDRC-Open-A1'}	{'MIDRC'}	2
-Breast Ultrasound	{'US'}	{'ACRdart-ACRIN_6666'}	{'ACRdart'}	2
-Breast Bil tumor ax	{'MR', nan}	{'IDC-IDC_tcga_brca', 'TCIA-tcga-brca'}	{'IDC', 'TCIA'}	2
-MAMMO diagnostic digital left	{'MG', nan}	{'TCIA-breast-cancer-screening-dbt', 'IDC-IDC_breast_cancer_screening_dbt'}	{'IDC', 'TCIA'}	2
-Brain Tumor	{'MR', nan}	{'IDC-IDC_upenn_gbm', 'TCIA-upenn-gbm'}	{'IDC', 'TCIA'}	2
-Biopsy_Lung	{'DX', nan}	{'TCIA-cmb-crc', 'IDC-IDC_cmb_crc'}	{'IDC', 'TCIA'}	2
-CAMRIS^PELVIS RESEARCH	{'MR'}	{'ACRdart-ACRIN_6701'}	{'ACRdart'}	2
-MR CERVICAL SPINE WITHOUT CONTRAST (S)	{'MR'}	{'MIDRC-Open-R1'}	{'MIDRC'}	2
-C/A/P W/WO  RENAL	{'SEG', nan}	{'TCIA-tcga-kirc', 'IDC-IDC_tcga_kirc'}	{'IDC', 'TCIA'}	2
-C/A/P POST	{'SEG', nan}	{'TCIA-lidc-idri', 'IDC-IDC_lidc_idri'}	{'IDC', 'TCIA'}	2
-BILAT/ATTN LEFT BREAST	{'MR', nan}	{'IDC-IDC_acrin_contralateral_breast_mr', 'TCIA-acrin-contralateral-breast-mr'}	{'IDC', 'TCIA'}	2
-C.3D	{'CT', nan}	{'IDC-IDC_lung_pet_ct_dx', 'TCIA-lung-pet-ct-dx'}	{'IDC', 'TCIA'}	2
-C/A/P	{'SEG', nan}	{'TCIA-tcga-kirc', 'IDC-IDC_tcga_kirc'}	{'IDC', 'TCIA'}	2
-C-SP Chest	{'CT', nan}	{'IDC-IDC_lung_pet_ct_dx', 'TCIA-lung-pet-ct-dx'}	{'IDC', 'TCIA'}	2
-MAMMO SCREENING BILATERAL	{'MG'}	{'ACRdart-EA1141Restricted', 'IDC-IDC_ea1141'}	{'ACRdart', 'IDC'}	2
-BLADDER EMPTY	{'CT', nan}	{'IDC-IDC_pelvic_reference_data', 'TCIA-pelvic-reference-data'}	{'IDC', 'TCIA'}	2
-C/A/P LIVER PROTOCOL	{'SEG', nan}	{'IDC-IDC_hcc_tace_seg', 'TCIA-hcc-tace-seg'}	{'IDC', 'TCIA'}	2
-C-J	{'CT', nan}	{'IDC-IDC_lung_pet_ct_dx', 'TCIA-lung-pet-ct-dx'}	{'IDC', 'TCIA'}	2
-BILATERAL BREAST	{'MR', nan}	{'IDC-IDC_acrin_contralateral_breast_mr', 'TCIA-acrin-contralateral-breast-mr'}	{'IDC', 'TCIA'}	2
-C-A-P/ LIVER PROTOCOL	{'SEG', nan}	{'IDC-IDC_hcc_tace_seg', 'TCIA-hcc-tace-seg'}	{'IDC', 'TCIA'}	2
-C-A-P NO IV CONTRAST	{'CT', nan}	{'IDC-IDC_tcga_blca', 'TCIA-tcga-blca'}	{'IDC', 'TCIA'}	2
-C-A-P	{'SEG', nan}	{'TCIA-lidc-idri', 'IDC-IDC_lidc_idri'}	{'IDC', 'TCIA'}	2
-C SPINE AND T SPINE	{'SEG', nan}	{'TCIA-spine-mets-ct-seg', 'IDC-IDC_spine_mets_ct_seg'}	{'IDC', 'TCIA'}	2
-BLADDER FULL	{'CT', nan}	{'IDC-IDC_pelvic_reference_data', 'TCIA-pelvic-reference-data'}	{'IDC', 'TCIA'}	2
-MAMMO DIAGNOSTIC W OR WO CAD RT	{'MG'}	{'ACRdart-EA1141Restricted', 'IDC-IDC_ea1141'}	{'ACRdart', 'IDC'}	2
-MAMMO DIAGNOSTIC DIGITAL RIGHT	{'MG', nan}	{'TCIA-breast-cancer-screening-dbt', 'IDC-IDC_breast_cancer_screening_dbt'}	{'IDC', 'TCIA'}	2
-MAMMO - SELF REFERRAL SCREENING TOMO	{'MG'}	{'ACRdart-EA1141Restricted', 'IDC-IDC_ea1141'}	{'ACRdart', 'IDC'}	2
-CAP -LIVER	{'SEG', nan}	{'IDC-IDC_hcc_tace_seg', 'TCIA-hcc-tace-seg'}	{'IDC', 'TCIA'}	2
-LUNGCTA	{'CT', nan}	{'IDC-IDC_lung_pet_ct_dx', 'TCIA-lung-pet-ct-dx'}	{'IDC', 'TCIA'}	2
-MR LEFT BREAST WO/W CONT 6667	{'MR', nan}	{'IDC-IDC_acrin_contralateral_breast_mr', 'TCIA-acrin-contralateral-breast-mr'}	{'IDC', 'TCIA'}	2
-MR JAMY BRZUSZNEJ Z KONTRASTEM	{'RTSTRUCT', nan}	{'TCIA-cptac-pda', 'IDC-IDC_cptac_pda'}	{'IDC', 'TCIA'}	2
-CAP LYM PRE/POST	{'SEG', nan}	{'TCIA-lidc-idri', 'IDC-IDC_lidc_idri'}	{'IDC', 'TCIA'}	2
-MR JB	{'RTSTRUCT', nan}	{'TCIA-cptac-ccrcc', 'IDC-IDC_cptac_ccrcc'}	{'IDC', 'TCIA'}	2
-MR KNEE LEFT WO CONTRAST	{'MR'}	{'MIDRC-Open-A1'}	{'MIDRC'}	2
-MA BREAST NEDDLE LOCALIZATION	{'MG', nan}	{'TCIA-breast-diagnosis', 'IDC-IDC_breast_diagnosis'}	{'IDC', 'TCIA'}	2
-Lung Ventilation Scan	{'NM', nan}	{'TCIA-acrin-nsclc-fdg-pet', 'IDC-IDC_acrin_nsclc_fdg_pet'}	{'IDC', 'TCIA'}	2
-CAP OP	{'CT'}	{'MIDRC-Open-R1'}	{'MIDRC'}	2
-CAP RENAL PRT W/WO	{'SEG', nan}	{'TCIA-tcga-kirc', 'IDC-IDC_tcga_kirc'}	{'IDC', 'TCIA'}	2
-BODY/ BREAST STUDY	{'SEG'}	{'IDC-IDC_ispy1'}	{'IDC'}	2
-Lung Ca	{'SEG', nan}	{'TCIA-acrin-nsclc-fdg-pet', 'IDC-IDC_acrin_nsclc_fdg_pet'}	{'IDC', 'TCIA'}	2
-BWH CT ABDOMEN PELVIS OUTSIDE STUDY OICTAP	{'CT', nan}	{'TCIA-tcga-coad', 'IDC-IDC_tcga_coad'}	{'IDC', 'TCIA'}	2
-MR BREAST WO/W CONT 6667	{'MR', nan}	{'IDC-IDC_acrin_contralateral_breast_mr', 'TCIA-acrin-contralateral-breast-mr'}	{'IDC', 'TCIA'}	2
-Lung CA	{'SEG', nan}	{'TCIA-acrin-nsclc-fdg-pet', 'IDC-IDC_acrin_nsclc_fdg_pet'}	{'IDC', 'TCIA'}	2
-MR BREAST WO/W CONT (6667 - LT BREAST)	{'MR', nan}	{'IDC-IDC_acrin_contralateral_breast_mr', 'TCIA-acrin-contralateral-breast-mr'}	{'IDC', 'TCIA'}	2
-Liver CT Enhanced	{'CT', nan}	{'IDC-IDC_stageii_colorectal_ct', 'TCIA-stageii-colorectal-ct'}	{'IDC', 'TCIA'}	2
-MR BREAST WO/W CONT #6667	{'MR', nan}	{'IDC-IDC_acrin_contralateral_breast_mr', 'TCIA-acrin-contralateral-breast-mr'}	{'IDC', 'TCIA'}	2
-CAP LIVER W/WO	{'SEG', nan}	{'IDC-IDC_hcc_tace_seg', 'TCIA-hcc-tace-seg'}	{'IDC', 'TCIA'}	2
-MR HEART WITHOUT CONTRAST	{'MR'}	{'MIDRC-Open-R1'}	{'MIDRC'}	2
-MR HEART WITH AND WITHOUT CONTRAST	{'MR'}	{'MIDRC-Open-R1'}	{'MIDRC'}	2
-MR HEART HCM WITH AND WITHOUT CONTRAST	{'MR'}	{'MIDRC-Open-R1'}	{'MIDRC'}	2
-MAMMOGRAM RAD SCREENING TO DIAGNOSTIC UNILATERAL CONVERSION	{'MG'}	{'ACRdart-EA1141Restricted'}	{'ACRdart'}	2
-Bilateral Screening Mammogram CAD+TOMO	{'MG'}	{'ACRdart-EA1141Restricted'}	{'ACRdart'}	2
-Bilateral Diagnostic With Tomo	{'MG'}	{'ACRdart-EA1141Restricted', 'IDC-IDC_ea1141'}	{'ACRdart', 'IDC'}	2
-BODY/BREAST STUDY LEFT	{'MR', 'SEG'}	{'IDC-IDC_ispy1'}	{'IDC'}	2
-MAMMOGRAM UNI/LEFT DIGITAL	{'MG'}	{'ACRdart-EA1141Restricted', 'IDC-IDC_ea1141'}	{'ACRdart', 'IDC'}	2
-MAM MAMMOGRAPHY SCREENING	{'MG'}	{'ACRdart-EA1141Restricted', 'IDC-IDC_ea1141'}	{'ACRdart', 'IDC'}	2
-MAM MAMMOGRAPHY DIAGNOSTIC WITH TOMOSYNTHESIS LEFT	{'MG'}	{'ACRdart-EA1141Restricted', 'IDC-IDC_ea1141'}	{'ACRdart', 'IDC'}	2
-MAM MAMMOGRAPHY DIAGNOSTIC WITH TOMOSYNTHESIS	{'MG'}	{'ACRdart-EA1141Restricted', 'IDC-IDC_ea1141'}	{'ACRdart', 'IDC'}	2
-BI-LATERAL BREASTS	{'MR', nan}	{'IDC-IDC_acrin_contralateral_breast_mr', 'TCIA-acrin-contralateral-breast-mr'}	{'IDC', 'TCIA'}	2
-BI BREAST DIAGNOSTIC LEFT WITH TOMOSYNTHESIS	{'MG'}	{'ACRdart-EA1141Restricted', 'IDC-IDC_ea1141'}	{'ACRdart', 'IDC'}	2
-BCT CHEST	{'CT', nan}	{'TCIA-acrin-nsclc-fdg-pet', 'IDC-IDC_acrin_nsclc_fdg_pet'}	{'IDC', 'TCIA'}	2
-BC009   CT ABDOMEN W&WO	{'CT', nan}	{'TCIA-tcga-kirc', 'IDC-IDC_tcga_kirc'}	{'IDC', 'TCIA'}	2
-BAR CT ABDOMEN WITH CO	{'CT', nan}	{'TCIA-acrin-nsclc-fdg-pet', 'IDC-IDC_acrin_nsclc_fdg_pet'}	{'IDC', 'TCIA'}	2
-B RT THIGH	{'MR', nan}	{'IDC-IDC_soft_tissue_sarcoma', 'TCIA-soft-tissue-sarcoma'}	{'IDC', 'TCIA'}	2
-B MRI-PELVIS	{'MR', nan}	{'IDC-IDC_soft_tissue_sarcoma', 'TCIA-soft-tissue-sarcoma'}	{'IDC', 'TCIA'}	2
-MR UPPER EXTREMITY NOT JOINT WITHOUT CONTRAST RIGHT	{'MR', nan}	{'IDC-IDC_cptac_sar', 'TCIA-cptac-sar'}	{'IDC', 'TCIA'}	2
-LIVER	{'RTSTRUCT', nan}	{'TCIA-cptac-ccrcc', 'IDC-IDC_cptac_ccrcc'}	{'IDC', 'TCIA'}	2
-KT KLP BEZ+CE	{'CT', nan}	{'TCIA-cptac-lscc', 'IDC-IDC_cptac_lscc'}	{'IDC', 'TCIA'}	2
-BREAST MRI BIL W WO CON	{'MR', nan}	{'IDC-IDC_tcga_brca', 'TCIA-tcga-brca'}	{'IDC', 'TCIA'}	2
-MR BODY RESEARC	{'MR', nan}	{'TCIA-breast-mri-nact-pilot', 'IDC-IDC_breast_mri_nact_pilot'}	{'IDC', 'TCIA'}	2
-KNEE	{'MR'}	{'MIDRC-Open-A1'}	{'MIDRC'}	2
-BREAST RT	{'MR', nan}	{'IDC-IDC_acrin_contralateral_breast_mr', 'TCIA-acrin-contralateral-breast-mr'}	{'IDC', 'TCIA'}	2
-MRI ABDOMEN EXTERNAL IMAGING	{'RTSTRUCT', nan}	{'TCIA-cptac-pda', 'IDC-IDC_cptac_pda'}	{'IDC', 'TCIA'}	2
-JHN OP CHEST WO	{'CT'}	{'MIDRC-Open-R1'}	{'MIDRC'}	2
-MRI ABDOMEN W/WO CONTR	{'MR', nan}	{'TCIA-tcga-kirc', 'IDC-IDC_tcga_kirc'}	{'IDC', 'TCIA'}	2
-MR BR SC HR	{'MR', nan}	{'IDC-IDC_acrin_contralateral_breast_mr', 'TCIA-acrin-contralateral-breast-mr'}	{'IDC', 'TCIA'}	2
-MRI ABDOMEN LIVER WWO CONTRAST	{'MR', nan}	{'TCIA-tcga-ucec', 'IDC-IDC_tcga_ucec'}	{'IDC', 'TCIA'}	2
-KNEE 2 VIEWS LEFT	{'CR', 'DX'}	{'MIDRC-Open-R1'}	{'MIDRC'}	2
-MR BREAST #6667 WO/W CONT	{'MR', nan}	{'IDC-IDC_acrin_contralateral_breast_mr', 'TCIA-acrin-contralateral-breast-mr'}	{'IDC', 'TCIA'}	2
-MR BREAST UNI E	{'MR'}	{'IDC-IDC_ispy1'}	{'IDC'}	2
-KNEE 3 VIEWS LEFT	{'CR', 'DX'}	{'MIDRC-Open-R1'}	{'MIDRC'}	2
-MRI ABDOMEN W&W/O CONTRAST	{'MR', nan}	{'TCIA-tcga-ucec', 'IDC-IDC_tcga_ucec'}	{'IDC', 'TCIA'}	2
-MRI ABDOMEN WITH AND WITHOUT CONTRAST	{'RTSTRUCT', nan}	{'TCIA-cptac-ccrcc', 'IDC-IDC_cptac_ccrcc'}	{'IDC', 'TCIA'}	2
-BREAST WO/W CONT	{'MR', nan}	{'IDC-IDC_acrin_contralateral_breast_mr', 'TCIA-acrin-contralateral-breast-mr'}	{'IDC', 'TCIA'}	2
-MR BRAIN WITH AND WITHOUT CONTRAST (O)	{'MR'}	{'MIDRC-Open-R1'}	{'MIDRC'}	2
-MRI ,ABD W&W/O, CONT 74183	{'SEG', nan}	{'TCIA-tcga-lihc', 'IDC-IDC_tcga_lihc'}	{'IDC', 'TCIA'}	2
-BRAIN/SPINE	{'MR', nan}	{'IDC-IDC_icdc_glioma', 'TCIA-icdc-glioma'}	{'IDC', 'TCIA'}	2
-MRI  RT. BREAST	{'MR', nan}	{'IDC-IDC_acrin_contralateral_breast_mr', 'TCIA-acrin-contralateral-breast-mr'}	{'IDC', 'TCIA'}	2
-MR ABDOMEN NO CONTRAST=AB	{'RTSTRUCT', nan}	{'TCIA-cptac-pda', 'IDC-IDC_cptac_pda'}	{'IDC', 'TCIA'}	2
-KNEE LEFT 3 VIEWS (ROUTINE)	{'CR'}	{'MIDRC-Open-R1'}	{'MIDRC'}	2
-BREAST 1^CE BREAST	{'MR', nan}	{'IDC-IDC_acrin_contralateral_breast_mr', 'TCIA-acrin-contralateral-breast-mr'}	{'IDC', 'TCIA'}	2
-Abdomen^JAMA_BRZUSZNA_WIELO_FAZ (Adult)	{'RTSTRUCT', nan}	{'TCIA-cptac-pda', 'IDC-IDC_cptac_pda'}	{'IDC', 'TCIA'}	2
-MRI ABDOMEN W&W/O CONT	{'MR', nan}	{'TCIA-tcga-kirc', 'IDC-IDC_tcga_kirc'}	{'IDC', 'TCIA'}	2
-MRI ABDOMEN W/O AND WITH CONTRAST	{'MR', nan}	{'TCIA-tcga-lihc', 'IDC-IDC_tcga_lihc'}	{'IDC', 'TCIA'}	2
-MRI ABDOMEN  WTHOUT CONTRAST	{'RTSTRUCT', nan}	{'TCIA-cptac-ccrcc', 'IDC-IDC_cptac_ccrcc'}	{'IDC', 'TCIA'}	2
-MRI ABDOMEN	{'MR', nan}	{'IDC-IDC_tcga_blca', 'TCIA-tcga-blca'}	{'IDC', 'TCIA'}	2
-CERVICAL	{'MR', nan}	{'IDC-IDC_icdc_glioma', 'TCIA-icdc-glioma'}	{'IDC', 'TCIA'}	2
-JHN CT CHEST WO OP	{'CT'}	{'MIDRC-Open-R1'}	{'MIDRC'}	2
-Abdomen^Jama_Brzuszna_3_Fazy (Adult)	{'RTSTRUCT', nan}	{'TCIA-cptac-ccrcc', 'IDC-IDC_cptac_ccrcc'}	{'IDC', 'TCIA'}	2
-MRI ABD WO/W CONTRAST	{'RTSTRUCT', nan}	{'TCIA-cptac-pda', 'IDC-IDC_cptac_pda'}	{'IDC', 'TCIA'}	2
-JOINY CT CHEST/PELVIS WITH	{'CT'}	{'MIDRC-Open-R1'}	{'MIDRC'}	2
-Abdomen^KIDNEY_STONE (Adult)	{'RTSTRUCT', nan}	{'TCIA-cptac-ccrcc', 'IDC-IDC_cptac_ccrcc'}	{'IDC', 'TCIA'}	2
-Abdomen^JBRZUSZNA_3FAZY_OPOZNIONE (Adult)	{'RTSTRUCT', nan}	{'TCIA-cptac-ccrcc', 'IDC-IDC_cptac_ccrcc'}	{'IDC', 'TCIA'}	2
-BRAIN IMAGING (PET)	{'SEG', nan}	{'IDC-IDC_nsclc_radiogenomics', 'TCIA-nsclc-radiogenomics'}	{'IDC', 'TCIA'}	2
-K-9 BRAIN	{'MR', nan}	{'IDC-IDC_icdc_glioma', 'TCIA-icdc-glioma'}	{'IDC', 'TCIA'}	2
-Abdomen^J_BRZUSZNA_3_FAZY (Adult)	{'RTSTRUCT', nan}	{'TCIA-cptac-pda', 'IDC-IDC_cptac_pda'}	{'IDC', 'TCIA'}	2
-Abdomen^KLP_JB_M (Adult)	{'RTSTRUCT', nan}	{'TCIA-cptac-pda', 'IDC-IDC_cptac_pda'}	{'IDC', 'TCIA'}	2
-CCT- ABD [LIVER]	{'SEG', nan}	{'IDC-IDC_hcc_tace_seg', 'TCIA-hcc-tace-seg'}	{'IDC', 'TCIA'}	2
-K9 SPINE	{'MR', nan}	{'IDC-IDC_icdc_glioma', 'TCIA-icdc-glioma'}	{'IDC', 'TCIA'}	2
-K9 SRS FULL BRAIN	{'MR', nan}	{'IDC-IDC_icdc_glioma', 'TCIA-icdc-glioma'}	{'IDC', 'TCIA'}	2
-KIDNEYS	{'MR', nan}	{'TCIA-tcga-kirc', 'IDC-IDC_tcga_kirc'}	{'IDC', 'TCIA'}	2
-MRI ABDOMEN AND PELVIS WITHOUT CONTRAST	{'MR'}	{'MIDRC-Open-A1'}	{'MIDRC'}	2
-KL.P BEZ I Z CE	{'CT', nan}	{'TCIA-cptac-luad', 'IDC-IDC_cptac_luad'}	{'IDC', 'TCIA'}	2
-MR ANGIOGRAPHY ABDOMEN WITH CONTRAST	{'MR', nan}	{'TCIA-tcga-kirc', 'IDC-IDC_tcga_kirc'}	{'IDC', 'TCIA'}	2
-CCT, AP LIVER	{'SEG', nan}	{'IDC-IDC_hcc_tace_seg', 'TCIA-hcc-tace-seg'}	{'IDC', 'TCIA'}	2
-MR BREAST BI W/WO	{'MR', nan}	{'IDC-IDC_acrin_contralateral_breast_mr', 'TCIA-acrin-contralateral-breast-mr'}	{'IDC', 'TCIA'}	2
-BREAST(s) ULTRA	{'US'}	{'ACRdart-ACRIN_6666'}	{'ACRdart'}	2
-BRAIN POST OP	{'MR', nan}	{'IDC-IDC_icdc_glioma', 'TCIA-icdc-glioma'}	{'IDC', 'TCIA'}	2
-Abdomen^JB_3FAZY_BOLUS (Adult)	{'RTSTRUCT', nan}	{'TCIA-cptac-ccrcc', 'IDC-IDC_cptac_ccrcc'}	{'IDC', 'TCIA'}	2
-BONE MINERAL DENSITY DXA AXIAL SKELETON (ROUTINE)	{'CR'}	{'MIDRC-Open-R1'}	{'MIDRC'}	2
-Abdomen^J_BRZUSZNA_3FAZY_OPOZNIONA (Adult)	{'RTSTRUCT', nan}	{'TCIA-cptac-ccrcc', 'IDC-IDC_cptac_ccrcc'}	{'IDC', 'TCIA'}	2
-MRI ANKLE W/O CONTRAST - LEFT	{'MR'}	{'MIDRC-Open-A1'}	{'MIDRC'}	2
-MRBRUR	{'MR'}	{'IDC-IDC_ispy1'}	{'IDC'}	2
-MR BREAST BIL SCREENING W CONTRAST	{'MR'}	{'ACRdart-EA1141Restricted', 'IDC-IDC_ea1141'}	{'ACRdart', 'IDC'}	2
-Abdomen^RENAL_PROTOCOL (Adult)	{'CT', nan}	{'TCIA-tcga-kirc', 'IDC-IDC_tcga_kirc'}	{'IDC', 'TCIA'}	2
-BODY^ABDOMEN PELVIS	{'MR', nan}	{'TCIA-tcga-ov', 'IDC-IDC_tcga_ov'}	{'IDC', 'TCIA'}	2
-Abdomen^RENAL_STONE (Adult)	{'CT', nan}	{'TCIA-cptac-ccrcc', 'IDC-IDC_cptac_ccrcc'}	{'IDC', 'TCIA'}	2
-Abdomen^ROUTINE_AP_LOW_DOSE_WO__Customized (Adult)	{'CT'}	{'MIDRC-Open-A1'}	{'MIDRC'}	2
-MR prostaat 3T + ERC_mc MCAPRO3T	{'MR', nan}	{'IDC-IDC_prostate_3t', 'TCIA-prostate-3t'}	{'IDC', 'TCIA'}	2
-JK^Brzuch	{'RTSTRUCT', nan}	{'TCIA-cptac-pda', 'IDC-IDC_cptac_pda'}	{'IDC', 'TCIA'}	2
-JOICC CT CHEST	{'CT'}	{'MIDRC-Open-R1'}	{'MIDRC'}	2
-BREAST ACRIN STUDY	{'MR', nan}	{'IDC-IDC_acrin_contralateral_breast_mr', 'TCIA-acrin-contralateral-breast-mr'}	{'IDC', 'TCIA'}	2
-BRAIN-STEROTATIC	{'MR', nan}	{'IDC-IDC_icdc_glioma', 'TCIA-icdc-glioma'}	{'IDC', 'TCIA'}	2
-BREAST/PRONE	{'SEG', nan}	{'IDC-IDC_qin_breast', 'TCIA-qin-breast'}	{'IDC', 'TCIA'}	2
-BRAIN W/WO CONTRAST (CT)-CS	{'CT'}	{'MIDRC-Open-A1'}	{'MIDRC'}	2
-CCHST+	{'CT', nan}	{'TCIA-acrin-nsclc-fdg-pet', 'IDC-IDC_acrin_nsclc_fdg_pet'}	{'IDC', 'TCIA'}	2
-MR jamy brzusznej: wielofazowo	{'RTSTRUCT', nan}	{'TCIA-cptac-pda', 'IDC-IDC_cptac_pda'}	{'IDC', 'TCIA'}	2
-KT KLP +C	{'CT', nan}	{'TCIA-cptac-lscc', 'IDC-IDC_cptac_lscc'}	{'IDC', 'TCIA'}	2
-MR prostaat stadiering PCMAPS_mc MCAPCMAPS	{'MR', nan}	{'IDC-IDC_prostate_3t', 'TCIA-prostate-3t'}	{'IDC', 'TCIA'}	2
-JHN STNECK CAP W OP	{'CT'}	{'MIDRC-Open-R1'}	{'MIDRC'}	2
-MR BREAST BILAT/SPECIAL BILLING	{'MR'}	{'IDC-IDC_ispy1'}	{'IDC'}	2
-JOINY CT C/A/P COMBO	{'CT'}	{'MIDRC-Open-R1'}	{'MIDRC'}	2
-MRI ABDOMEN WO CONT	{'MR', nan}	{'IDC-IDC_tcga_kirp', 'TCIA-tcga-kirp'}	{'IDC', 'TCIA'}	2
-MR ABDOMEN +/- CONTRAST=AB	{'RTSTRUCT', nan}	{'TCIA-cptac-pda', 'IDC-IDC_cptac_pda'}	{'IDC', 'TCIA'}	2
-JOINE CT CHEST	{'CT'}	{'MIDRC-Open-R1'}	{'MIDRC'}	2
-MRA HEART LEFT ATRIAL MAPPING WITH AND WITHOUT CONTRAST	{'MR'}	{'MIDRC-Open-R1'}	{'MIDRC'}	2
-MR BREAST BIL DIAG WO W CONTRAST	{'MR'}	{'ACRdart-EA1141Restricted', 'IDC-IDC_ea1141'}	{'ACRdart', 'IDC'}	2
-Abdomen^KlpBrzuchMiednica (Adult)	{'CT', nan}	{'IDC-IDC_cptac_cm', 'TCIA-cptac-cm'}	{'IDC', 'TCIA'}	2
-MRI ABDOMEN WITHOUT CONTRAST	{'MR', nan}	{'TCIA-tcga-ucec', 'IDC-IDC_tcga_ucec'}	{'IDC', 'TCIA'}	2
-Abdomen^PEDS__ABD_PEL_WITH (Child)	{'CT'}	{'MIDRC-Open-A1'}	{'MIDRC'}	2
-MR ABDOMEN ENHANCED & NON-BODY	{'MR', nan}	{'TCIA-tcga-lihc', 'IDC-IDC_tcga_lihc'}	{'IDC', 'TCIA'}	2
-MRA RENAL	{'MR', nan}	{'TCIA-tcga-kirc', 'IDC-IDC_tcga_kirc'}	{'IDC', 'TCIA'}	2
-MR- Cholangiografia	{'RTSTRUCT', nan}	{'TCIA-cptac-pda', 'IDC-IDC_cptac_pda'}	{'IDC', 'TCIA'}	2
-MRI ABDOMENI WO CONT	{'MR', nan}	{'TCIA-tcga-kirc', 'IDC-IDC_tcga_kirc'}	{'IDC', 'TCIA'}	2
-X-RAY FOREARM 2 VIEWS - RIGHT	{'DX'}	{'MIDRC-Open-A1'}	{'MIDRC'}	1
-XR LEFT RIBS 2 VIEWS UNILATERAL	{'CR'}	{'MIDRC-Open-A1'}	{'MIDRC'}	1
-BODY/LEFT BREAST	{'SEG'}	{'IDC-IDC_ispy1'}	{'IDC'}	1
-BODY/BREAST STUDY/LEFT	{'MR'}	{'IDC-IDC_ispy1'}	{'IDC'}	1
-X-RAY FOREARM 2 VIEWS - LEFT	{'DX'}	{'MIDRC-Open-A1'}	{'MIDRC'}	1
-CT LUMBAR PUNCTURE DIAGNOSTIC	{'CT'}	{'MIDRC-Open-R1'}	{'MIDRC'}	1
-XR LUMBAR SPINE 2-3 VIEWS (AP/LAT/SPOT)	{'CR'}	{'MIDRC-Open-A1'}	{'MIDRC'}	1
-XR LUMBAR SPINE 3 VIEWS	{'DX'}	{'MIDRC-Open-R1'}	{'MIDRC'}	1
-BODY/BREAST RESEARCH	{'SEG'}	{'IDC-IDC_ispy1'}	{'IDC'}	1
-BR-Breast US_LT	{'US'}	{'ACRdart-ACRIN_6666'}	{'ACRdart'}	1
-BR-BxBreast LUS	{'US'}	{'ACRdart-ACRIN_6666'}	{'ACRdart'}	1
-CT LT LOWER EXTREMITY W/O CONTRAST	{'CT'}	{'MIDRC-Open-A1'}	{'MIDRC'}	1
-3611 - 6657 RT BREAST/GAD	{'MR'}	{'IDC-IDC_ispy1'}	{'IDC'}	1
-MRI THIGH WITHOUT CONTRAST - RIGHT	{'MR'}	{'MIDRC-Open-A1'}	{'MIDRC'}	1
-MR BREAST BILATERAL W/ OR W/O GAD	{'MR'}	{'ACRdart-EA1141Restricted'}	{'ACRdart'}	1
-XR LUMBAR SPINE 1 VIEW	{'CR'}	{'MIDRC-Open-A1'}	{'MIDRC'}	1
-XR LEFT THUMB	{'CR'}	{'MIDRC-Open-A1'}	{'MIDRC'}	1
-XR LEFT WRIST 1-2 VIEWS	{'CR'}	{'MIDRC-Open-A1'}	{'MIDRC'}	1
-ANGIOS^GBO	{'MR'}	{'MIDRC-Open-A1'}	{'MIDRC'}	1
-MR BREAST-RIGHT	{'MR'}	{'IDC-IDC_ispy1'}	{'IDC'}	1
-MRI UROGRAM WO/W CONTRAST	{'MR'}	{'MIDRC-Open-A1'}	{'MIDRC'}	1
-CT PULMONARY EMBOLI WITH IV CONTRAST	{'CT'}	{'MIDRC-Open-A1_SCCM_VIRUS'}	{'MIDRC'}	1
-3D TOMO HD DX BI	{'MG'}	{'ACRdart-EA1141Restricted'}	{'ACRdart'}	1
-ANKLE 3 VIEWS RIGHT	{'DX'}	{'MIDRC-Open-R1'}	{'MIDRC'}	1
-CT PULM VEIN OP	{'CT'}	{'MIDRC-Open-R1'}	{'MIDRC'}	1
-XR LUMBAR SPINE 1 VIEW INTRAOPERATIVE	{'DX'}	{'MIDRC-Open-A1'}	{'MIDRC'}	1
-BR-BxBreast RUS	{'US'}	{'ACRdart-ACRIN_6666'}	{'ACRdart'}	1
-XR PORT ABDOMEN COMPLETE DECUB & O*	{'CR'}	{'MIDRC-Open-A1'}	{'MIDRC'}	1
-MR BRST BI BIRAD W/WO CNTRST	{'MR'}	{'ACRdart-EA1141Restricted'}	{'ACRdart'}	1
-XR LUMBAR SPINE WITH OBLIQUES	{'DX'}	{'MIDRC-Open-R1'}	{'MIDRC'}	1
-X-RAY ENTIRE SPINE SCOLIOSIS 1 VIEW	{'DX'}	{'MIDRC-Open-A1'}	{'MIDRC'}	1
-MRI SPINE - LUMBAR W/O CONTRAST FOLLOWED BY W CONTRAST	{nan}	{'TCIA-varepop-apollo'}	{'TCIA'}	1
-CT RFA LUMBAR/SACRAL NERVE/JOINT 1 LEVEL	{'CT'}	{'MIDRC-Open-R1'}	{'MIDRC'}	1
-CT RT LOWER EXTREMITY WO/W IV CONTRAST	{'CT'}	{'MIDRC-Open-A1'}	{'MIDRC'}	1
-X-RAY ELBOW 2 VIEWS - LEFT	{'DX'}	{'MIDRC-Open-A1'}	{'MIDRC'}	1
-MR_Brain	{nan}	{'TCIA-cmb-lca'}	{'TCIA'}	1
-XR RIGHT CLAVICLE	{'DX'}	{'MIDRC-Open-A1'}	{'MIDRC'}	1
-X-RAY CLAVICLE COMPLETE - LEFT	{'CR'}	{'MIDRC-Open-A1'}	{'MIDRC'}	1
-XR RIGHT ELBOW 1-2 VIEWS	{'CR'}	{'MIDRC-Open-A1'}	{'MIDRC'}	1
-CT HEART WO IV CONTRAST CALCIUM SCORING	{'CT'}	{'MIDRC-Open-A1'}	{'MIDRC'}	1
-CT RT UPPER EXTREMITY WO/W IV CONTRAST	{'CT'}	{'MIDRC-Open-A1'}	{'MIDRC'}	1
-CT SCREENING COLONOSCOPY	{'CT'}	{'MIDRC-Open-R1'}	{'MIDRC'}	1
-CT ABDOMEN PELVIS WWO	{'CT'}	{'MIDRC-Open-A1'}	{'MIDRC'}	1
-X-RAY CHEST 1 VIEW, FRONTAL, portable	{'DX'}	{'MIDRC-Open-R1'}	{'MIDRC'}	1
-X-RAY CHEST 1 VIEW, FRONTAL, PORTABLE	{'DX'}	{'MIDRC-Open-R1'}	{'MIDRC'}	1
-XR RIGHT FEMUR 1 VIEW	{'CR'}	{'MIDRC-Open-A1'}	{'MIDRC'}	1
-XR RIGHT FEMUR MIN 2 VIEWS	{'CR'}	{'MIDRC-Open-A1'}	{'MIDRC'}	1
-MR Breast Bilateral w?	{'SEG'}	{'IDC-IDC_ispy1'}	{'IDC'}	1
-CT HEART PULMONARY VEINS STRUCTURE MORPHOLOGY WITH CONTRAST	{'CT'}	{'MIDRC-Open-R1'}	{'MIDRC'}	1
-MRI SHOULDER W/ + W/O CNTRST RIGHT	{'MR'}	{'MIDRC-Open-A1'}	{'MIDRC'}	1
-X-RAY CERVICAL SPINE COMPLT INCL OBL/FLX AND/OR EXT	{'DX'}	{'MIDRC-Open-A1'}	{'MIDRC'}	1
-CT HRCT THORAX	{'CT'}	{'AIMI-COCA'}	{'AIMI'}	1
-MRI SPINE - THORACIC W/O CONTRAST FOLLOWED BY W CONTRAST	{nan}	{'TCIA-varepop-apollo'}	{'TCIA'}	1
-MRI SPINE LUMBAR WO IV CONTRAST	{'MR'}	{'MIDRC-Open-A1'}	{'MIDRC'}	1
-MR Body Development Proc	{'MR'}	{'ACRdart-ACRIN_6701'}	{'ACRdart'}	1
-CT LEVEL 1-2 FACE WO ED TRAUMA	{'CT'}	{'MIDRC-Open-A1'}	{'MIDRC'}	1
-XR P PORT ABDOMEN COMPLETE DECUB &*	{'CR'}	{'MIDRC-Open-R1'}	{'MIDRC'}	1
-MR BRST UNI E L	{'SEG'}	{'IDC-IDC_ispy1'}	{'IDC'}	1
-XR PELVIS 1 VIEW ANTEROPOSTERIOR	{'DX'}	{'MIDRC-Open-A1'}	{'MIDRC'}	1
-BR-SV	{'US'}	{'ACRdart-ACRIN_6666'}	{'ACRdart'}	1
-CT LEVEL 1-2 ANGIOGRAPHY NECK ED TRAUMA	{'CT'}	{'MIDRC-Open-A1'}	{'MIDRC'}	1
-XR PELVIS COMPLETE MINIMUM 3 VIEWS	{'DX'}	{'MIDRC-Open-A1'}	{'MIDRC'}	1
-XR PELVIS LIMITED 1 OR 2 VIEW	{'DX'}	{'MIDRC-Open-A1'}	{'MIDRC'}	1
-ABD_PELVIS 61_100LB(Child)	{'CT'}	{'MIDRC-Open-A1'}	{'MIDRC'}	1
-XR LEFT KNEE 4+ VIEWS	{'DX'}	{'MIDRC-Open-A1'}	{'MIDRC'}	1
-CT Initial/Annual Lung Screening	{'CT'}	{'MIDRC-Open-R1'}	{'MIDRC'}	1
-X-RAY FINGER(S) MINIMUM 2 VIEWS - RIGHT	{'DX'}	{'MIDRC-Open-A1'}	{'MIDRC'}	1
-BODY/ BREAST	{'MR'}	{'IDC-IDC_ispy1'}	{'IDC'}	1
-ABD^RAPID MRCP	{'MR'}	{'MIDRC-Open-A1'}	{'MIDRC'}	1
-X-RAY FACIAL BONES COMPLT MINIMUM 3 VIEWS	{'DX'}	{'MIDRC-Open-A1'}	{'MIDRC'}	1
-BRAIN LAB ENT(Adult)	{'CT'}	{'MIDRC-Open-A1'}	{'MIDRC'}	1
-BRAIN MRA 2.21^NEW BRAIN W WO	{'MR'}	{'MIDRC-Open-A1'}	{'MIDRC'}	1
-CT L-SPINE W/O CONTRAST/BONE RECON	{'CT'}	{'MIDRC-Open-A1'}	{'MIDRC'}	1
-XR RIBS BILATERAL	{'CR'}	{'MIDRC-Open-A1'}	{'MIDRC'}	1
-CT ABDOMEN WWO CONTRAST (KIDNEYS)	{'CT'}	{'MIDRC-Open-A1'}	{'MIDRC'}	1
-CT LUMBAR SPINE FACET BLOCK MULTI LEVEL	{'CT'}	{'MIDRC-Open-R1'}	{'MIDRC'}	1
-X-RAY PELVIS COMPLETE MINIMUM 3 VIEWS	{'DX'}	{'MIDRC-Open-A1'}	{'MIDRC'}	1
-BR-BX BrstCoreB	{'US'}	{'ACRdart-ACRIN_6666'}	{'ACRdart'}	1
-XR IVP W TOMOGRAMS	{'CR'}	{'MIDRC-Open-A1'}	{'MIDRC'}	1
-XR FEET BILATERAL	{'DX'}	{'MIDRC-Open-A1'}	{'MIDRC'}	1
-ADD VIEWS-UNILATERAL DIAGNOSTIC MAMMO-RT	{'MG'}	{'ACRdart-EA1141Restricted'}	{'ACRdart'}	1
-CT P CHEST AND UPPER ABD W	{'CT'}	{'MIDRC-Open-A1'}	{'MIDRC'}	1
-3607 MR BREAST WO/W CONT & BOLD	{'SEG'}	{'IDC-IDC_ispy1'}	{'IDC'}	1
-3607 6657 RT BREAST WO/W CONT	{'MR'}	{'IDC-IDC_ispy1'}	{'IDC'}	1
-XR FOREARM (RADIUS/ULNA) LEFT	{'DX'}	{'MIDRC-Open-A1'}	{'MIDRC'}	1
-BIUSGCBXUS GUIDED CORE BX	{'US'}	{'ACRdart-ACRIN_6666'}	{'ACRdart'}	1
-XR FOREARM (RADIUS/ULNA) RIGHT	{'DX'}	{'MIDRC-Open-A1'}	{'MIDRC'}	1
-X-RAY WRIST 2 VIEWS - RIGHT	{'DX'}	{'MIDRC-Open-A1'}	{'MIDRC'}	1
-X-RAY WRIST 2 VIEWS - LEFT	{'DX'}	{'MIDRC-Open-A1'}	{'MIDRC'}	1
-X-RAY TOE(S) MINIMUM 2 VIEWS - RIGHT	{'CR'}	{'MIDRC-Open-A1'}	{'MIDRC'}	1
-CT ABDOMEN W&W/O CONT	{nan}	{'TCIA-varepop-apollo'}	{'TCIA'}	1
-XR HAND LEFT (LIMITED: AP,LAT)	{'CR'}	{'MIDRC-Open-A1'}	{'MIDRC'}	1
-XR HAND LEFT (ROUTINE: AP LAT OBL)	{'DX'}	{'MIDRC-Open-A1'}	{'MIDRC'}	1
-CT ABDOMEN W/O CONTRAST	{'CT'}	{'MIDRC-Open-A1'}	{'MIDRC'}	1
-X-RAY TIBIA & FIBULA 2 VIEWS - LEFT	{'DX'}	{'MIDRC-Open-A1'}	{'MIDRC'}	1
-ADULT CHEST - 2 VIEWS	{'CR'}	{'MIDRC-Open-R1'}	{'MIDRC'}	1
-X-RAY THORACOLUMBAR SPINE 2 VIEWS	{'DX'}	{'MIDRC-Open-A1'}	{'MIDRC'}	1
-XR HANDS BILATERAL (1-2 VIEWS)	{'DX'}	{'MIDRC-Open-A1'}	{'MIDRC'}	1
-ADULT CHEST 2 VIEW	{'CR'}	{'MIDRC-Open-R1'}	{'MIDRC'}	1
-CT OUTSIDE ABDOMEN PELVIS W INTERPRETATION OR CONSULT	{'CT'}	{'MIDRC-Open-A1_PETAL_REDCORAL'}	{'MIDRC'}	1
-X-RAY THORACIC SPINE 3 VIEWS	{'DX'}	{'MIDRC-Open-A1'}	{'MIDRC'}	1
-CT ORBITS OPTIC NERVES WWO CONTRAST	{'CT'}	{'MIDRC-Open-A1'}	{'MIDRC'}	1
-XR ELBOW RIGHT (LIMITED: AP LAT)	{'DX'}	{'MIDRC-Open-A1'}	{'MIDRC'}	1
-ACRIN6666 / SV	{'US'}	{'ACRdart-ACRIN_6666'}	{'ACRdart'}	1
-3607 ACRIN 6657 LT BREAST/GAD	{'MR'}	{'IDC-IDC_ispy1'}	{'IDC'}	1
-3607 MR BOLD BREAST WO/W CONT	{'SEG'}	{'IDC-IDC_ispy1'}	{'IDC'}	1
-XR ABDOMEN SINGLE AP VIEW	{'CR'}	{'MIDRC-Open-A1'}	{'MIDRC'}	1
-XR ABDOMEN SITZ MARKER	{'DX'}	{'MIDRC-Open-A1_PETAL_REDCORAL'}	{'MIDRC'}	1
-XR ABDOMEN SUPINE AND ERECT	{'DX'}	{'MIDRC-Open-A1'}	{'MIDRC'}	1
-XR ABDOMEN TO CHECK TUBE PLCMT	{'DX'}	{'MIDRC-Open-R1'}	{'MIDRC'}	1
-XR ABDOMEN TUBE POSITION CHECK	{'DX'}	{'MIDRC-Open-A1_PETAL_REDCORAL'}	{'MIDRC'}	1
-XR ANKLE 3+ VIEWS	{'CR'}	{'MIDRC-Open-A1'}	{'MIDRC'}	1
-XR ANKLE LEFT (ROUTINE: AP,LAT,OBL)	{'DX'}	{'MIDRC-Open-A1'}	{'MIDRC'}	1
-MR BREAST UNILAT LEFT W&WO CONT	{'MR'}	{'IDC-IDC_ispy1'}	{'IDC'}	1
-XR Abdomen AP	{'DX'}	{'MIDRC-Open-A1_PETAL_BLUECORAL'}	{'MIDRC'}	1
-CT ABDOMEN W/DYE	{nan}	{'TCIA-varepop-apollo'}	{'TCIA'}	1
-XR ABDOMEN ACUTE PORTABLE	{'CR'}	{'MIDRC-Open-A1'}	{'MIDRC'}	1
-3607 LT MR BREAST WO/W CONT 6657	{'MR'}	{'IDC-IDC_ispy1'}	{'IDC'}	1
-3607 MR ACRIN 6657: RIGHT BREAST WO/W CONT	{'MR'}	{'IDC-IDC_ispy1'}	{'IDC'}	1
-BODY/RT BREAST	{'MR'}	{'IDC-IDC_ispy1'}	{'IDC'}	1
-3607 MR BREAST RIGHT	{'MR'}	{'IDC-IDC_ispy1'}	{'IDC'}	1
-XR CERVICAL SPINE 2-3 VIEWS WITH FLEXION EXTENSION NEURO	{'CR'}	{'MIDRC-Open-A1'}	{'MIDRC'}	1
-CT ABDOMEN W/O & W/DYE	{nan}	{'TCIA-varepop-apollo'}	{'TCIA'}	1
-XR CERVICAL SPINE 6+ VIEWS	{'CR'}	{'MIDRC-Open-A1'}	{'MIDRC'}	1
-3607 MR BREAST W/WO LEFT	{'MR'}	{'IDC-IDC_ispy1'}	{'IDC'}	1
-CT PELVIS W CONTRAST GIGU	{'CT'}	{'MIDRC-Open-A1_PETAL_BLUECORAL'}	{'MIDRC'}	1
-MR BREAST UNIL W OR WO SCCA	{'MR'}	{'IDC-IDC_ispy1'}	{'IDC'}	1
-XR CLAVICLE LEFT	{'DX'}	{'MIDRC-Open-A1'}	{'MIDRC'}	1
-XR HUMERUS LEFT	{'CR'}	{'MIDRC-Open-A1'}	{'MIDRC'}	1
-3607 6657 BREAST LEFT MR RESEARCH	{'MR'}	{'IDC-IDC_ispy1'}	{'IDC'}	1
-BR Screening DBT Mammogram RT	{'MG'}	{'ACRdart-EA1141Restricted'}	{'ACRdart'}	1
-CT ORBITS OPTIC NERVES WO CONTRAST	{'CT'}	{'MIDRC-Open-A1'}	{'MIDRC'}	1
-3607 MR LT BREAST WO/W CONT (6657)	{'SEG'}	{'IDC-IDC_ispy1'}	{'IDC'}	1
-XR LEFT FINGERS	{'DX'}	{'MIDRC-Open-A1'}	{'MIDRC'}	1
-3 SITES	{'CT'}	{'IDC-IDC_lctsc'}	{'IDC'}	1
-X-RAY NASAL BONES MINIMUM 3 VIEWS	{'DX'}	{'MIDRC-Open-A1'}	{'MIDRC'}	1
-3607 MR RESEARCH 6657: LEFT BREAST WO/W	{'MR'}	{'IDC-IDC_ispy1'}	{'IDC'}	1
-3607 MR RIGHT BREAST W/WO CONTRAST	{'SEG'}	{'IDC-IDC_ispy1'}	{'IDC'}	1
-MR BREAST WO/W CONT#6657	{'MR'}	{'IDC-IDC_ispy1'}	{'IDC'}	1
-X-RAY KNEES BILATERAL AP STANDING	{'DX'}	{'MIDRC-Open-A1'}	{'MIDRC'}	1
-CT ABDOMEN WWO CHEST PELVIS W (KIDNEYS)	{'CT'}	{'MIDRC-Open-A1'}	{'MIDRC'}	1
-ACRIN 6701 MRT Prostata Follow-up	{'MR'}	{'ACRdart-ACRIN_6701'}	{'ACRdart'}	1
-CT ABDOMEN WWO CONTRAST	{'CT'}	{'MIDRC-Open-A1'}	{'MIDRC'}	1
-MR BREAST WO/W CONT-6657	{'SEG'}	{'IDC-IDC_ispy1'}	{'IDC'}	1
-CT LUMBAR SPINE WITHOUT CONTRAST (S)	{'CT'}	{'MIDRC-Open-R1'}	{'MIDRC'}	1
-3607 MRI RT BREAST WO/W CONT 6657	{'SEG'}	{'IDC-IDC_ispy1'}	{'IDC'}	1
-3607 RT BREAST WO/W CONT 6657	{'MR'}	{'IDC-IDC_ispy1'}	{'IDC'}	1
-3607- MR BREAST WO OR W BILAT 6657	{'SEG'}	{'IDC-IDC_ispy1'}	{'IDC'}	1
-3607-6657 LT BREAST	{'SEG'}	{'IDC-IDC_ispy1'}	{'IDC'}	1
-CT LUMBAR SPINE WITH CONTRAST	{'CT'}	{'MIDRC-Open-R1'}	{'MIDRC'}	1
-BODY/LEFTBREAST	{'SEG'}	{'IDC-IDC_ispy1'}	{'IDC'}	1
-3608 MR #6657 BOLD BREAST WO/W CONT	{'SEG'}	{'IDC-IDC_ispy1'}	{'IDC'}	1
-CT LUMBAR SPINE NERVE BLOCK 1 LEVEL	{'CT'}	{'MIDRC-Open-R1'}	{'MIDRC'}	1
-X-RAY HUMERUS MINIMUM 2 VIEWS - RIGHT	{'DX'}	{'MIDRC-Open-A1'}	{'MIDRC'}	1
-X-RAY HUMERUS MINIMUM 2 VIEWS - LEFT	{'DX'}	{'MIDRC-Open-A1'}	{'MIDRC'}	1
-XR ABDOMEN FEEDING TUBE 1 VIEW	{'DX'}	{'MIDRC-Open-A1_PETAL_REDCORAL'}	{'MIDRC'}	1
-X-RAY RIBS BILATERAL 3 VIEWS	{'DX'}	{'MIDRC-Open-A1'}	{'MIDRC'}	1
-X-RAY SACROILIAC JOINTS 3 OR MORE VIEWS	{'DX'}	{'MIDRC-Open-A1'}	{'MIDRC'}	1
-3607 - 6657 MR RIGHT BREAST	{'SEG'}	{'IDC-IDC_ispy1'}	{'IDC'}	1
-CT ORBIT WITH CONTRAST	{'CT'}	{'MIDRC-Open-R1'}	{'MIDRC'}	1
-MRI/MRA BRAIN WITHOUT AND WITH CONTRAST (INCLUDE VWI)	{'MR'}	{'MIDRC-Open-R1'}	{'MIDRC'}	1
-BODY/RESEARCH STUDY	{'SEG'}	{'IDC-IDC_ispy1'}	{'IDC'}	1
-3607 MR BREAST WO/W CONT 6657	{'SEG'}	{'IDC-IDC_ispy1'}	{'IDC'}	1
-XR KNEES BILATERAL	{'DX'}	{'MIDRC-Open-A1'}	{'MIDRC'}	1
-XR KNEES BILATERAL STANDING (3 VIEWS)	{'DX'}	{'MIDRC-Open-A1'}	{'MIDRC'}	1
-3607 -#6657 ACRIN BOLD  RIGHT BREAST WO/W CONT	{'MR'}	{'IDC-IDC_ispy1'}	{'IDC'}	1
-MR BREAST WO OR W BILAT	{'MR'}	{'IDC-IDC_ispy1'}	{'IDC'}	1
-3607 - MR BREAST WO/W CONT ACRIN 6657	{'MR'}	{'IDC-IDC_ispy1'}	{'IDC'}	1
-3607 - 6657 RT BREAST WO/W CONT	{'SEG'}	{'IDC-IDC_ispy1'}	{'IDC'}	1
-X-RAY SPINE SINGLE VIEW SPECIFY LEVEL	{'DX'}	{'MIDRC-Open-A1'}	{'MIDRC'}	1
-CT PELVIS WITHOUT CONTRAST (S)	{'CT'}	{'MIDRC-Open-R1'}	{'MIDRC'}	1
-XR LEFT CALCANEUS 2 VIEWS	{'CR'}	{'MIDRC-Open-A1'}	{'MIDRC'}	1
-3607 - 6657 LT BREAST/GAD	{'MR'}	{'IDC-IDC_ispy1'}	{'IDC'}	1
-BODY/LT BREAST STUDY	{'SEG'}	{'IDC-IDC_ispy1'}	{'IDC'}	1
-3607 MR BREAST WO/W CONT/BOLD	{'SEG'}	{'IDC-IDC_ispy1'}	{'IDC'}	1
-3607 - 6657 LT BREAST WO/W CONT	{'SEG'}	{'IDC-IDC_ispy1'}	{'IDC'}	1
-XR LEFT ELBOW 4+ VIEWS	{'DX'}	{'MIDRC-Open-A1'}	{'MIDRC'}	1
-XR LEFT FEMUR 1 VIEW	{'CR'}	{'MIDRC-Open-A1'}	{'MIDRC'}	1
-3607 MR BREAST/GAD-BOLD	{'SEG'}	{'IDC-IDC_ispy1'}	{'IDC'}	1
-BR Screening DBT Mammogram Bilat	{'MG'}	{'ACRdart-EA1141Restricted'}	{'ACRdart'}	1
-CT PELVIS WITHOUT CONTRAST	{'CT'}	{'MIDRC-Open-R1'}	{'MIDRC'}	1
-MR Breast Left wo+w co	{'SEG'}	{'IDC-IDC_ispy1'}	{'IDC'}	1
-JHN CST/PEL W/	{'CT'}	{'MIDRC-Open-R1'}	{'MIDRC'}	1
-CT HEAD WITHOUT CONTRAST	{'CT'}	{'MIDRC-Open-A1_PETAL_BLUECORAL'}	{'MIDRC'}	1
-XR RIGHT HIP 1 VIEW	{'DX'}	{'MIDRC-Open-A1'}	{'MIDRC'}	1
-Abdomen^RENAL_MASS (Adult)	{'CT'}	{'MIDRC-Open-A1'}	{'MIDRC'}	1
-Abdomen^ABDOMEN_PELVIS_W (Adult)	{'CT'}	{'MIDRC-Open-A1_SCCM_VIRUS'}	{'MIDRC'}	1
-Abdomen^ABDOMEN_PELVIS_WO (Adult)	{'CT'}	{'MIDRC-Open-A1'}	{'MIDRC'}	1
-Abdomen^ABDOMEN_PELVIS_W_WO (Adult)	{'CT'}	{'MIDRC-Open-A1'}	{'MIDRC'}	1
-CT CHEST W W/O CONTRAST	{'CT'}	{'MIDRC-Open-R1'}	{'MIDRC'}	1
-Abdomen^MARKS_CAILLATT_PROTOCOL (Adult)	{'CT'}	{'MIDRC-Open-A1'}	{'MIDRC'}	1
-CT CHEST W CONTRAST PULMONARY EMBOLISM	{'CT'}	{'MIDRC-Open-R1'}	{'MIDRC'}	1
-CT CHEST W CONTRAST OP	{'CT'}	{'MIDRC-Open-R1'}	{'MIDRC'}	1
-CT CHEST W CONT PULMONARY ARTERIES FOR PE	{'CT'}	{'MIDRC-Open-A1_PETAL_REDCORAL'}	{'MIDRC'}	1
-CT CHEST W CON OP	{'CT'}	{'MIDRC-Open-R1'}	{'MIDRC'}	1
-CT CHEST W AND WO IV CONTRAST	{'CT'}	{'MIDRC-Open-A1'}	{'MIDRC'}	1
-CT CHEST W ABDOMEN PELVIS WWO	{'CT'}	{'MIDRC-Open-A1'}	{'MIDRC'}	1
-MRI BREAST BILATERAL WO W IV CONTRAST	{'MR'}	{'MIDRC-Open-A1'}	{'MIDRC'}	1
-breast^Breast Clinical Trial	{'MR'}	{'ACRdart-EA1141Restricted'}	{'ACRdart'}	1
-breast^DENSE BREAST RESEARCH	{'MR'}	{'ACRdart-EA1141Restricted'}	{'ACRdart'}	1
-CT CAP IP	{'CT'}	{'MIDRC-Open-R1'}	{'MIDRC'}	1
-CT CHEST SCREENING FOR LUNG CANCER	{'CT'}	{'MIDRC-Open-A1'}	{'MIDRC'}	1
-CT CHEST SCREENING	{nan}	{'TCIA-varepop-apollo'}	{'TCIA'}	1
-Abdomen^ABD_WITHXXL_GR (Adult)	{'CT'}	{'MIDRC-Open-A1'}	{'MIDRC'}	1
-CT CHEST RADIATION ONCOLOGY	{'CT'}	{'AIMI-COCA'}	{'AIMI'}	1
-MRI - BREAST BILATERAL WITHOUT AND WITH IV CONTRAST	{'MR'}	{'ACRdart-EA1141Restricted'}	{'ACRdart'}	1
-Abdomen^ABD_WWO_renalmass_GR (Adult)	{'CT'}	{'MIDRC-Open-A1'}	{'MIDRC'}	1
-CT CHEST PULMONARY EMBOLISM (CTPE) (S)	{'CT'}	{'MIDRC-Open-R1'}	{'MIDRC'}	1
-Abdomen^AVERAGE_CTU_OVER_60 (Adult)	{nan}	{'TCIA-varepop-apollo'}	{'TCIA'}	1
-Abdomen^AVERAGE_PELVIS_WITHOUT_IV_CONTRAST (Adult)	{nan}	{'TCIA-varepop-apollo'}	{'TCIA'}	1
-MRI BREAST BILATERAL ABREV. NRMC	{'MR'}	{'ACRdart-EA1141Restricted'}	{'ACRdart'}	1
-CT CHEST OUTSIDE WITH INTERPRETATION OR CONSULT	{'CT'}	{'MIDRC-Open-A1_PETAL_BLUECORAL'}	{'MIDRC'}	1
-CT CAP W TRAUMA	{'CT'}	{'MIDRC-Open-R1'}	{'MIDRC'}	1
-MRI BREAST BILATERAL ABREV.	{'MR'}	{'IDC-IDC_ea1141'}	{'IDC'}	1
-Abdomen^AB02A_AP_W (Adult)	{'CT'}	{'MIDRC-Open-A1_PETAL_BLUECORAL'}	{'MIDRC'}	1
-MRI BREAST UNILATERAL	{nan}	{'TCIA-tcga-brca'}	{'TCIA'}	1
-CT CHEST W/O & W IV CON	{'CT'}	{'MIDRC-Open-R1'}	{'MIDRC'}	1
-MR SHOULDER LEFT WO CONTRAST	{'MR'}	{'MIDRC-Open-A1'}	{'MIDRC'}	1
-MR RT BREAST WO/W CONT/6657	{'SEG'}	{'IDC-IDC_ispy1'}	{'IDC'}	1
-Abdomen^13_TRAUMA_CAP (Adult)	{'CT'}	{'MIDRC-Open-A1'}	{'MIDRC'}	1
-MRI Breast w Contrast bilat BIRADS	{'MR'}	{'ACRdart-EA1141Restricted'}	{'ACRdart'}	1
-MR Research wo w 15 minutes	{'MR'}	{'ACRdart-EA1141Restricted'}	{'ACRdart'}	1
-Abdomen^STONE_LOW_DOSE_1 (Adult)	{'CT'}	{'MIDRC-Open-A1'}	{'MIDRC'}	1
-MR Research wo w 45 minutes	{'MR'}	{'ACRdart-EA1141Restricted'}	{'ACRdart'}	1
-MR Research wo w 60 minutes	{'MR'}	{'ACRdart-ACRIN_6701'}	{'ACRdart'}	1
-MR SACROILIAC JOINTS WITHOUT CONTRAST (S)	{'MR'}	{'MIDRC-Open-R1'}	{'MIDRC'}	1
-Abdomen^STONE_FULL (Adult)	{'CT'}	{'MIDRC-Open-A1'}	{'MIDRC'}	1
-MRI Breast Bil - with and without Contrast	{'MR'}	{'ACRdart-EA1141Restricted'}	{'ACRdart'}	1
-CT CHEST WITHOUT CONTRAST WITH OR WITHOUT 2D RECON	{'CT'}	{'MIDRC-Open-A1_PETAL_BLUECORAL'}	{'MIDRC'}	1
-CT Angio Abdomen and Pelvis	{'CT'}	{'MIDRC-Open-A1_PETAL_BLUECORAL'}	{'MIDRC'}	1
-CT Angio Chest W+/or WO + Recon	{'CT'}	{'MIDRC-Open-A1_PETAL_BLUECORAL'}	{'MIDRC'}	1
-MRI BRST ABBR	{'MR'}	{'ACRdart-EA1141Restricted'}	{'ACRdart'}	1
-MR WHOLE BODY PEDIATRIC WITHOUT CONTRAST	{'MR'}	{'MIDRC-Open-R1'}	{'MIDRC'}	1
-MR SPINE CERVICAL WO CONTRAST	{'MR'}	{'MIDRC-Open-A1'}	{'MIDRC'}	1
-CT CHEST WITH CONTRAST (O)	{'CT'}	{'MIDRC-Open-R1'}	{'MIDRC'}	1
-MR SPINE THORACIC WO CONTRAST	{'MR'}	{'MIDRC-Open-A1'}	{'MIDRC'}	1
-CT CHEST WITH CONTR	{'CT'}	{'MIDRC-Open-R1'}	{'MIDRC'}	1
-CT CHEST WITH CONT	{'CT'}	{'MIDRC-Open-R1'}	{'MIDRC'}	1
-MRI BREAST, UNILATERAL	{'MR'}	{'IDC-IDC_tcga_brca'}	{'IDC'}	1
-MR THORACIC SPINE WITH CONTRAST	{'MR'}	{'MIDRC-Open-R1'}	{'MIDRC'}	1
-MR THORACIC SPINE WITHOUT CONTRAST	{'MR'}	{'MIDRC-Open-R1'}	{'MIDRC'}	1
-Abdomen^ROUTINE_AP_WITH_OVER_50_OVER_250 (Adult)	{'CT'}	{'MIDRC-Open-A1'}	{'MIDRC'}	1
-MRI BREAST WITH AND W/O CONTRAST-BILATERAL	{'MR'}	{'ACRdart-EA1141Restricted'}	{'ACRdart'}	1
-MRI BREAST W/WO CONT 6657	{'SEG'}	{'IDC-IDC_ispy1'}	{'IDC'}	1
-MR TOTAL SPINE WITH AND WITHOUT CONTRAST (S)	{'MR'}	{'MIDRC-Open-R1'}	{'MIDRC'}	1
-CT BRAIN WITH AND WITHOUT CONTRAST (S)	{'CT'}	{'MIDRC-Open-R1'}	{'MIDRC'}	1
-ct chest abdomen pelvi	{'CT'}	{'MIDRC-Open-R1'}	{'MIDRC'}	1
-CT CAP W/ DYE	{nan}	{'TCIA-varepop-apollo'}	{'TCIA'}	1
-CT CHEST LUNG CANCER SCREENING LOW DOSE W/O CM	{'CT'}	{'MIDRC-Open-A1'}	{'MIDRC'}	1
-CT CHEST ABDOMEN AND PELVIS WITHOUT IV CONTRAST	{'CT'}	{'MIDRC-Open-A1_PETAL_BLUECORAL'}	{'MIDRC'}	1
-CT CERVICAL SPINE NERVE BLOCK 1 LEVEL	{'CT'}	{'MIDRC-Open-R1'}	{'MIDRC'}	1
-CT CERVICAL SPINE WITHOUT IV CONTRAST	{'CT'}	{'MIDRC-Open-A1_SCCM_VIRUS'}	{'MIDRC'}	1
-jhn ct chest wo op	{'CT'}	{'MIDRC-Open-R1'}	{'MIDRC'}	1
-Abdomen^CT_AP_WITH_L_SPINE_MPRS (Adult)	{'CT'}	{'MIDRC-Open-A1'}	{'MIDRC'}	1
-CT CHEST ABDOMEN PELVIS W WO CONTRAST (S)	{'CT'}	{'MIDRC-Open-R1'}	{'MIDRC'}	1
-MRI ABDOMEN W/O&W/DYE	{nan}	{'TCIA-varepop-apollo'}	{'TCIA'}	1
-Abdomen^HEMATURIA_GREATERTHAN45 (Adult)	{'CT'}	{'MIDRC-Open-A1'}	{'MIDRC'}	1
-Abdomen^CT_MARKS_CAILLAT_AP_RENAL (Adult)	{'CT'}	{'MIDRC-Open-A1'}	{'MIDRC'}	1
-Abdomen^CT_UROGRAM_STONE (Adult)	{'CT'}	{'MIDRC-Open-A1'}	{'MIDRC'}	1
-CT CHEST ABDOMEN PELVIS ANGIOGRAM WITH IV CONTRAST	{'CT'}	{'MIDRC-Open-A1_SCCM_VIRUS'}	{'MIDRC'}	1
-MRI BRAIN, MRA BRAIN, MRA NECK - WITHOUT CONTRAST FOCUSED STROKE	{'MR'}	{'MIDRC-Open-R1'}	{'MIDRC'}	1
-MRI BRAIN, MRA BRAIN, MRA NECK - WITHOUT AND WITH CONTRAST (S)	{'MR'}	{'MIDRC-Open-R1'}	{'MIDRC'}	1
-mammogram/ultrasiund exam	{'US'}	{'ACRdart-ACRIN_6666'}	{'ACRdart'}	1
-CT CHEST ABDOMEN AND PELVIS WITH IV CONTRAST	{'CT'}	{'MIDRC-Open-A1_PETAL_BLUECORAL'}	{'MIDRC'}	1
-CT CHEST ABDOMEN W CONTRAST (PANCREAS)	{'CT'}	{'MIDRC-Open-A1'}	{'MIDRC'}	1
-Abdomen^DE_CTA_AAA (Adult)	{'CT'}	{'MIDRC-Open-A1'}	{'MIDRC'}	1
-MRI BRACHIAL PLEXUS WO/W CONTRAST - LEFT SIDE	{'MR'}	{'MIDRC-Open-A1'}	{'MIDRC'}	1
-CT CHEST ABD PELVIS W O CONTRAST	{'CT'}	{'MIDRC-Open-A1_PETAL_REDCORAL'}	{'MIDRC'}	1
-Abdomen^DE_ROUTINE_AP_WITH_UNDER_50 (Adult)	{'CT'}	{'MIDRC-Open-A1'}	{'MIDRC'}	1
-CT CHEST (PULMONARY EMBOLISM) PELVIS LOWER EXTREMITY BILATERAL (	{'CT'}	{'MIDRC-Open-A1_PETAL_REDCORAL'}	{'MIDRC'}	1
-CT CHEST (HIGH RESOLUTION) WITHOUT CONTRAST	{'CT'}	{'MIDRC-Open-A1_PETAL_BLUECORAL'}	{'MIDRC'}	1
-CT CHEST (CPT=71250)	{'CT'}	{'MIDRC-Open-A1'}	{'MIDRC'}	1
-Abdomen^DUAL_PHASE_ABDOMEN (Adult)	{'CT'}	{'MIDRC-Open-A1'}	{'MIDRC'}	1
-/BD/PRO Pelvis w	{nan}	{'TCIA-qin-prostate-repeatability'}	{'TCIA'}	1
-MRI ANKLE W/O CONTRAST - RIGHT	{'MR'}	{'MIDRC-Open-A1'}	{'MIDRC'}	1
-Abdomen^HEMATURIA_45_and_UNDER (Adult)	{'CT'}	{'MIDRC-Open-A1'}	{'MIDRC'}	1
-CT CHEST  W/O 71250	{'CT'}	{'MIDRC-Open-R1'}	{'MIDRC'}	1
-Abdomen^GH_AbdomenRoutine (Adult)	{'CT'}	{'MIDRC-Open-A1_SCCM_VIRUS'}	{'MIDRC'}	1
-Abdomen^CT_AP_GI_BLEED_ISCHEMIC_BOWEL_WWO (Adult)	{'CT'}	{'MIDRC-Open-A1'}	{'MIDRC'}	1
-Abdomen^CT_ABDOMEN_WITH (Adult)	{'CT'}	{'MIDRC-Open-A1'}	{'MIDRC'}	1
-CT CAP W/ WT lOSS OP	{'CT'}	{'MIDRC-Open-R1'}	{'MIDRC'}	1
-e+1 CT T SPINE RECON	{'CT'}	{'MIDRC-Open-R1'}	{'MIDRC'}	1
-CT CHEST IV IP	{'CT'}	{'MIDRC-Open-R1'}	{'MIDRC'}	1
-CT CHEST HRCT NO IVCON	{'CT'}	{'MIDRC-Open-A1_PETAL_BLUECORAL'}	{'MIDRC'}	1
-CT CHEST HIGH RESOLUTION (S)	{'CT'}	{'MIDRC-Open-R1'}	{'MIDRC'}	1
-e+1 CT ANGIO CHEST W	{'CT'}	{'MIDRC-Open-A1'}	{'MIDRC'}	1
-e+1 CT CHEST ABDOMEN PELVIS WITHOUT CONTRAST	{'CT'}	{'MIDRC-Open-R1'}	{'MIDRC'}	1
-e+1 CT CHEST ABDOMEN PELVIS WO	{'CT'}	{'MIDRC-Open-A1'}	{'MIDRC'}	1
-e+1 CT CHEST W	{'CT'}	{'MIDRC-Open-R1'}	{'MIDRC'}	1
-e+1 CT CHEST WITHOUT CONTRAST	{'CT'}	{'MIDRC-Open-R1'}	{'MIDRC'}	1
-e+1 CT CHEST WO	{'CT'}	{'MIDRC-Open-A1'}	{'MIDRC'}	1
-CT CAP W/DYE	{nan}	{'TCIA-varepop-apollo'}	{'TCIA'}	1
-CT CHEST HI-RESOLUTION W/O IV CONTRAST	{'CT'}	{'MIDRC-Open-R1'}	{'MIDRC'}	1
-CT CHEST FOR NODULE	{'CT'}	{'MIDRC-Open-R1'}	{'MIDRC'}	1
-e+1 CT SOFT TISSUE NECK W CONTRAST	{'CT'}	{'MIDRC-Open-R1'}	{'MIDRC'}	1
-e+1 CTA ANGIO NECK	{'CT'}	{'MIDRC-Open-R1'}	{'MIDRC'}	1
-e+2 PET LYMPHOMA HODGKINS	{'PT,CT'}	{'MIDRC-Open-A1'}	{'MIDRC'}	1
-e+1 CTA CHEST (PE STUDY) W CONTRAST	{'CT'}	{'MIDRC-Open-A1'}	{'MIDRC'}	1
-e+1 CTA CHEST WO/W	{'CT'}	{'MIDRC-Open-A1'}	{'MIDRC'}	1
-e+1 CTA dissection	{'CT'}	{'MIDRC-Open-A1'}	{'MIDRC'}	1
-MRI BREAST BILAT WO/W?	{'SEG'}	{'IDC-IDC_ispy1'}	{'IDC'}	1
-Abdomen^CTA_ABD_PEL_RUNOFF_UNDER_250LB_Customized (Adult)	{'CT'}	{'MIDRC-Open-A1'}	{'MIDRC'}	1
-MRI BREAST BILAT WO/W CONTR	{'MR'}	{'IDC-IDC_ispy1'}	{'IDC'}	1
-e+1 Head	{'CT'}	{'MIDRC-Open-A1'}	{'MIDRC'}	1
-CT CAP WITH CONTRAST	{'CT'}	{'MIDRC-Open-R1'}	{'MIDRC'}	1
-CT CHEST ANGIOGRAM IMAGE IMPORT	{'CT'}	{'MIDRC-Open-A1_PETAL_BLUECORAL'}	{'MIDRC'}	1
-Abdomen^CTA_RUNOFF (Adult)	{'CT'}	{'MIDRC-Open-A1'}	{'MIDRC'}	1
-e+1 ct chest abdomen pelvi	{'CT'}	{'MIDRC-Open-R1'}	{'MIDRC'}	1
-e+1 ct chest abdomen pelvis with contrast	{'CT'}	{'MIDRC-Open-R1'}	{'MIDRC'}	1
-CT CHEST ABDOMEN WO CO	{'CT'}	{'MIDRC-Open-A1'}	{'MIDRC'}	1
-CT CHEST WWO CONT	{'CT'}	{'MIDRC-Open-A1_PETAL_BLUECORAL'}	{'MIDRC'}	1
-CT CHEST W_ ABDOMEN PELVIS WWO	{'CT'}	{'MIDRC-Open-R1'}	{'MIDRC'}	1
-_t4of4_MR IAMs	{nan}	{'TCIA-vestibular-schwannoma-mc-rc'}	{'TCIA'}	1
-MR FACE, NASO, NECK WITH AND WITHOUT CONTRAST (S)	{'MR'}	{'MIDRC-Open-R1'}	{'MIDRC'}	1
-MR ELASTOGRAPHY OF THE ABDOMEN WITH AND WITHOUT CONTRAST	{'MR'}	{'MIDRC-Open-R1'}	{'MIDRC'}	1
-MR ELASTOGRAPHY OF THE ABDOMEN WITHOUT CONTRAST	{'MR'}	{'MIDRC-Open-R1'}	{'MIDRC'}	1
-XR SPINE LUMBAR (LATERAL ONLY FLEX/EX)	{'CR'}	{'MIDRC-Open-A1'}	{'MIDRC'}	1
-XR SPINE LUMBAR (LATERAL ONLY)	{'CR'}	{'MIDRC-Open-A1'}	{'MIDRC'}	1
-XR SPINE THORACIC (3 VIEWS - AP+LAT BENDING)	{'CR'}	{'MIDRC-Open-A1'}	{'MIDRC'}	1
-XR SPINE THORACIC (3 VIEWS)	{'CR'}	{'MIDRC-Open-A1'}	{'MIDRC'}	1
-CT EXAM SPLIT W/CON	{nan}	{'TCIA-varepop-apollo'}	{'TCIA'}	1
-XR SPINE THORACIC (AP+LAT, SUP/UPRIGHT)	{'DX'}	{'MIDRC-Open-A1'}	{'MIDRC'}	1
-XR STERNUM 2+ VIEWS	{'DX'}	{'MIDRC-Open-A1'}	{'MIDRC'}	1
-MR FACE, NASO, NECK WITH AND WITHOUT CONTRAST	{'MR'}	{'MIDRC-Open-R1'}	{'MIDRC'}	1
-XR Spine Thoracic 2 Views	{'CR'}	{'MIDRC-Open-A1_PETAL_BLUECORAL'}	{'MIDRC'}	1
-XR THIGH/FEMUR LEFT 2V	{'DX'}	{'MIDRC-Open-A1'}	{'MIDRC'}	1
-XR THIGH/FEMUR RIGHT 2V	{'DX'}	{'MIDRC-Open-A1'}	{'MIDRC'}	1
-XR THORACIC SPINE 3 VIEWS	{'CR'}	{'MIDRC-Open-A1'}	{'MIDRC'}	1
-CT FACE/SINUSES (BRAINLAB) W* CONTRAST	{'CT'}	{'MIDRC-Open-A1'}	{'MIDRC'}	1
-CT ENTEROGRAPHY DONE AT WAKE FOREST BAPTIST IMAGING	{'CT'}	{'MIDRC-Open-A1'}	{'MIDRC'}	1
-XR THORACOLUMBAR SPINE AP AND LATERAL	{'DX'}	{'MIDRC-Open-R1'}	{'MIDRC'}	1
-XR THORACOLUMBAR SPINE STANDING 2 OR 3 VIEWS	{'DX'}	{'MIDRC-Open-R1'}	{'MIDRC'}	1
-XR THUMB RIGHT	{'CR'}	{'MIDRC-Open-A1'}	{'MIDRC'}	1
-XR TOES RIGHT (SPECIFY DIGITS)	{'DX'}	{'MIDRC-Open-A1'}	{'MIDRC'}	1
-XR WRIST 3+ VIEWS	{'DX'}	{'MIDRC-Open-A1'}	{'MIDRC'}	1
-XR WRIST LEFT (LIMITED: AP,LAT)	{'DX'}	{'MIDRC-Open-A1'}	{'MIDRC'}	1
-MR FOOT (FOREFOOT) RIGHT WO CONTRAST	{'MR'}	{'MIDRC-Open-A1'}	{'MIDRC'}	1
-MR GUIDED BREAST BIOPSY	{'MR'}	{'ACRdart-EA1141Restricted'}	{'ACRdart'}	1
-XR WRIST RIGHT (SCAPHOID VIEW)	{'DX'}	{'MIDRC-Open-A1'}	{'MIDRC'}	1
-BILAT BREAST US	{'US'}	{'ACRdart-ACRIN_6666'}	{'ACRdart'}	1
-CT DIAGNOSTIC COLONOSCOPY	{'CT'}	{'MIDRC-Open-R1'}	{'MIDRC'}	1
-CT ANGIO ABDOMINAL ARTERIES	{nan}	{'TCIA-varepop-apollo'}	{'TCIA'}	1
-CT ANG CHEST, ABD, PEL WWO	{'CT'}	{'MIDRC-Open-R1'}	{'MIDRC'}	1
-XR SPINE CERVICAL (LATERAL ONLY - FLEX/EX)	{'DX'}	{'MIDRC-Open-A1'}	{'MIDRC'}	1
-CT SOFT TISSUE NECK W/DYE	{nan}	{'TCIA-varepop-apollo'}	{'TCIA'}	1
-CT ABDOMEN/PELVIS WITH CONTRAST (O)	{'CT'}	{'MIDRC-Open-R1'}	{'MIDRC'}	1
-XR RIGHT HIP 1 VIEW PORTABLE	{'CR'}	{'MIDRC-Open-A1'}	{'MIDRC'}	1
-BIOPSY BREAST-PERC NEEDLE AUTOMATED	{'US'}	{'ACRdart-ACRIN_6666'}	{'ACRdart'}	1
-CT HEAD W/O CONT	{nan}	{'TCIA-varepop-apollo'}	{'TCIA'}	1
-BILATERAL KNEE 3 VIEWS-CS	{'CR'}	{'MIDRC-Open-A1'}	{'MIDRC'}	1
-BILATERAL FOOT AP&LAT-CS	{'CR'}	{'MIDRC-Open-A1'}	{'MIDRC'}	1
-Abdomen GU,Abdomen	{'CR'}	{'MIDRC-Open-R1'}	{'MIDRC'}	1
-BILATERAL DIAGNOSTIC PLUS TOMO	{'MG'}	{'ACRdart-EA1141Restricted'}	{'ACRdart'}	1
-XR RIGHT KNEE 4+ VIEWS	{'DX'}	{'MIDRC-Open-A1'}	{'MIDRC'}	1
-CT HEAD	{'CT'}	{'MIDRC-Open-A1'}	{'MIDRC'}	1
-XR RIGHT RIBS 2 VIEWS UNILATERAL	{'DX'}	{'MIDRC-Open-A1'}	{'MIDRC'}	1
-MR CERVICAL SPINE WITH AND WITHOUT CONTRAST (S)	{'MR'}	{'MIDRC-Open-R1'}	{'MIDRC'}	1
-MR CERVICAL SPINE WITH CONTRAST	{'MR'}	{'MIDRC-Open-R1'}	{'MIDRC'}	1
-XR RIGHT THUMB	{'CR'}	{'MIDRC-Open-A1'}	{'MIDRC'}	1
-CT ABDOMEN/PELVIS WITHOUT CONTRAST (O)	{'CT'}	{'MIDRC-Open-R1'}	{'MIDRC'}	1
-XR SPINE CERVICAL (AP+LAT+OBLS+SWIM+ODONTOID)	{'CR'}	{'MIDRC-Open-A1'}	{'MIDRC'}	1
-CT GUIDED CHEST LUNG B	{'CT'}	{'MIDRC-Open-A1_PETAL_BLUECORAL'}	{'MIDRC'}	1
-XR SACROILIAC JOINTS 3+ VIEWS	{'DX'}	{'MIDRC-Open-A1'}	{'MIDRC'}	1
-XR SCAPULA RIGHT	{'CR'}	{'MIDRC-Open-A1'}	{'MIDRC'}	1
-XR SCOLIOSIS STUDY 2 OR 3 VIEWS (NEURO INTERPRETATION)	{'DX'}	{'MIDRC-Open-R1'}	{'MIDRC'}	1
-XR SCOLIOSIS STUDY 4 OR 5 VIEWS	{'DX'}	{'MIDRC-Open-R1'}	{'MIDRC'}	1
-XR SCOLIOSIS STUDY MINIMUM OF 6 VIEWS	{'DX'}	{'MIDRC-Open-R1'}	{'MIDRC'}	1
-CT GUIDED BIOPSY LUNG MEDIASTINUM	{'CT'}	{'MIDRC-Open-R1'}	{'MIDRC'}	1
-XR SHOULDER 2+ VIEWS	{'CR'}	{'MIDRC-Open-A1'}	{'MIDRC'}	1
-XR SHOULDER LEFT (COMPLETE: IR/ER/GRASHEY/Y/AXILLARY)	{'CR'}	{'MIDRC-Open-A1'}	{'MIDRC'}	1
-XR SHOULDER LT 2 OR MORE VIEWS	{'DX'}	{'MIDRC-Open-A1'}	{'MIDRC'}	1
-XR SHOULDER RIGHT (COMPLETE: IR/ER/GRASHEY/Y/AXILLARY)	{'CR'}	{'MIDRC-Open-A1'}	{'MIDRC'}	1
-MR CONGENITAL HEART DISORDER WITH AND WITHOUT CONTRAST	{'MR'}	{'MIDRC-Open-R1'}	{'MIDRC'}	1
-XR SPINE CERVICAL (4 VIEWS - AP+LAT+FLEX/EX)*	{'DX'}	{'MIDRC-Open-A1'}	{'MIDRC'}	1
-MRI PRE&POST INF BREASTMR	{'MR'}	{'IDC-IDC_ispy1'}	{'IDC'}	1
-XR_WholeBody	{nan}	{'TCIA-cmb-mml'}	{'TCIA'}	1
-_t4of4_MR IAM's	{'MR'}	{'IDC-IDC_vestibular_schwannoma_mc_rc'}	{'IDC'}	1
-MRI GUIDED BREAST BIOPSY AUT VAC ROT RIGHT	{'MR'}	{'ACRdart-EA1141Restricted'}	{'ACRdart'}	1
-MRI LOWER EXTREMITY JOINT W/O CONTRAST - RIGHT	{'MR'}	{'MIDRC-Open-A1'}	{'MIDRC'}	1
-MRI LOWER EXTREMITY JOINT W/O CONTRAST - LEFT	{'MR'}	{'MIDRC-Open-A1'}	{'MIDRC'}	1
-MRI LIVER WO/W CONTRAST	{'MR'}	{'MIDRC-Open-A1'}	{'MIDRC'}	1
-MRI LIVER W/O CONTRAST WITH ELASTOGRAPHY	{'MR'}	{'MIDRC-Open-A1'}	{'MIDRC'}	1
-MRI LIVER METS WITH AND WITHOUT EOVIST	{'MR'}	{'MIDRC-Open-R1'}	{'MIDRC'}	1
-MR ORBIT WITH AND WITHOUT CONTRAST	{'MR'}	{'MIDRC-Open-R1'}	{'MIDRC'}	1
-CT CODE STROKE CTA	{'CT'}	{'MIDRC-Open-A1'}	{'MIDRC'}	1
-MRI L SPINE	{'MR'}	{'MIDRC-Open-A1'}	{'MIDRC'}	1
-CT CHST/ABD/PEL W/IV CONTRAST	{'CT'}	{'MIDRC-Open-A1_PETAL_REDCORAL'}	{'MIDRC'}	1
-CT CHEST/ABDOMEN/PELVIS W/CONTRAST	{'CT'}	{'MIDRC-Open-R1'}	{'MIDRC'}	1
-MRI JNT OF LWR EXTRE W/O DYE - LEFT	{nan}	{'TCIA-varepop-apollo'}	{'TCIA'}	1
-Adult Chest - 2 Views	{'DX'}	{'MIDRC-Open-R1'}	{'MIDRC'}	1
-MRI HAND WITHOUT CONTRAST-RIGHT	{'MR'}	{'MIDRC-Open-A1'}	{'MIDRC'}	1
-Acute Abd child	{'DX'}	{'MIDRC-Open-A1'}	{'MIDRC'}	1
-CT ANGIOGRAPHY CHEST WITH CONTRAST PULMEMB	{'CT'}	{'MIDRC-Open-A1_PETAL_REDCORAL'}	{'MIDRC'}	1
-MRI FOOT (FOREFOOT) WITHOUT CONTRAST -RIGHT	{'MR'}	{'MIDRC-Open-A1'}	{'MIDRC'}	1
-MR PROSTATE W ENDORECTAL COIL	{'SEG'}	{'IDC-IDC_prostate_mri_us_biopsy'}	{'IDC'}	1
-MRI ENTEROGRAPHY WO/W CONTRAST	{'MR'}	{'MIDRC-Open-A1'}	{'MIDRC'}	1
-MRI ELASTOGRAPHY	{'MR'}	{'MIDRC-Open-A1'}	{'MIDRC'}	1
-_t3of4_MR IAM's	{'MR'}	{'IDC-IDC_vestibular_schwannoma_mc_rc'}	{'IDC'}	1
-_t3of4_MR IAMs	{nan}	{'TCIA-vestibular-schwannoma-mc-rc'}	{'TCIA'}	1
-CT CHEST-ABD-PELV W/O CM	{'CT'}	{'MIDRC-Open-A1'}	{'MIDRC'}	1
-CT CHEST-ABD-PELV W/ CM	{'CT'}	{'MIDRC-Open-A1'}	{'MIDRC'}	1
-Abdomen^10_STONE_STUDY (Adult)	{'CT'}	{'MIDRC-Open-A1'}	{'MIDRC'}	1
-CT CHEST, ABDOMEN, PEL	{'CT'}	{'MIDRC-Open-A1_PETAL_REDCORAL'}	{'MIDRC'}	1
-CT CHEST, ABDOMEN & PELVIS WO CONTRAST	{'CT'}	{'MIDRC-Open-A1_PETAL_BLUECORAL'}	{'MIDRC'}	1
-CT CHEST, ABDOMEN & PELVIS W/ 74177,71260,Q9967	{'CT'}	{'MIDRC-Open-R1'}	{'MIDRC'}	1
-Abdomen^STONE_XXL (Adult)	{'CT'}	{'MIDRC-Open-A1'}	{'MIDRC'}	1
-MRI LOWER EXTREMITY NON JOINT WO/W IV CONTRAST - LEFT	{'MR'}	{'MIDRC-Open-A1'}	{'MIDRC'}	1
-_t1of9_MR IAMs	{nan}	{'TCIA-vestibular-schwannoma-mc-rc'}	{'TCIA'}	1
-CT ANGIO CHEST PE	{'CT'}	{'MIDRC-Open-A1_PETAL_REDCORAL'}	{'MIDRC'}	1
-_t1of4_MR IAMs	{nan}	{'TCIA-vestibular-schwannoma-mc-rc'}	{'TCIA'}	1
-CT ANGIO CHEST WITH ECG GATING	{'CT'}	{'MIDRC-Open-R1'}	{'MIDRC'}	1
-CT ANGIO CHEST/ABD/PELVIS	{'CT'}	{'MIDRC-Open-A1_PETAL_BLUECORAL'}	{'MIDRC'}	1
-CT ANGIO CHST/ABD/PEL W/WO CONTRAST	{'CT'}	{'MIDRC-Open-A1_PETAL_REDCORAL'}	{'MIDRC'}	1
-CT ANGIO HEAD W OR WO CONTRAST	{'CT'}	{'MIDRC-Open-A1'}	{'MIDRC'}	1
-_t1of2_MR IAM's	{'MR'}	{'IDC-IDC_vestibular_schwannoma_mc_rc'}	{'IDC'}	1
-_t1of2_MR IAMs	{nan}	{'TCIA-vestibular-schwannoma-mc-rc'}	{'TCIA'}	1
-MRI PELVIS SOFT TISSUE W/O CONTRAST	{'MR'}	{'MIDRC-Open-A1'}	{'MIDRC'}	1
-MRI OF THE ABDOMEN WITH AND WITHOUT CONTRAST	{nan}	{'TCIA-varepop-apollo'}	{'TCIA'}	1
-CT ANGIO NECK	{'CT'}	{'MIDRC-Open-A1_PETAL_REDCORAL'}	{'MIDRC'}	1
-MRI OF LUMBAR SPINE WITHOUT CONTRAST	{nan}	{'TCIA-varepop-apollo'}	{'TCIA'}	1
-CT Chest WO	{'CT'}	{'MIDRC-Open-R1'}	{'MIDRC'}	1
-CT ANGIOGRAM CHEST W CONTRAST	{'CT'}	{'MIDRC-Open-A1_PETAL_REDCORAL'}	{'MIDRC'}	1
-_t1of4_MR IAM's	{'MR'}	{'IDC-IDC_vestibular_schwannoma_mc_rc'}	{'IDC'}	1
-MRI NECK SPINE W/O DYE	{nan}	{'TCIA-varepop-apollo'}	{'TCIA'}	1
-_t1of9_MR IAM's	{'MR'}	{'IDC-IDC_vestibular_schwannoma_mc_rc'}	{'IDC'}	1
-CT ANGIOGRAM CHEST W W	{'CT'}	{'MIDRC-Open-R1'}	{'MIDRC'}	1
-_t1of5_MR IAM's	{'MR'}	{'IDC-IDC_vestibular_schwannoma_mc_rc'}	{'IDC'}	1
-_t1of5_MR IAMs	{nan}	{'TCIA-vestibular-schwannoma-mc-rc'}	{'TCIA'}	1
-CT ANGIOGRAM CHEST [CH]	{'CT'}	{'MIDRC-Open-A1_PETAL_BLUECORAL'}	{'MIDRC'}	1
-CT Chest W	{'CT'}	{'MIDRC-Open-R1'}	{'MIDRC'}	1
-MRI MSK CHEST WALL WO/W CONTRAST	{'MR'}	{'MIDRC-Open-A1'}	{'MIDRC'}	1
-_t1of6_MR IAM's	{'MR'}	{'IDC-IDC_vestibular_schwannoma_mc_rc'}	{'IDC'}	1
-_t1of6_MR IAMs	{nan}	{'TCIA-vestibular-schwannoma-mc-rc'}	{'TCIA'}	1
-CT ANGIOGRAM LOWER EXTREMITY RIGHT W WO CONTRAST	{'CT'}	{'MIDRC-Open-R1'}	{'MIDRC'}	1
-MRI LUMBAR SPINE W/O DYE	{nan}	{'TCIA-varepop-apollo'}	{'TCIA'}	1
-MR LUMBAR SPINE WITH AND WITHOUT CONTRAST (S)	{'MR'}	{'MIDRC-Open-R1'}	{'MIDRC'}	1
-MR LUMBAR SPINE WITH CONTRAST	{'MR'}	{'MIDRC-Open-R1'}	{'MIDRC'}	1
-CT CT-Abdomen/Pelvis W/Contrast	{'CT'}	{'MIDRC-Open-A1_PETAL_BLUECORAL'}	{'MIDRC'}	1
-CT ANGIO AORTA RUNOFF	{'CT'}	{'MIDRC-Open-A1'}	{'MIDRC'}	1
-NM TC-HIDA SCAN	{'NM'}	{'MIDRC-Open-R1'}	{'MIDRC'}	1
-CT SPINE LUMBAR WOUT CON	{'CT'}	{'MIDRC-Open-A1_PETAL_BLUECORAL'}	{'MIDRC'}	1
-LT Foot	{'CR'}	{'MIDRC-Open-A1'}	{'MIDRC'}	1
-Skull, Sinus & Facial,Nasal & Orbits	{'CR'}	{'MIDRC-Open-R1'}	{'MIDRC'}	1
-CARDIAC MICS OP	{'CT'}	{'MIDRC-Open-R1'}	{'MIDRC'}	1
-LEFT US BREAST LIMITED	{'US'}	{'ACRdart-EA1141Restricted'}	{'ACRdart'}	1
-CARDIAC IP	{'CT'}	{'MIDRC-Open-R1'}	{'MIDRC'}	1
-LEFT WRIST-ROUTINE STUDY-CS	{'CR'}	{'MIDRC-Open-A1'}	{'MIDRC'}	1
-Specials^BX_PROCEDURE (Adult)	{'CT'}	{'MIDRC-Open-A1'}	{'MIDRC'}	1
-Specials^OVER_220_LBS_CHEST_LOW_DOSE (Adult)	{nan}	{'TCIA-varepop-apollo'}	{'TCIA'}	1
-Specials^Perfusion (Adult)	{'CT'}	{'MIDRC-Open-A1'}	{'MIDRC'}	1
-Spine^CT_LUMBAR_SPINE_WO (Adult)	{'CT'}	{'MIDRC-Open-A1'}	{'MIDRC'}	1
-Spine^C_Spine_Tin_Filter (Adult)	{'CT'}	{'MIDRC-Open-A1'}	{'MIDRC'}	1
-LOW DOSE LUNG CA SCRN 71271-CS	{'CT'}	{'MIDRC-Open-A1'}	{'MIDRC'}	1
-LOWER EXTREMITY^KNEE	{'MR'}	{'MIDRC-Open-A1'}	{'MIDRC'}	1
-LT APEX	{'CT'}	{'IDC-IDC_lctsc'}	{'IDC'}	1
-Sup MSK	{'US'}	{'ACRdart-ACRIN_6666'}	{'ACRdart'}	1
-LT LUNG/MEDIASTINUM	{'RTSTRUCT'}	{'IDC-IDC_lctsc'}	{'IDC'}	1
-Siemens AP	{nan}	{'TCIA-qiba-ct-liver-phantom'}	{'TCIA'}	1
-GASTROGRAFIN SINGLE CONTRAST ENEMA	{'RF'}	{'MIDRC-Open-R1'}	{'MIDRC'}	1
-T0 - US	{'US'}	{'ACRdart-ACRIN_6666'}	{'ACRdart'}	1
-GASTROGRAFIN CHALLENGE, ABDOMEN 1V, INITIAL	{'DX'}	{'MIDRC-Open-R1'}	{'MIDRC'}	1
-T0 6 MO F/U	{'US'}	{'ACRdart-ACRIN_6666'}	{'ACRdart'}	1
-T0 ultrasound	{'US'}	{'ACRdart-ACRIN_6666'}	{'ACRdart'}	1
-T1 -  F/U 1	{'US'}	{'ACRdart-ACRIN_6666'}	{'ACRdart'}	1
-T1 - 1 YR F/U	{'US'}	{'ACRdart-ACRIN_6666'}	{'ACRdart'}	1
-T1 - F/U 1 ultrasound	{'US'}	{'ACRdart-ACRIN_6666'}	{'ACRdart'}	1
-T1 - F/U1- ULTRASOUND	{'US'}	{'ACRdart-ACRIN_6666'}	{'ACRdart'}	1
-T1 - F/U1-additional images	{'US'}	{'ACRdart-ACRIN_6666'}	{'ACRdart'}	1
-CHEST X-RAY	{'DX'}	{'MIDRC-Open-R1'}	{'MIDRC'}	1
-T1 1 YR F/U	{'US'}	{'ACRdart-ACRIN_6666'}	{'ACRdart'}	1
-T1 ultrasound	{'US'}	{'ACRdart-ACRIN_6666'}	{'ACRdart'}	1
-Foot RT	{'DX'}	{'MIDRC-Open-R1'}	{'MIDRC'}	1
-Siemens PVP	{nan}	{'TCIA-qiba-ct-liver-phantom'}	{'TCIA'}	1
-Shoulder L	{'CR'}	{'MIDRC-Open-A1'}	{'MIDRC'}	1
-Femur / Joints L	{'CR'}	{'MIDRC-Open-A1'}	{'MIDRC'}	1
-CHEST VENOGRAM IP	{'CT'}	{'MIDRC-Open-R1'}	{'MIDRC'}	1
-CHEST PLAIN OP	{'CT'}	{'MIDRC-Open-R1'}	{'MIDRC'}	1
-CHEST PORT LINE TUBE PLCT 1 EXAM	{'CR'}	{'MIDRC-Open-A1_PETAL_BLUECORAL'}	{'MIDRC'}	1
-CHEST PORTABLE SINGLE VIEW	{'CR'}	{'MIDRC-Open-A1_PETAL_BLUECORAL'}	{'MIDRC'}	1
-Knee - 3 Views	{'DX'}	{'MIDRC-Open-A1'}	{'MIDRC'}	1
-Knee Lt.	{'CR'}	{'MIDRC-Open-A1'}	{'MIDRC'}	1
-HUP5 PROTOCOLS^NECK	{'MR'}	{'IDC-IDC_ispy1'}	{'IDC'}	1
-CHEST PULMONARY WITH	{'CT'}	{'MIDRC-Open-R1'}	{'MIDRC'}	1
-HIP RIGHT 1 VIEW	{'CR'}	{'MIDRC-Open-R1'}	{'MIDRC'}	1
-HIP LEFT MIN 2 VIEWS ORTHO (LATERAL AND AP HIP)	{'CR'}	{'MIDRC-Open-R1'}	{'MIDRC'}	1
-L MRI PRE&POST INF BREAMR	{'MR'}	{'IDC-IDC_ispy1'}	{'IDC'}	1
-CARDIAC TRIPLE OP	{'CT'}	{'MIDRC-Open-R1'}	{'MIDRC'}	1
-CHEST SINGLE VIEW	{'DX'}	{'MIDRC-Open-A1_PETAL_BLUECORAL'}	{'MIDRC'}	1
-CHEST SINGLE VIEW ADULT PORTABLE	{'DX'}	{'MIDRC-Open-A1_PETAL_REDCORAL'}	{'MIDRC'}	1
-L-SPINE(Adult)	{'CT'}	{'MIDRC-Open-A1'}	{'MIDRC'}	1
-L-SPINE^L-SP optimized	{'MR'}	{'MIDRC-Open-A1'}	{'MIDRC'}	1
-PETCT GENERIC (RESEARCH ONLY)	{'PT'}	{'MIDRC-Open-R1'}	{'MIDRC'}	1
-CHEST W/ OP	{'CT'}	{'MIDRC-Open-R1'}	{'MIDRC'}	1
-CHEST W/O IP	{'CT'}	{'MIDRC-Open-R1'}	{'MIDRC'}	1
-L-SpineLAT WALL	{'DX'}	{'MIDRC-Open-R1'}	{'MIDRC'}	1
-L/S SP W/OBL FLEX & EXTEN-CS	{'CR'}	{'MIDRC-Open-A1'}	{'MIDRC'}	1
-HAND RIGHT 3 VIEWS MIN	{'DX'}	{'MIDRC-Open-R1'}	{'MIDRC'}	1
-HAND 2 VIEWS LEFT	{'CR'}	{'MIDRC-Open-R1'}	{'MIDRC'}	1
-CHEST WC	{'CT'}	{'MIDRC-Open-A1_SCCM_VIRUS'}	{'MIDRC'}	1
-CARDIAC PV OP	{'CT'}	{'MIDRC-Open-R1'}	{'MIDRC'}	1
-GD CHEST ONE VIEW	{'DX'}	{'MIDRC-Open-R1'}	{'MIDRC'}	1
-LCMC XR ABDOMEN 1 VW	{'CR'}	{'MIDRC-Open-A1_PETAL_REDCORAL'}	{'MIDRC'}	1
-CARDIAC PUL VEIN OP	{'CT'}	{'MIDRC-Open-R1'}	{'MIDRC'}	1
-Screening Breast Tomosynthesis Bil	{'MG'}	{'ACRdart-EA1141Restricted'}	{'ACRdart'}	1
-LEFT FOOT - ROUTINE STUDY(RAD)-CS	{'CR'}	{'MIDRC-Open-A1'}	{'MIDRC'}	1
-LEFT HILUM	{'RTSTRUCT'}	{'IDC-IDC_lctsc'}	{'IDC'}	1
-Foot - 2 Views	{'DX'}	{'MIDRC-Open-R1'}	{'MIDRC'}	1
-LTLUNG UP DIBH	{'CT'}	{'IDC-IDC_lctsc'}	{'IDC'}	1
-Digital Diagnostic Mammogram Bilateral	{nan}	{'TCIA-breast-diagnosis'}	{'TCIA'}	1
-MRI Abdomen w/ + w/o Contrast	{'MR'}	{'MIDRC-Open-A1'}	{'MIDRC'}	1
-Lumbar spine	{'CR'}	{'MIDRC-Open-A1'}	{'MIDRC'}	1
-CHEST/PELVIS OP	{'CT'}	{'MIDRC-Open-R1'}	{'MIDRC'}	1
-TOMOSYNTHESIS MAMMO DIGITAL DIAGNOSTIC BILATERAL	{'MG'}	{'ACRdart-EA1141Restricted'}	{'ACRdart'}	1
-TOMOSYNTHESIS MAMMO DIGITAL DIAGNOSTIC LEFT	{'MG'}	{'IDC-IDC_ea1141'}	{'IDC'}	1
-TOMOSYNTHESIS MAMMO DIGITAL DIAGNOSTIC RIGHT	{'MG'}	{'IDC-IDC_ea1141'}	{'IDC'}	1
-TOSHIBA MEC	{nan}	{'TCIA-qiba-ct-1c'}	{'TCIA'}	1
-PET,HEAD&NECK CA INIT'	{'SEG'}	{'IDC-IDC_acrin_nsclc_fdg_pet'}	{'IDC'}	1
-PET,HEAD&NECK CA INIT	{nan}	{'TCIA-acrin-nsclc-fdg-pet'}	{'TCIA'}	1
-CHEST; 1V	{'CR'}	{'MIDRC-Open-A1_SCCM_VIRUS'}	{'MIDRC'}	1
-FDA  LCIT	{nan}	{'TCIA-qiba-ct-1c'}	{'TCIA'}	1
-CHESTWALL	{'RTSTRUCT'}	{'IDC-IDC_lctsc'}	{'IDC'}	1
-Thoracic spine	{'CR'}	{'MIDRC-Open-A1'}	{'MIDRC'}	1
-PET TUMOR IMAGING WITH GA-68 DOTATATE	{'PT,CT'}	{'MIDRC-Open-A1'}	{'MIDRC'}	1
-MA MAMMOGRAM DIAGNOSTIC BILATERAL W/TOMO	{'MG'}	{'ACRdart-EA1141Restricted'}	{'ACRdart'}	1
-ELBOW COMPLETE LEFT MIN 3 VIEWS	{'DX'}	{'MIDRC-Open-R1'}	{'MIDRC'}	1
-TO - INITIAL  ULTRASOUND	{'US'}	{'ACRdart-ACRIN_6666'}	{'ACRdart'}	1
-ELBOW	{'MR'}	{'MIDRC-Open-A1'}	{'MIDRC'}	1
-CAP IV ER	{'CT'}	{'MIDRC-Open-R1'}	{'MIDRC'}	1
-MAGNETIC IMAGE,LOWER EXTREMITY	{nan}	{'TCIA-varepop-apollo'}	{'TCIA'}	1
-Thorax^01_CHEST_ROUTINE_WO (Adult)	{'CT'}	{'MIDRC-Open-R1'}	{'MIDRC'}	1
-Thorax^01_CHEST_W_HR (Adult)	{'CT'}	{'MIDRC-Open-R1'}	{'MIDRC'}	1
-PET THYROID CANCER (W/	{'PT,CT'}	{'MIDRC-Open-A1'}	{'MIDRC'}	1
-Thorax^01_LG_CHEST_lowdose_WO_screenin (Adult)	{'CT'}	{'MIDRC-Open-R1'}	{'MIDRC'}	1
-MAM BILAT DIGITAL SCREENING W/CAD	{'MG'}	{'ACRdart-EA1141Restricted'}	{'ACRdart'}	1
-EC BILATERAL DIAGNOSTIC MAMMOGRAM WITH CAD	{'MG'}	{'ACRdart-EA1141Restricted'}	{'ACRdart'}	1
-Duke University Medical Center	{nan}	{'TCIA-qiba-ct-1c'}	{'TCIA'}	1
-PET SARCOMA (W/LOW DOSE CT)	{'PT,CT'}	{'MIDRC-Open-A1'}	{'MIDRC'}	1
-PET SARCOIDOSIS WITH N	{'PT,CT'}	{'MIDRC-Open-A1'}	{'MIDRC'}	1
-Digital Screening Mammogram Bilateral TOMO NRMC	{'MG'}	{'ACRdart-EA1141Restricted'}	{'ACRdart'}	1
-Digital Screening Mammogram	{'MG'}	{'ACRdart-EA1141Restricted'}	{'ACRdart'}	1
-TO INITIAL	{'US'}	{'ACRdart-ACRIN_6666'}	{'ACRdart'}	1
-TO - INITIAL	{'US'}	{'ACRdart-ACRIN_6666'}	{'ACRdart'}	1
-THORACIC SPINE 2 VIEWS	{'CR'}	{'MIDRC-Open-R1'}	{'MIDRC'}	1
-CAP W/WO OP	{'CT'}	{'MIDRC-Open-R1'}	{'MIDRC'}	1
-LUMBAR SACRAL SPINE MIN 4 VIEWS	{'CR'}	{'MIDRC-Open-R1'}	{'MIDRC'}	1
-THORACIC SPINE 3 VIEWS-CS	{'DX'}	{'MIDRC-Open-A1'}	{'MIDRC'}	1
-CHEST, LAT DECUB LT	{'CR'}	{'MIDRC-Open-R1'}	{'MIDRC'}	1
-LUMBOSACRAL SP W/OBL ROUTINE-CS	{'DX'}	{'MIDRC-Open-A1'}	{'MIDRC'}	1
-LUMBOSACRAL SPINE AP/LAT ONLY-CS	{'CR'}	{'MIDRC-Open-A1'}	{'MIDRC'}	1
-LUNG 4DCT	{'CT'}	{'IDC-IDC_lctsc'}	{'IDC'}	1
-CAP WO IP	{'CT'}	{'MIDRC-Open-R1'}	{'MIDRC'}	1
-FOREARM LEFT 2 VIEWS	{'CR'}	{'MIDRC-Open-R1'}	{'MIDRC'}	1
-THORAX/ZXL	{'CT'}	{'IDC-IDC_lctsc'}	{'IDC'}	1
-THORAX^CHEST_WO (ADULT)	{'CT'}	{'MIDRC-Open-A1'}	{'MIDRC'}	1
-TIBIA AND FIBULA LEFT 2 VIEWS	{'DX'}	{'MIDRC-Open-R1'}	{'MIDRC'}	1
-TIBIA AND FIBULA RIGHT 2 VIEWS	{'DX'}	{'MIDRC-Open-R1'}	{'MIDRC'}	1
-TIBIA AND FIBULA RT, 4 VWS OR MORE	{'CR'}	{'MIDRC-Open-R1'}	{'MIDRC'}	1
-FOOT LEFT MIN 3 VIEWS (ROUTINE)	{'CR'}	{'MIDRC-Open-R1'}	{'MIDRC'}	1
-FOOT 3+ VIEWS, LEFT	{'DX'}	{'MIDRC-Open-R1'}	{'MIDRC'}	1
-TO  - INITIAL ULTRASOUND	{'US'}	{'ACRdart-ACRIN_6666'}	{'ACRdart'}	1
-FOOT 2 VIEWS RIGHT	{'DX'}	{'MIDRC-Open-R1'}	{'MIDRC'}	1
-FNA, WITH IMAGING GUIDANCE - CT	{nan}	{'TCIA-varepop-apollo'}	{'TCIA'}	1
-FLUOROSCOPY CHEST W/SNIFF	{'RF'}	{'MIDRC-Open-R1'}	{'MIDRC'}	1
-CHEST/ABD-PEL 3PHASE IP	{'CT'}	{'MIDRC-Open-R1'}	{'MIDRC'}	1
-FL PYELOGRAM RETROGRADE INTRAOPERATIVE	{'CR'}	{'MIDRC-Open-A1'}	{'MIDRC'}	1
-FL KIDNEY RETROGRAD	{'RF'}	{'MIDRC-Open-R1'}	{'MIDRC'}	1
-FL HYSTEROSALPINGOGRAM	{'RF'}	{'MIDRC-Open-R1'}	{'MIDRC'}	1
-CAP W/O IP	{'CT'}	{'MIDRC-Open-R1'}	{'MIDRC'}	1
-FL ERCP CHOLANGIOGRAM PANCREATOGRAPHY	{'XA'}	{'MIDRC-Open-R1'}	{'MIDRC'}	1
-FINGER(S) LEFT 2 VIEWS MIN	{'DX'}	{'MIDRC-Open-R1'}	{'MIDRC'}	1
-FEMUR RIGHT 2 VIEWS MIN	{'DX'}	{'MIDRC-Open-R1'}	{'MIDRC'}	1
-FEMUR LEFT 2 VIEWS MIN	{'CR'}	{'MIDRC-Open-R1'}	{'MIDRC'}	1
-PET/CT (SKULL-MIDTHIGH)	{nan}	{'TCIA-varepop-apollo'}	{'TCIA'}	1
-TO	{'US'}	{'ACRdart-ACRIN_6666'}	{'ACRdart'}	1
-CHEST PE STUDY	{'CT'}	{'MIDRC-Open-A1_SCCM_VIRUS'}	{'MIDRC'}	1
-Head^CT_HEAD_WO_CHEST_WO (Adult)	{'CT'}	{'MIDRC-Open-A1'}	{'MIDRC'}	1
-SV BR	{'US'}	{'ACRdart-ACRIN_6666'}	{'ACRdart'}	1
-JCCI CAP TRIPLE	{'CT'}	{'MIDRC-Open-R1'}	{'MIDRC'}	1
-JCCI CT CHEST AND PELVIS ENHANCED	{'CT'}	{'MIDRC-Open-R1'}	{'MIDRC'}	1
-QA scan^MQA_DAILY_QA	{'MR'}	{'MIDRC-Open-A1'}	{'MIDRC'}	1
-CHEST - PA AND LAT	{'CR'}	{'MIDRC-Open-A1'}	{'MIDRC'}	1
-JCCI CT CAP WITHOUT	{'CT'}	{'MIDRC-Open-R1'}	{'MIDRC'}	1
-R MRI PRE&POST INF BREAST,UNILAT	{'MR'}	{'IDC-IDC_ispy1'}	{'IDC'}	1
-CHEST /A/ P IV IP	{'CT'}	{'MIDRC-Open-R1'}	{'MIDRC'}	1
-RA Chest 1 View Frontal	{'CR'}	{'MIDRC-Open-R1'}	{'MIDRC'}	1
-CHEST 1 VIEW AP/PA	{'CR'}	{'MIDRC-Open-R1'}	{'MIDRC'}	1
-JCCI CHEST/PEL	{'CT'}	{'MIDRC-Open-R1'}	{'MIDRC'}	1
-JCCI CHEST WO	{'CT'}	{'MIDRC-Open-R1'}	{'MIDRC'}	1
-JCCI CHEST WITHOUT	{'CT'}	{'MIDRC-Open-R1'}	{'MIDRC'}	1
-JCCI CHEST WITH PE	{'CT'}	{'MIDRC-Open-R1'}	{'MIDRC'}	1
-JCCI CHEST	{'CT'}	{'MIDRC-Open-R1'}	{'MIDRC'}	1
-RENAL BIOPSY PERQ	{nan}	{'TCIA-varepop-apollo'}	{'TCIA'}	1
-JCCI CAP ENHANCED	{'CT'}	{'MIDRC-Open-R1'}	{'MIDRC'}	1
-Private^1_CHEST_ABD_PELVIS_PET (Adult)	{nan}	{'TCIA-varepop-apollo'}	{'TCIA'}	1
-JOICC CT CHEST W/	{'CT'}	{'MIDRC-Open-R1'}	{'MIDRC'}	1
-JOIEN C/P	{'CT'}	{'MIDRC-Open-R1'}	{'MIDRC'}	1
-JOIEN CT ABD/PEL	{'CT'}	{'MIDRC-Open-R1'}	{'MIDRC'}	1
-CHEST 1 VIEW PA	{'CR'}	{'MIDRC-Open-R1'}	{'MIDRC'}	1
-JOIEN CT CHEST - PE	{'CT'}	{'MIDRC-Open-R1'}	{'MIDRC'}	1
-RH CTA CHEST WITH CONTRAST	{'CT'}	{'MIDRC-Open-A1_PETAL_BLUECORAL'}	{'MIDRC'}	1
-JOIEN CT CHEST W/O	{'CT'}	{'MIDRC-Open-R1'}	{'MIDRC'}	1
-RIBS UNILATERAL LEFT 2 VIEWS	{'CR'}	{'MIDRC-Open-R1'}	{'MIDRC'}	1
-RIBS UNILATERAL LEFT 2 VWS WITH PA CHEST	{'CR'}	{'MIDRC-Open-R1'}	{'MIDRC'}	1
-RIBS UNILATERAL RIGHT 2 VWS WITH PA CHEST	{'CR'}	{'MIDRC-Open-R1'}	{'MIDRC'}	1
-RIGHT - Unilateral Diagnostic Mammogram	{'MG'}	{'ACRdart-EA1141Restricted'}	{'ACRdart'}	1
-IWC MAMMO+3D SCREEN	{'MG'}	{'ACRdart-EA1141Restricted'}	{'ACRdart'}	1
-RIGHT FOOT-ROUTINE STUDY(RAD)-CS	{'CR'}	{'MIDRC-Open-A1'}	{'MIDRC'}	1
-RIGHT KNEE-ROUTINE STUDY (RAD)-CS	{'CR'}	{'MIDRC-Open-A1'}	{'MIDRC'}	1
-JCCI CT CHEST FOR PE	{'CT'}	{'MIDRC-Open-R1'}	{'MIDRC'}	1
-JHN PE CHEST IP	{'CT'}	{'MIDRC-Open-R1'}	{'MIDRC'}	1
-CHEST OP CARDIAC/PVEIN	{'CT'}	{'MIDRC-Open-R1'}	{'MIDRC'}	1
-JHN CAP IP	{'CT'}	{'MIDRC-Open-R1'}	{'MIDRC'}	1
-JHN CHEST WO IP	{'CT'}	{'MIDRC-Open-R1'}	{'MIDRC'}	1
-PV-Ven	{'US'}	{'ACRdart-ACRIN_6666'}	{'ACRdart'}	1
-JHN CHEST WITH OP	{'CT'}	{'MIDRC-Open-R1'}	{'MIDRC'}	1
-JHN CHEST W OP	{'CT'}	{'MIDRC-Open-R1'}	{'MIDRC'}	1
-JHN CTA CHEST WITH ONLY IP	{'CT'}	{'MIDRC-Open-R1'}	{'MIDRC'}	1
-JHN IP CAP W	{'CT'}	{'MIDRC-Open-R1'}	{'MIDRC'}	1
-JHN CHEST IP	{'CT'}	{'MIDRC-Open-R1'}	{'MIDRC'}	1
-JHN CAP WITH IP	{'CT'}	{'MIDRC-Open-R1'}	{'MIDRC'}	1
-JHN IP PE W/	{'CT'}	{'MIDRC-Open-R1'}	{'MIDRC'}	1
-JHN CAP W/ OP	{'CT'}	{'MIDRC-Open-R1'}	{'MIDRC'}	1
-PelvisAP TABLE	{'DX'}	{'MIDRC-Open-R1'}	{'MIDRC'}	1
-JHN CAP W/ IP	{'CT'}	{'MIDRC-Open-R1'}	{'MIDRC'}	1
-JHN CAP W OP	{'CT'}	{'MIDRC-Open-R1'}	{'MIDRC'}	1
-JHN OP CAP COMBO	{'CT'}	{'MIDRC-Open-R1'}	{'MIDRC'}	1
-JHN CAP COMBO IV	{'CT'}	{'MIDRC-Open-R1'}	{'MIDRC'}	1
-JHN OP CTA CHEST W/W/O	{'CT'}	{'MIDRC-Open-R1'}	{'MIDRC'}	1
-JHN CAP COMBO IP	{'CT'}	{'MIDRC-Open-R1'}	{'MIDRC'}	1
-Pelvis^PELVIS_W__GR (Adult)	{'CT'}	{'MIDRC-Open-A1'}	{'MIDRC'}	1
-Pelvis^Pelvis (Adult)	{'CT'}	{'MIDRC-Open-A1'}	{'MIDRC'}	1
-Pelvis^ROUTINE_PELVIS (Adult)	{'CT'}	{'MIDRC-Open-A1'}	{'MIDRC'}	1
-JHN CAP 3D PANC AP OP	{'CT'}	{'MIDRC-Open-R1'}	{'MIDRC'}	1
-JHN A/P IP	{'CT'}	{'MIDRC-Open-R1'}	{'MIDRC'}	1
-JCCI CTA CHEST	{'CT'}	{'MIDRC-Open-R1'}	{'MIDRC'}	1
-JCCI CT TRIPLE CAP	{'CT'}	{'MIDRC-Open-R1'}	{'MIDRC'}	1
-JCCI CT PE CHEST	{'CT'}	{'MIDRC-Open-R1'}	{'MIDRC'}	1
-JHN OP CHEST W/O	{'CT'}	{'MIDRC-Open-R1'}	{'MIDRC'}	1
-JCCI CT LUNG CANCER SCREENING	{'CT'}	{'MIDRC-Open-R1'}	{'MIDRC'}	1
-JCCI CT LOW DOSE CHEST	{'CT'}	{'MIDRC-Open-R1'}	{'MIDRC'}	1
-JCCI CT CHESTW	{'CT'}	{'MIDRC-Open-R1'}	{'MIDRC'}	1
-JCCI CT CHEST W/O	{'CT'}	{'MIDRC-Open-R1'}	{'MIDRC'}	1
-IWC DIG MAM SCRN> BIL DX SAME DAY	{'MG'}	{'ACRdart-EA1141Restricted'}	{'ACRdart'}	1
-CHEST ABD PELVIS	{'CT'}	{'MIDRC-Open-R1'}	{'MIDRC'}	1
-JOINY CT C/A/P TRIPLE	{'CT'}	{'MIDRC-Open-R1'}	{'MIDRC'}	1
-SINUSES COMPLETE MIN 3 VIEWS	{'CR'}	{'MIDRC-Open-R1'}	{'MIDRC'}	1
-CHEST CT WITHOUT CONTRAST	{'CT'}	{'MIDRC-Open-A1_PETAL_REDCORAL'}	{'MIDRC'}	1
-PET^1PETCT_150to200LBS (Adult)	{nan}	{'TCIA-varepop-apollo'}	{'TCIA'}	1
-CCHWO	{'CT'}	{'MIDRC-Open-A1_PETAL_REDCORAL'}	{'MIDRC'}	1
-KNEE COMPLETE LEFT 4 OR MORE VIEWS	{'DX'}	{'MIDRC-Open-R1'}	{'MIDRC'}	1
-PET^1HP_PETCT_DOTATATE (Adult)	{'PT,CT'}	{'MIDRC-Open-A1'}	{'MIDRC'}	1
-SCREENING MAMMOGRAPHY	{'MG'}	{'ACRdart-EA1141Restricted'}	{'ACRdart'}	1
-SCREENING PROGRAM MAMMO/TOMO BIL	{'MG'}	{'ACRdart-EA1141Restricted'}	{'ACRdart'}	1
-SCREENING WITH SAME DAY DX WORK UP	{'MG'}	{'ACRdart-EA1141Restricted'}	{'ACRdart'}	1
-Head^HEAD_C_SPINE (Adult)	{'CT'}	{'MIDRC-Open-A1'}	{'MIDRC'}	1
-SHOULDER 3 VIEWS RIGHT	{'CR'}	{'MIDRC-Open-R1'}	{'MIDRC'}	1
-SHOULDER LEFT 1 VIEW	{'CR'}	{'MIDRC-Open-R1'}	{'MIDRC'}	1
-SHOULDER RIGHT 2 VIEWS	{'CR'}	{'MIDRC-Open-R1'}	{'MIDRC'}	1
-SHOULDER RIGHT 4 VIEWS	{'CR'}	{'MIDRC-Open-R1'}	{'MIDRC'}	1
-SINUS(Adult)	{'CT'}	{'MIDRC-Open-A1'}	{'MIDRC'}	1
-Head^HEAD_CERV_COMB (Adult)	{'CT'}	{'MIDRC-Open-A1'}	{'MIDRC'}	1
-RIGHT foot	{'MR'}	{'MIDRC-Open-A1'}	{'MIDRC'}	1
-CHEST ER	{'CT'}	{'MIDRC-Open-R1'}	{'MIDRC'}	1
-SMALL BOWEL	{'DX'}	{'MIDRC-Open-R1'}	{'MIDRC'}	1
-Head^FAST_HEAD_Customized (Adult)	{'CT'}	{'MIDRC-Open-A1'}	{'MIDRC'}	1
-Head^FACIAL_BONES_WO (Adult)	{'CT'}	{'MIDRC-Open-A1'}	{'MIDRC'}	1
-CHEST FOUR VIEWS	{'CR'}	{'MIDRC-Open-R1'}	{'MIDRC'}	1
-SPINE L-SPINE	{'MR'}	{'MIDRC-Open-A1'}	{'MIDRC'}	1
-CHEST IP IV	{'CT'}	{'MIDRC-Open-R1'}	{'MIDRC'}	1
-SPINE^C SPINE	{nan}	{'TCIA-varepop-apollo'}	{'TCIA'}	1
-Head^FACE_ORBITS_GR (Adult)	{'CT'}	{'MIDRC-Open-A1'}	{'MIDRC'}	1
-Head^DE_HEAD_WITH_Customized (Adult)	{'CT'}	{'MIDRC-Open-A1'}	{'MIDRC'}	1
-CHEST LAT	{'CR'}	{'MIDRC-Open-R1'}	{'MIDRC'}	1
-SPLIT DISSECTION GATED CTA	{'CT'}	{'MIDRC-Open-A1'}	{'MIDRC'}	1
-CHEST OP CARDIAC	{'CT'}	{'MIDRC-Open-R1'}	{'MIDRC'}	1
-KNEE^LEFT	{'MR'}	{'MIDRC-Open-A1'}	{'MIDRC'}	1
-SCRAPBOOK	{'US'}	{'ACRdart-ACRIN_6666'}	{'ACRdart'}	1
-KNEE 2 VIEWS RIGHT	{'DX'}	{'MIDRC-Open-R1'}	{'MIDRC'}	1
-SBRT LUNG	{'CT'}	{'IDC-IDC_lctsc'}	{'IDC'}	1
-SACRUM AND COCCYX MIN 2 VIEWS	{'CR'}	{'MIDRC-Open-R1'}	{'MIDRC'}	1
-CERVICAL SPINE 2-3 VIEWS	{'CR'}	{'MIDRC-Open-R1'}	{'MIDRC'}	1
-JOINY CT C/A/P WO	{'CT'}	{'MIDRC-Open-R1'}	{'MIDRC'}	1
-RM CHEST PA OR AP	{'DX'}	{'MIDRC-Open-A1_PETAL_BLUECORAL'}	{'MIDRC'}	1
-RM CTA CHEST WITH CONT	{'CT'}	{'MIDRC-Open-A1_PETAL_BLUECORAL'}	{'MIDRC'}	1
-JOINY CT CHES WITH	{'CT'}	{'MIDRC-Open-R1'}	{'MIDRC'}	1
-IRM FÉMUR/CUISSE GAUCHE C- C+ -MUSQ	{'MR'}	{'IDC-IDC_soft_tissue_sarcoma'}	{'IDC'}	1
-RP ABDOMEN DRAINAGE	{'CT'}	{'MIDRC-Open-A1'}	{'MIDRC'}	1
-RP ABSCESS DRAINAGE	{'CT'}	{'MIDRC-Open-A1'}	{'MIDRC'}	1
-RP IR CONSULT	{'CT'}	{'MIDRC-Open-A1'}	{'MIDRC'}	1
-RP RIGHT CHEST TUBE PLACEMENT	{'CT'}	{'MIDRC-Open-A1'}	{'MIDRC'}	1
-IRM FEMUR/CUISSE GAUCHE C- C+ -MUSQ	{nan}	{'TCIA-soft-tissue-sarcoma'}	{'TCIA'}	1
-JOINY CT CHEST PE STUDY	{'CT'}	{'MIDRC-Open-R1'}	{'MIDRC'}	1
-RT BREAST ACCRIN	{'MR'}	{'IDC-IDC_ispy1'}	{'IDC'}	1
-PORTABLE ABDOMEN	{'CR'}	{'MIDRC-Open-A1_PETAL_REDCORAL'}	{'MIDRC'}	1
-PORT CHEST	{'DX'}	{'MIDRC-Open-R1'}	{'MIDRC'}	1
-RT BREAST US	{'US'}	{'ACRdart-ACRIN_6666'}	{'ACRdart'}	1
-JOINY CT CHEST W/O	{'CT'}	{'MIDRC-Open-R1'}	{'MIDRC'}	1
-77057 Screening Mamm Bilat	{'MG'}	{'ACRdart-EA1141Restricted'}	{'ACRdart'}	1
-JOINY CT CHEST WITH	{'CT'}	{'MIDRC-Open-R1'}	{'MIDRC'}	1
-RT LOW LUNG	{'RTSTRUCT'}	{'IDC-IDC_lctsc'}	{'IDC'}	1
-IR ESI SPINE CERVICAL THORACIC	{'CT'}	{'MIDRC-Open-A1'}	{'MIDRC'}	1
-PET^PETCT_DailyQC (Adult)	{'PT,CT'}	{'MIDRC-Open-A1'}	{'MIDRC'}	1
-IR CHEST TUBE PLACEMENT (ORERABLE BY	{'CT'}	{'MIDRC-Open-R1'}	{'MIDRC'}	1
-RT^RCCT_THORAX_8F_High_CONTRAST (Adult)	{'CT'}	{'IDC-IDC_lctsc'}	{'IDC'}	1
-RT^RCCT_THORAX_8F_Low (Adult)	{'RTSTRUCT'}	{'IDC-IDC_lctsc'}	{'IDC'}	1
-INFANT BONE SURVEY UP TO 12 MONTHS OLD	{'CR'}	{'MIDRC-Open-R1'}	{'MIDRC'}	1
-Ribs bilat	{'CR'}	{'MIDRC-Open-A1'}	{'MIDRC'}	1
-Head^TEMP_BONES_GR (Adult)	{'CT'}	{'MIDRC-Open-A1'}	{'MIDRC'}	1
-Head^TEMPORAL_BONE (Adult)	{'CT'}	{'MIDRC-Open-A1'}	{'MIDRC'}	1
-MAM DIAG LT/TOMO	{'MG'}	{'ACRdart-EA1141Restricted'}	{'ACRdart'}	1
-MAM Digital Breast Diag Tomosynthesis	{'MG'}	{'ACRdart-EA1141Restricted'}	{'ACRdart'}	1
-CT ABDOMEN PELVIS WO CONTRAST	{'CT'}	{'MIDRC-Open-R1'}	{'MIDRC'}	1
-US BREAST UNILATERAL	{'US'}	{'ACRdart-EA1141Restricted'}	{'ACRdart'}	1
-ULTRASOUND T0 TARGETED IMAGES	{'US'}	{'ACRdart-ACRIN_6666'}	{'ACRdart'}	1
-CT ABD/PEL W/ CON	{nan}	{'TCIA-varepop-apollo'}	{'TCIA'}	1
-ULTRASOUNDS T0 INITIAL	{'US'}	{'ACRdart-ACRIN_6666'}	{'ACRdart'}	1
-ULTRASOUNDS T0 INITIAL/6 MO. F/U	{'US'}	{'ACRdart-ACRIN_6666'}	{'ACRdart'}	1
-ULTRSOUND	{'US'}	{'ACRdart-ACRIN_6666'}	{'ACRdart'}	1
-ULTZ RESEARCH	{'US'}	{'ACRdart-ACRIN_6666'}	{'ACRdart'}	1
-MM US LT BREAST BIOPSY	{'US'}	{'ACRdart-ACRIN_6666'}	{'ACRdart'}	1
-MR 3607 RT BREAST WO/W CONT	{'MR'}	{'IDC-IDC_ispy1'}	{'IDC'}	1
-ABDOMEN 2018^ABD GENERIC ABDOMEN DOT 2019	{'MR'}	{'MIDRC-Open-A1'}	{'MIDRC'}	1
-MR 6657 RT BREAST WO/W #92	{'SEG'}	{'IDC-IDC_ispy1'}	{'IDC'}	1
-US ABDOMEN COMPLETE	{'US'}	{'MIDRC-Open-A1'}	{'MIDRC'}	1
-CT ABD/PEL W/CON	{nan}	{'TCIA-varepop-apollo'}	{'TCIA'}	1
-BREAST^	{'MR'}	{'ACRdart-EA1141Restricted'}	{'ACRdart'}	1
-Needle Biopsy Guidance (US)	{'US'}	{'ACRdart-ACRIN_6666'}	{'ACRdart'}	1
-Neck^DE_CT_NECK (Adult)	{'CT'}	{'MIDRC-Open-A1'}	{'MIDRC'}	1
-UCLA	{nan}	{'TCIA-qiba-ct-1c'}	{'TCIA'}	1
-ABDOMEN COMPLETE MIN 2 VWS	{'DX'}	{'MIDRC-Open-R1'}	{'MIDRC'}	1
-CT ABD/PEL WITH	{nan}	{'TCIA-varepop-apollo'}	{'TCIA'}	1
-Neck^CTA_HEAD_NECK (Adult)	{'CT'}	{'MIDRC-Open-A1'}	{'MIDRC'}	1
-CT ABD/PEL WITH IV CONTRAST	{'CT'}	{'MIDRC-Open-A1'}	{'MIDRC'}	1
-NUC MED RENAL SCAN WITH PHARM INTERVENTION	{'NM'}	{'MIDRC-Open-A1'}	{'MIDRC'}	1
-US DUPLEX EXTRCRAN CAROTID ART CMPLT	{'US'}	{'MIDRC-Open-A1'}	{'MIDRC'}	1
-NUC MED MYOCARD PERF SPECT STRESS AND REST	{'NM,CT'}	{'MIDRC-Open-A1'}	{'MIDRC'}	1
-NUC MED LYMPHOSCINTIGRAPHY	{'NM'}	{'MIDRC-Open-A1'}	{'MIDRC'}	1
-NUC MED GASTRIC EMPTYING STUDY	{'NM'}	{'MIDRC-Open-A1'}	{'MIDRC'}	1
-US L-VAC BX W CLIP	{'US'}	{'ACRdart-ACRIN_6666'}	{'ACRdart'}	1
-US LOWER EXTREMITY VENOUS DUPLEX BILATERAL	{'US'}	{'MIDRC-Open-A1'}	{'MIDRC'}	1
-CT WHOLE BODY LOW DOSE WITHOUT CONTRAST (ABDOMEN FOCUS)	{'CT'}	{'MIDRC-Open-R1'}	{'MIDRC'}	1
-MR ABD OUTSIDE IMAGING	{'SEG'}	{'IDC-IDC_prostate_mri_us_biopsy'}	{'IDC'}	1
-BREAST-RIGHT	{'MR'}	{'IDC-IDC_ispy1'}	{'IDC'}	1
-CT-CHEST WO	{'CT'}	{'MIDRC-Open-A1_PETAL_REDCORAL'}	{'MIDRC'}	1
-BREAST^SENTINELLE FOV  PINK COIL	{'MR'}	{'ACRdart-EA1141Restricted'}	{'ACRdart'}	1
-CT VIRTUAL COLON	{'CT'}	{'IDC-IDC_ct_colonography'}	{'IDC'}	1
-CT ABD/PEL W IVCON	{'CT'}	{'MIDRC-Open-A1_PETAL_BLUECORAL'}	{'MIDRC'}	1
-4D 3MM	{nan}	{'TCIA-pancreatic-ct-cbct-seg'}	{'TCIA'}	1
-Thorax^ROUTINE_CONTRAST_CHEST_175lbs_andUnder (Adult)	{'CT'}	{'MIDRC-Open-R1'}	{'MIDRC'}	1
-BRST UNI LT SCREENING MAMMO W/ TOMO	{'MG'}	{'ACRdart-EA1141Restricted'}	{'ACRdart'}	1
-MG DIAGNOSTIC MAMMO DIGITAL LEFT WCAD	{'MG'}	{'ACRdart-EA1141Restricted'}	{'ACRdart'}	1
-MG DIGITAL DX LT	{'MG'}	{'ACRdart-EA1141Restricted'}	{'ACRdart'}	1
-Thorax^ThoraxRoutine (Adult)	{'CT'}	{'MIDRC-Open-A1_SCCM_VIRUS'}	{'MIDRC'}	1
-Thorax^ThoraxRoutine (Child)	{'CT'}	{'MIDRC-Open-A1'}	{'MIDRC'}	1
-Thorax^VERAN_LARGE (Adult)	{'CT'}	{'MIDRC-Open-A1'}	{'MIDRC'}	1
-MG Diagnostic Left	{'MG'}	{'ACRdart-EA1141Restricted'}	{'ACRdart'}	1
-MG Diagnostic Mammo Digital Right w/CAD	{'MG'}	{'ACRdart-EA1141Restricted'}	{'ACRdart'}	1
-CTA CARDIAC OP	{'CT'}	{'MIDRC-Open-R1'}	{'MIDRC'}	1
-Thorax^XL_CAP_WO_Customized (Adult)	{'CT'}	{'MIDRC-Open-A1'}	{'MIDRC'}	1
-Thorax^XL_CHEST_WITH_Customized (Adult)	{'CT'}	{'MIDRC-Open-A1'}	{'MIDRC'}	1
-Obstruction Series	{'DX'}	{'MIDRC-Open-R1'}	{'MIDRC'}	1
-Thorax^XL_CTA_CAP (Adult)	{'CT'}	{'MIDRC-Open-A1'}	{'MIDRC'}	1
-CT ABD/PEL W/	{nan}	{'TCIA-varepop-apollo'}	{'TCIA'}	1
-CTA ABDOMEN AND PELVIS-CS	{'CT'}	{'MIDRC-Open-A1'}	{'MIDRC'}	1
-Thorax^XL_PE_ABD_PELVIS (Adult)	{'CT'}	{'MIDRC-Open-A1'}	{'MIDRC'}	1
-MG Tomosynthesis Breast Diagnostic Bilateral	{'MG'}	{'ACRdart-EA1141Restricted'}	{'ACRdart'}	1
-CTA ABD AORTA W/BILAT LE ARTERIES	{'CT'}	{'MIDRC-Open-A1'}	{'MIDRC'}	1
-OUTSIDE FILM REVIEW_ABDOMINAL MRI	{'SEG'}	{'IDC-IDC_prostate_mri_us_biopsy'}	{'IDC'}	1
-CT: Chest without Cont	{nan}	{'TCIA-varepop-apollo'}	{'TCIA'}	1
-OUTSIDE FILM REVIEW-ABDOMINAL MRI	{nan}	{'TCIA-prostate-mri-us-biopsy'}	{'TCIA'}	1
-CT: CTA Chest for PE	{'CT'}	{'MIDRC-Open-A1_PETAL_REDCORAL'}	{'MIDRC'}	1
-OUT X-RAY CHEST 1 VIEW 71045	{'CR'}	{'MIDRC-Open-A1_PETAL_BLUECORAL'}	{'MIDRC'}	1
-OUT X-RAY CHEST 1 VIEW	{'CR'}	{'MIDRC-Open-A1_PETAL_REDCORAL'}	{'MIDRC'}	1
-CT/CH/ABD/PEL(PANC)	{nan}	{'TCIA-rider-pilot'}	{'TCIA'}	1
-OUT CTA CHEST WWO CONTRAST	{'CT'}	{'MIDRC-Open-A1_PETAL_REDCORAL'}	{'MIDRC'}	1
-OUT CT CHEST WO	{'CT'}	{'MIDRC-Open-A1_PETAL_BLUECORAL'}	{'MIDRC'}	1
-Tomosynthesis Breast Screening Bilateral	{'MG'}	{'ACRdart-EA1141Restricted'}	{'ACRdart'}	1
-US SCROTUM AND CONTENTS	{'US'}	{'MIDRC-Open-A1'}	{'MIDRC'}	1
-MR ABDOMEN MRCP WITHOUT CONTRAST	{'MR'}	{'MIDRC-Open-R1'}	{'MIDRC'}	1
-MAM Digital Diagnostic Lt	{'MG'}	{'ACRdart-EA1141Restricted'}	{'ACRdart'}	1
-Vascular^_DISSECTION_CHEST_only (Adult)	{'CT'}	{'MIDRC-Open-R1'}	{'MIDRC'}	1
-MR BRAIN WITHOUT CONTRAST RAPID (S)	{'MR'}	{'MIDRC-Open-R1'}	{'MIDRC'}	1
-Vascular^HEAD_NECK_CTA (Adult)	{'CT'}	{'MIDRC-Open-A1'}	{'MIDRC'}	1
-ABDOMEN^GSO ABDOMEN	{'MR'}	{'MIDRC-Open-A1'}	{'MIDRC'}	1
-ABDOMEN^GSO MRCP	{'MR'}	{'MIDRC-Open-A1'}	{'MIDRC'}	1
-Vascular^PE_2023 (Adult)	{'CT'}	{'MIDRC-Open-A1'}	{'MIDRC'}	1
-Mammogram Diagnostic Bilat	{'MG'}	{'ACRdart-EA1141Restricted'}	{'ACRdart'}	1
-Vascular^POST_THORACIC_STENT (Adult)	{'CT'}	{'MIDRC-Open-A1'}	{'MIDRC'}	1
-MR BRAIN WWO CONTRAST (EPILEPSY PROTOCOL)	{'MR'}	{'MIDRC-Open-A1'}	{'MIDRC'}	1
-MR BRAIN/MR ANGIOGRAM WITH AND WITHOUT CONTRAST	{'MR'}	{'MIDRC-Open-R1'}	{'MIDRC'}	1
-Vascular^RENAL_CTA (Adult)	{'CT'}	{'MIDRC-Open-A1'}	{'MIDRC'}	1
-Mammo-Digital Diagnostic BILAT w/ Tomosynthesis	{'MG'}	{'ACRdart-EA1141Restricted'}	{'ACRdart'}	1
-CT ABDOMEN PELVIS W CONTRAST (CIRRHOSIS)	{'CT'}	{'MIDRC-Open-A1'}	{'MIDRC'}	1
-Vascular^VASC02_CTA_AAA_W_DELAY (Adult)	{'CT'}	{'MIDRC-Open-A1_PETAL_BLUECORAL'}	{'MIDRC'}	1
-Vascular^VENOUS_AbdPel_Less45 (Adult)	{'CT'}	{'MIDRC-Open-A1'}	{'MIDRC'}	1
-BREAST - LT	{'MR'}	{'IDC-IDC_ispy1'}	{'IDC'}	1
-ABDOMEN^ENTEROGRAPHY 2013	{'MR'}	{'MIDRC-Open-A1'}	{'MIDRC'}	1
-Mamm Digital Addl Views Right	{'MG'}	{'ACRdart-EA1141Restricted'}	{'ACRdart'}	1
-MSK US NONVASCULAR EXTREMITY LTD - RIGHT	{'US'}	{'MIDRC-Open-A1'}	{'MIDRC'}	1
-CT ABDOMEN PELVIS W/IVCON	{'CT'}	{'MIDRC-Open-A1_PETAL_BLUECORAL'}	{'MIDRC'}	1
-ABDOMINAL^GENERIC ABD_PEL	{'MR'}	{'MIDRC-Open-A1'}	{'MIDRC'}	1
-MR_Spine	{nan}	{'TCIA-cmb-mml'}	{'TCIA'}	1
-CT THORACIC SPINE WITHOUT IV CONTRAST	{'CT'}	{'MIDRC-Open-A1_SCCM_VIRUS'}	{'MIDRC'}	1
-WRIST^ROUTINE	{'MR'}	{'MIDRC-Open-A1'}	{'MIDRC'}	1
-CT THORACIC SPINE REFORMAT IMAG	{'CT'}	{'MIDRC-Open-A1'}	{'MIDRC'}	1
-Wrist 4 View	{'CR'}	{'MIDRC-Open-A1'}	{'MIDRC'}	1
-X-RAY ABDOMEN 2 VIEWS	{'DX'}	{'MIDRC-Open-A1'}	{'MIDRC'}	1
-X-RAY ABDOMEN COMPLETE W/CHEST 1 VIEW	{'DX'}	{'MIDRC-Open-A1'}	{'MIDRC'}	1
-MR_Pelvis	{nan}	{'TCIA-cmb-lca'}	{'TCIA'}	1
-CT T-SPINE W/O CONTRAST/BONE RECON	{'CT'}	{'MIDRC-Open-A1'}	{'MIDRC'}	1
-ABDOMINAL^LIVER	{'MR'}	{'MIDRC-Open-A1'}	{'MIDRC'}	1
-Vascular^Dissection_CHEST_CTA (Adult)	{'CT'}	{'MIDRC-Open-A1'}	{'MIDRC'}	1
-CT ABDOMEN AND PELVIS WO INFUSION - UROLOGY TX	{'CT'}	{'MIDRC-Open-A1'}	{'MIDRC'}	1
-CT ABD/PELVIS WITH CON	{nan}	{'TCIA-varepop-apollo'}	{'TCIA'}	1
-VP SHUNT - CHEST 2V, ABD COMPLETE, SKULL < 4VWS	{'CR'}	{'MIDRC-Open-R1'}	{'MIDRC'}	1
-BREAST US	{'US'}	{'ACRdart-ACRIN_6666'}	{'ACRdart'}	1
-ABDOMEN PELVIS MRI^MRCP	{'MR'}	{'MIDRC-Open-A1'}	{'MIDRC'}	1
-Ultrasound-Additional images	{'US'}	{'ACRdart-ACRIN_6666'}	{'ACRdart'}	1
-University of MD	{nan}	{'TCIA-qiba-ct-1c'}	{'TCIA'}	1
-CT UROGRAM W POST PROCESSING	{'CT'}	{'MIDRC-Open-A1'}	{'MIDRC'}	1
-Unknown RIS Code	{'CR'}	{'MIDRC-Open-A1'}	{'MIDRC'}	1
-MR ABDOMEN WITH AND WITHOUT CONTRAST (S)	{'MR'}	{'MIDRC-Open-R1'}	{'MIDRC'}	1
-MR ANGIOGRAM ABDOMEN WITH AND WITHOUT CONTRAST (S)	{'MR'}	{'MIDRC-Open-R1'}	{'MIDRC'}	1
-Unspecified Merge Only CR	{'CR'}	{'MIDRC-Open-A1_PETAL_BLUECORAL'}	{'MIDRC'}	1
-NM REST MYOCARDIAL PERFUSION (S)	{'NM'}	{'MIDRC-Open-R1'}	{'MIDRC'}	1
-MR ANGIOGRAM BRAIN WITHOUT CONTRAST	{'MR'}	{'MIDRC-Open-R1'}	{'MIDRC'}	1
-MR ANGIOGRAM CHEST WITH AND WITHOUT CONTRAST	{'MR'}	{'MIDRC-Open-R1'}	{'MIDRC'}	1
-ABDOMEN SERIES-NO CHEST-CS	{'CR'}	{'MIDRC-Open-A1'}	{'MIDRC'}	1
-MR ARM W/O CONTRAST	{nan}	{'TCIA-varepop-apollo'}	{'TCIA'}	1
-CT Thorax High Resolution	{'CT'}	{'MIDRC-Open-A1_PETAL_REDCORAL'}	{'MIDRC'}	1
-CT ABDOMEN AND PELVIS WO CONTRAST	{'CT'}	{'MIDRC-Open-A1_PETAL_BLUECORAL'}	{'MIDRC'}	1
-MR BRAIN (BRAIN TUMOR PROTOCOL) WWO CONTRAST*	{'MR'}	{'MIDRC-Open-A1'}	{'MIDRC'}	1
-NM LUNG VENTILATION/PERFUSION SCAN (S)	{'NM'}	{'MIDRC-Open-R1'}	{'MIDRC'}	1
-BREAST BX RT PERC W/IMAGES	{'US'}	{'ACRdart-ACRIN_6666'}	{'ACRdart'}	1
-Vascular^CODE_STROKE_CTA_WITH_PERFUSION_WS (Adult)	{'CT'}	{'MIDRC-Open-A1'}	{'MIDRC'}	1
-Vascular^CTA_ABD_PEL_GI_BLEED (Adult)	{'CT'}	{'MIDRC-Open-A1'}	{'MIDRC'}	1
-Vascular^CTA_CAP_GR (Adult)	{'CT'}	{'MIDRC-Open-A1'}	{'MIDRC'}	1
-Vascular^CTA_CHEST (Adult)	{'CT'}	{'MIDRC-Open-A1'}	{'MIDRC'}	1
-CT TRAUMA CHEST ABDOMEN PELVIS W CONTRAST	{'CT'}	{'MIDRC-Open-A1_PETAL_REDCORAL'}	{'MIDRC'}	1
-BREAST BIOPSY	{'US'}	{'ACRdart-ACRIN_6666'}	{'ACRdart'}	1
-Vascular^CTA_HEADNECK_GR (Adult)	{'CT'}	{'MIDRC-Open-A1'}	{'MIDRC'}	1
-MR BRAIN WITHOUT CONTRAST - FOCUSED BRAIN	{'MR'}	{'MIDRC-Open-R1'}	{'MIDRC'}	1
-CT THORAX w/o	{nan}	{'TCIA-varepop-apollo'}	{'TCIA'}	1
-CT ABDOMEN AND PELVIS RENAL STONE LOW DOSE	{'CT'}	{'MIDRC-Open-A1'}	{'MIDRC'}	1
-NIST	{nan}	{'TCIA-qiba-ct-1c'}	{'TCIA'}	1
-CTA CHEST AORTA ANGIOGRAPHY W WO CONTRAST	{'CT'}	{'MIDRC-Open-R1'}	{'MIDRC'}	1
-MAMMOGram/ultrasound exam	{'US'}	{'ACRdart-ACRIN_6666'}	{'ACRdart'}	1
-Thorax^ROUTINE_CHEST_W (Adult)	{'CT'}	{'MIDRC-Open-A1'}	{'MIDRC'}	1
-Chest PA + Lat	{'CR'}	{'MIDRC-Open-A1_PETAL_REDCORAL'}	{'MIDRC'}	1
-MAMMO 3D TOMO DIAGNOSTIC BILATERAL	{'MG'}	{'ACRdart-EA1141Restricted'}	{'ACRdart'}	1
-Thorax^CAP_WO_W_IRIS (Adult)	{'CT'}	{'MIDRC-Open-R1'}	{'MIDRC'}	1
-Thorax^CAP_W_IRIS (Adult)	{'CT'}	{'MIDRC-Open-R1'}	{'MIDRC'}	1
-Thorax^CH2_CHEST_WITH (Adult)	{'CT'}	{'MIDRC-Open-A1_PETAL_REDCORAL'}	{'MIDRC'}	1
-CADAVER	{'MR'}	{'IDC-IDC_nlm_visible_human_project'}	{'IDC'}	1
-ChestPA WALL	{'DX'}	{'MIDRC-Open-R1'}	{'MIDRC'}	1
-CR_WholeBody	{nan}	{'TCIA-cmb-mml'}	{'TCIA'}	1
-CSPINE^ROUTINE 2013	{'MR'}	{'MIDRC-Open-A1'}	{'MIDRC'}	1
-MAMMO ADD VIEWS UNI DIAGNOSTIC LT	{'MG'}	{'ACRdart-EA1141Restricted'}	{'ACRdart'}	1
-MAMMO ADD VIEWS UNI DIAGNOSTIC RT	{'MG'}	{'ACRdart-EA1141Restricted'}	{'ACRdart'}	1
-C/AP WO OP	{'CT'}	{'MIDRC-Open-R1'}	{'MIDRC'}	1
-Chest PE AVERAGE	{'CT'}	{'MIDRC-Open-R1'}	{'MIDRC'}	1
-Thorax^CHEST_ANGIO_PE_W (Adult)	{'CT'}	{'MIDRC-Open-A1_PETAL_REDCORAL'}	{'MIDRC'}	1
-Thorax^CHEST_BMI_30_TO_34 (Adult)	{'CT'}	{'MIDRC-Open-A1'}	{'MIDRC'}	1
-Thorax^CHEST_ILD (Adult)	{'CT'}	{'MIDRC-Open-A1_PETAL_BLUECORAL'}	{'MIDRC'}	1
-CRANE 4D 3MM	{'CT'}	{'IDC-IDC_pancreatic_ct_cbct_seg'}	{'IDC'}	1
-Thorax^CHEST_LOW_DOSE_WO (Adult)	{'CT'}	{'MIDRC-Open-A1'}	{'MIDRC'}	1
-Thorax^CHEST_W (Adult)	{'CT'}	{'MIDRC-Open-R1'}	{'MIDRC'}	1
-PET ESOPHAGEAL OR GASTRIC CANCER (W/LOW DOSE CT)	{'PT,CT'}	{'MIDRC-Open-A1'}	{'MIDRC'}	1
-PET ESOPHAGEAL OR GAST	{'PT,CT'}	{'MIDRC-Open-A1'}	{'MIDRC'}	1
-PET ENDOMETRIAL OR CERVICAL CANCER (W/LOW DOSE CT)	{'PT,CT'}	{'MIDRC-Open-A1'}	{'MIDRC'}	1
-Thorax^CHEST_WITHOUT_WITH (Adult)	{'CT'}	{'MIDRC-Open-A1'}	{'MIDRC'}	1
-MAMMO DIGITAL DIAGNOSTIC BILAT WITH TOMOSYNTHESIS	{'MG'}	{'ACRdart-EA1141Restricted'}	{'ACRdart'}	1
-MAMMO DIGITAL DIAGNOSTIC BILAT WITH TOMOSYNTHESIS_CAD	{'MG'}	{'IDC-IDC_ea1141'}	{'IDC'}	1
-Chest 2 View	{'DX'}	{'MIDRC-Open-R1'}	{'MIDRC'}	1
-MAMMO DIGITAL DIAGNOSTIC LEFT	{'MG'}	{'ACRdart-EA1141Restricted'}	{'ACRdart'}	1
-C/A/P OP TAVAR	{'CT'}	{'MIDRC-Open-R1'}	{'MIDRC'}	1
-Thorax^CHEST_W_AP_WWO (Adult)	{'CT'}	{'MIDRC-Open-A1'}	{'MIDRC'}	1
-C/A/P IP ADRENAL	{'CT'}	{'MIDRC-Open-R1'}	{'MIDRC'}	1
-C/A/P IP 3D PANC	{'CT'}	{'MIDRC-Open-R1'}	{'MIDRC'}	1
-ComboHD Unilateral Right	{'MG'}	{'ACRdart-EA1141Restricted'}	{'ACRdart'}	1
-DCH2	{'CR'}	{'MIDRC-Open-A1_PETAL_REDCORAL'}	{'MIDRC'}	1
-MAMMOGRSM/ULTRASOUND EXAM	{'US'}	{'ACRdart-ACRIN_6666'}	{'ACRdart'}	1
-DIGITAL DIAG MAMM RIGHT UNIL W/ TOMO	{'MG'}	{'ACRdart-EA1141Restricted'}	{'ACRdart'}	1
-PET PANCREATIC CANCER (W/LOW DOSE CT)	{'PT,CT'}	{'MIDRC-Open-A1'}	{'MIDRC'}	1
-PET PANCREATIC CANCER	{'PT,CT'}	{'MIDRC-Open-A1'}	{'MIDRC'}	1
-DX ADULT VP SHUNT SERIES	{'DX'}	{'MIDRC-Open-A1_SCCM_VIRUS'}	{'MIDRC'}	1
-DX ABDOMEN PORTABLE ANTERIOR POSTERIOR 1 VIEW	{'DX'}	{'MIDRC-Open-A1_SCCM_VIRUS'}	{'MIDRC'}	1
-CAP ER TRAUMA	{'CT'}	{'MIDRC-Open-R1'}	{'MIDRC'}	1
-Thorax^1CAP_W_IRIS (Adult)	{'CT'}	{'MIDRC-Open-R1'}	{'MIDRC'}	1
-Thorax^1CHEST_W_IRIS (Adult)	{'CT'}	{'MIDRC-Open-R1'}	{'MIDRC'}	1
-DIGITAL SCREENING MAMMOGRAM BILATERAL TOMO	{'MG'}	{'IDC-IDC_ea1141'}	{'IDC'}	1
-DIGITAL SCR MAMMO BILAT	{'MG'}	{'ACRdart-EA1141Restricted'}	{'ACRdart'}	1
-CAP COMBO OP	{'CT'}	{'MIDRC-Open-R1'}	{'MIDRC'}	1
-MAM MAMMOGRAPHY UNILAT DIAG	{'MG'}	{'ACRdart-EA1141Restricted'}	{'ACRdart'}	1
-DIGITAL MAMMOGRAM BILATERAL	{nan}	{'TCIA-breast-diagnosis'}	{'TCIA'}	1
-Thorax^1ThoraxRoutine (Adult)	{'CT'}	{'MIDRC-Open-A1_SCCM_VIRUS'}	{'MIDRC'}	1
-CAP COMBO	{'CT'}	{'MIDRC-Open-R1'}	{'MIDRC'}	1
-DIGITAL CALL BACK DX MAMMO UNI NO CAD	{'MG'}	{'ACRdart-EA1141Restricted'}	{'ACRdart'}	1
-CAMRIS^PELVIC RESEARCH	{'MR'}	{'ACRdart-ACRIN_6701'}	{'ACRdart'}	1
-MAM SCREEN BILAT/TOMO	{'MG'}	{'ACRdart-EA1141Restricted'}	{'ACRdart'}	1
-CAP 3D PANC	{'CT'}	{'MIDRC-Open-R1'}	{'MIDRC'}	1
-CAP 3D LIVER	{'CT'}	{'MIDRC-Open-R1'}	{'MIDRC'}	1
-DIG MAM SCRN> BIL DX SAME DAY	{'MG'}	{'IDC-IDC_ea1141'}	{'IDC'}	1
-PET MELANOMA OR OTHER SKIN CANCER (W/LOW DOSE CT)	{'PT,CT'}	{'MIDRC-Open-A1'}	{'MIDRC'}	1
-Thorax^1_THORAX_XXL (Adult)	{nan}	{'TCIA-varepop-apollo'}	{'TCIA'}	1
-DIG CB DX TOMO MAM UNI NC	{'MG'}	{'ACRdart-EA1141Restricted'}	{'ACRdart'}	1
-DIG CB DX TOMO MAM UNI	{'MG'}	{'ACRdart-EA1141Restricted'}	{'ACRdart'}	1
-DG RIBS W/ CHEST 3+V*L*	{'CR'}	{'MIDRC-Open-A1'}	{'MIDRC'}	1
-Thorax^AVERAGE_CHEST_WITHOUT_IV_CONTRAST (Adult)	{nan}	{'TCIA-varepop-apollo'}	{'TCIA'}	1
-Thorax^AVERAGE_CTPA (Adult)	{nan}	{'TCIA-varepop-apollo'}	{'TCIA'}	1
-Thorax^C2_CHEST_ENHANCED (Adult)	{'CT'}	{'MIDRC-Open-A1_PETAL_REDCORAL'}	{'MIDRC'}	1
-Thorax^C4A_FLASH_CTA_PE_ROUTINE (Adult)	{'CT'}	{'MIDRC-Open-A1_PETAL_REDCORAL'}	{'MIDRC'}	1
-Thorax^C4_CTA_PE (Adult)	{'CT'}	{'MIDRC-Open-A1_PETAL_REDCORAL'}	{'MIDRC'}	1
-MAMMO LEFT ADDITIONAL VW	{'MG'}	{'ACRdart-EA1141Restricted'}	{'ACRdart'}	1
-C/A/P 3 PHASE IP	{'CT'}	{'MIDRC-Open-R1'}	{'MIDRC'}	1
-Cardiac^COR_RETRO_HR_MORE_THAN_85 (Adult)	{'CT'}	{'MIDRC-Open-A1'}	{'MIDRC'}	1
-PE/ACUTE GI IP ECMO	{'CT'}	{'MIDRC-Open-R1'}	{'MIDRC'}	1
-MAMMOGRAM DIAGNOSTIC BILATERAL W / TOMO	{'MG'}	{'IDC-IDC_ea1141'}	{'IDC'}	1
-CTSTNECK CHEST ABDOMEN PELVIS W WO CONTRAST	{'CT'}	{'MIDRC-Open-R1'}	{'MIDRC'}	1
-Thorax^LARGE_CTPA (Adult)	{nan}	{'TCIA-varepop-apollo'}	{'TCIA'}	1
-MAMMOGRAM DIAGNOSTIC LEFT W/TOMOSYNTHESIS	{'MG'}	{'ACRdart-EA1141Restricted'}	{'ACRdart'}	1
-Thorax^LOW_DOSE_CHEST_LG (Adult)	{'CT'}	{'MIDRC-Open-R1'}	{'MIDRC'}	1
-MAMMOGRAM DIGITAL DIAGNOSTIC BILATERAL W/TOMO	{'MG'}	{'ACRdart-EA1141Restricted'}	{'ACRdart'}	1
-MAMMOGRAM DIGITAL DIAGNOSTIC UNILATERAL W/TOMO	{'MG'}	{'ACRdart-EA1141Restricted'}	{'ACRdart'}	1
-BX_US	{'US'}	{'ACRdart-ACRIN_6666'}	{'ACRdart'}	1
-MAMMOGRAM/ ULTRASOUND EXAM	{'US'}	{'ACRdart-ACRIN_6666'}	{'ACRdart'}	1
-MAMMOGRAM/@ BIOPSY	{'US'}	{'ACRdart-ACRIN_6666'}	{'ACRdart'}	1
-CTA P PE CHEST W	{'CT'}	{'MIDRC-Open-A1'}	{'MIDRC'}	1
-Thorax^MCV_CH_AB_PL_ROUTINE (Adult)	{'CT'}	{'MIDRC-Open-A1_PETAL_REDCORAL'}	{'MIDRC'}	1
-CTA MICS IP	{'CT'}	{'MIDRC-Open-R1'}	{'MIDRC'}	1
-MAMMOGRAM/ULTRASOOUND EXAM	{'US'}	{'ACRdart-ACRIN_6666'}	{'ACRdart'}	1
-PE/ABDPEL IV ER	{'CT'}	{'MIDRC-Open-R1'}	{'MIDRC'}	1
-Thorax^CTA_CHEST_ABD_PELVIS (Adult)	{'CT'}	{'MIDRC-Open-A1'}	{'MIDRC'}	1
-CTA CHEST(ENTIRE AORTA)	{'CT'}	{'MIDRC-Open-A1'}	{'MIDRC'}	1
-PE IP	{'CT'}	{'MIDRC-Open-R1'}	{'MIDRC'}	1
-PE CHEST(Adult)	{'CT'}	{'MIDRC-Open-R1'}	{'MIDRC'}	1
-Thorax^PEDS__PE_CHEST (Child)	{'CT'}	{'MIDRC-Open-A1'}	{'MIDRC'}	1
-BX BRST. MAMMOTOME, W /GUID	{'US'}	{'ACRdart-ACRIN_6666'}	{'ACRdart'}	1
-Thorax^PE_CHEST_DSXXL (Adult)	{'CT'}	{'MIDRC-Open-A1_PETAL_BLUECORAL'}	{'MIDRC'}	1
-Thorax^PE_DE_UNDER_200 (Adult)	{'CT'}	{'MIDRC-Open-A1_PETAL_BLUECORAL'}	{'MIDRC'}	1
-PE CHEST OP	{'CT'}	{'MIDRC-Open-R1'}	{'MIDRC'}	1
-CTA CHEST W IV CONT	{'CT'}	{'MIDRC-Open-A1_PETAL_BLUECORAL'}	{'MIDRC'}	1
-Thorax^Pulmonary_Angiogram (Adult)	{'CT'}	{'MIDRC-Open-A1_PETAL_BLUECORAL'}	{'MIDRC'}	1
-Thorax^Pulmonary_Embolism_Study (Adult)	{'CT'}	{'MIDRC-Open-R1'}	{'MIDRC'}	1
-PE CHEST IP	{'CT'}	{'MIDRC-Open-R1'}	{'MIDRC'}	1
-MAMMOGRAM/US/BIOPSY	{'US'}	{'ACRdart-ACRIN_6666'}	{'ACRdart'}	1
-MAMMOGRAPHY-DIAGNOSTIC-TOMO-UNILAT-RT	{'MG'}	{'ACRdart-EA1141Restricted'}	{'ACRdart'}	1
-CT_AP_WO	{'CT'}	{'MIDRC-Open-A1'}	{'MIDRC'}	1
-CT ABD AND PELVIS W WO CONTRAS-CS	{'CT'}	{'MIDRC-Open-A1'}	{'MIDRC'}	1
-CT ABD & PELVIS W/O IV CONTRAST	{nan}	{'TCIA-varepop-apollo'}	{'TCIA'}	1
-Thorax^ILD_BMI_Greater_than_40 (Adult)	{'CT'}	{'MIDRC-Open-A1'}	{'MIDRC'}	1
-Cardiac^COR_HR_75to85 (Adult)	{'CT'}	{'MIDRC-Open-A1'}	{'MIDRC'}	1
-Cardiac^CA_SCORING_2021 (Adult)	{'CT'}	{'MIDRC-Open-A1'}	{'MIDRC'}	1
-Cardiac^CA_SCORING_2018 (Adult)	{'CT'}	{'MIDRC-Open-A1'}	{'MIDRC'}	1
-Cardiac^CALCIUM_SCORE_ROUTINE (Adult)	{'CT'}	{'MIDRC-Open-A1'}	{'MIDRC'}	1
-Thorax^CT_CAP_WITH_T_AND_L_SPINE_MPRS (Adult)	{'CT'}	{'MIDRC-Open-A1'}	{'MIDRC'}	1
-Cardiac^ALIVE (Adult)	{'CT'}	{'MIDRC-Open-A1'}	{'MIDRC'}	1
-Thorax^CT_CA_WO (Adult)	{'CT'}	{'MIDRC-Open-A1'}	{'MIDRC'}	1
-Thorax^CT_CHEST_ANGIO_PE_W (Adult)	{'CT'}	{'MIDRC-Open-A1_PETAL_REDCORAL'}	{'MIDRC'}	1
-CXR 2 VIEW	{'DX'}	{'MIDRC-Open-R1'}	{'MIDRC'}	1
-Thorax^CT_CHEST_WO (Adult)	{'CT'}	{'MIDRC-Open-A1_PETAL_REDCORAL'}	{'MIDRC'}	1
-C-ARM FLUOROSCOPY UP TO 4 HOURS	{'RF'}	{'MIDRC-Open-R1'}	{'MIDRC'}	1
-MAMMO SCREENING DIGITAL-BILATERAL	{'MG'}	{'ACRdart-EA1141Restricted'}	{'ACRdart'}	1
-Thorax^C_A_P_WO (Adult)	{'CT'}	{'MIDRC-Open-A1'}	{'MIDRC'}	1
-PET CT IMG ANY SITE NO	{'PT,CT'}	{'MIDRC-Open-A1'}	{'MIDRC'}	1
-Thorax^Chest_Routine_Without (Adult)	{'CT'}	{'MIDRC-Open-A1_PETAL_BLUECORAL'}	{'MIDRC'}	1
-PET CT FOR SARCOIDOSIS	{'PT,CT'}	{'MIDRC-Open-A1'}	{'MIDRC'}	1
-Thorax^DE_PE_ABD_PELVIS (Adult)	{'CT'}	{'MIDRC-Open-A1'}	{'MIDRC'}	1
-MAMMO TOMOGRAPHY DIAGNOSTIC LEFT	{'MG'}	{'ACRdart-EA1141Restricted'}	{'ACRdart'}	1
-Thorax^DE_TRAUMA_CAP_WITH_FEET_FIRST___ (Adult)	{'CT'}	{'MIDRC-Open-A1'}	{'MIDRC'}	1
-Thorax^DE_TRAUMA_CAP_WITH__INFUSION_AUTO_Customized (Adult)	{'CT'}	{'MIDRC-Open-A1'}	{'MIDRC'}	1
-Breast-Rifht	{'MR'}	{'IDC-IDC_ispy1'}	{'IDC'}	1
-Thorax^FLASH_CAP_WITHOUT (Adult)	{'CT'}	{'MIDRC-Open-A1'}	{'MIDRC'}	1
-Thorax^FLASH_CAP_WITH_Customized (Adult)	{'CT'}	{'MIDRC-Open-A1'}	{'MIDRC'}	1
-Thorax^FLASH_CTA_CAP (Adult)	{'CT'}	{'MIDRC-Open-A1'}	{'MIDRC'}	1
-Breast  Right	{'SEG'}	{'IDC-IDC_ispy1'}	{'IDC'}	1
-PEREZ	{'US'}	{'ACRdart-ACRIN_6666'}	{'ACRdart'}	1
-MAMMOGRAM / @ BIOPSY	{'US'}	{'ACRdart-ACRIN_6666'}	{'ACRdart'}	1
-MAMMOGRAM ADD'T VIEW LEFT W/TOMOSYNTHESIS	{'MG'}	{'ACRdart-EA1141Restricted'}	{'ACRdart'}	1
-PELVIS^ROUTINE	{'MR'}	{'MIDRC-Open-A1'}	{'MIDRC'}	1
-ELBOW RIGHT MIN 3 VIEWS (ROUTINE)	{'CR'}	{'MIDRC-Open-R1'}	{'MIDRC'}	1
+StudyDescription	Modality	platform	frequency
+XR Chest AP or PA	CR, PR, DX, XR, CT, MR, CR,DX, nan	IDC,TCIA,AIMI,NIHCC,MIDRC	428198
+NLST-LSS	SR, CT, SEG	IDC	48544
+NLST-ACRIN	SR, CT, SEG	IDC	24569
+Histopathology	SR, ANN, SEG, SM	IDC	17045
+CHEST AP PORT	CR, DX, nan	IDC,TCIA,MIDRC	12732
+CHEST PORT 1 VIEW (RAD)-CS	CR, CR,DX, DX	MIDRC	7341
+MAMMO screening digital bilateral	MG, nan	IDC,TCIA	6752
+CHEST AP VIEWONLY	CR, DX, nan	IDC,TCIA,MIDRC	5297
+3D Rendering	US, nan	IDC,TCIA	3416
+Simulated DBT Projection	MG	IDC	2994
+Simulated Digital Mammography	MG	IDC	2994
+DBT Reconstructed Volume	MG, nan	IDC,TCIA	2765
+NCI PDMR Tumor Characterization	SR, MR, nan	IDC,TCIA	2554
+Chest	CR, DX, CT, nan	IDC,TCIA,MIDRC	2165
+BrainTumor	MR, SEG, nan	IDC,TCIA	2108
+MAMMO SCREENING DIGITAL BILATERAL	MG, nan	IDC,TCIA	1922
+BRAIN W/O CONTRAST (CT)-CS	CT	MIDRC	1640
+CHEST PA & LATERAL (RAD)-CS	CR, CR,DX, DX	MIDRC	1559
+CT CHEST WO CONTRAST	RTSTRUCT, CT, SEG, nan	IDC,TCIA,MIDRC	1390
+CHEST 1 VIEW	CR, DX	MIDRC	1303
+MRI BREASTS - Delayed contrast	MR, SEG, nan	IDC,TCIA	1264
+Portable Chest	CR	MIDRC	1239
+CT CHEST WITH CONTRAST	CT, SEG, nan	IDC,TCIA,MIDRC	1235
+CT CHEST W CONTRAST	CT, SEG, nan	IDC,TCIA,MIDRC	1216
+CT Coronary Angio with Contrast	CT	AIMI	1207
+p4	CT, nan	IDC,TCIA	1174
+MR PROSTATE WO+W CONTRAST	SEG, nan	IDC,TCIA	1082
+CTA CHEST (PE STUDY) W CONTRAST	CT	MIDRC	1018
+CT CHEST PULMONARY EMBOLISM (CTPE)	CT, nan	IDC,TCIA,MIDRC	1011
+BRAIN^ROUTINE	MR, SEG, nan	IDC,TCIA	982
+MAMMO SCREEN BREAST TOMOSYNTHESIS BILATERAL	MG, nan	IDC,TCIA	970
+CT CHEST WITHOUT CONTRAST	CT, nan	IDC,TCIA,MIDRC	925
+MRI BREAST BILATERAL W/WO	MR, SEG, nan	IDC,TCIA	882
+MAMMO diagnostic digital bilateral	MG, nan	IDC,TCIA	872
+Standard Screening - TomoHD	MG, nan	IDC,TCIA,ACRdart	800
+ACRIN-6698_ISPY2_MRI_T0	MR, SEG, nan	IDC,TCIA	770
+CT	RTSTRUCT, CT, nan	IDC,TCIA	764
+MRI PROSTATE W WO CONTRAST	MR, SEG, nan	IDC,TCIA	762
+CT CHEST ANGIOGRAM AND PULMONARY ARTERIES WITH IV CONTRAST	CT	MIDRC	739
+CT HEAD WO CONTRAST	CT	MIDRC	717
+ISPY2_MRI_T0	MR, SEG	IDC	717
+PET-CT STUDY	CT, PT, nan	IDC,TCIA	716
+CHEST-SINGLE VIEW (RAD)-CS	CR, DX	MIDRC	707
+ISPY2_MRI_T1	MR, SEG	IDC	690
+CHEST AP PORT CENTRAL LINE PL	CR, DX, nan	IDC,TCIA,MIDRC	654
+ISPY2_MRI_T2	MR, SEG	IDC	647
+ISPY2_MRI_T3	MR, SEG	IDC	634
+BRAIN^SPECTROSCOPY	MR, SEG, nan	IDC,TCIA	598
+Chest 2V	CR	MIDRC	593
+CT CHEST WO IV CONT	CT, nan	IDC,TCIA,MIDRC	554
+CT CHEST WO	CT	MIDRC	527
+ACRIN-6698_ISPY2_MRI_T1	MR, SEG, nan	IDC,TCIA	516
+CHEST W/O CONTRAST (CT)-CS	CT	MIDRC	513
+Chest Portable	CR, DX	MIDRC	494
+X-RAY CHEST SINGLE VIEW	CR, DX	MIDRC	486
+ACRIN-6698_ISPY2_MRI_T2	MR, SEG, nan	IDC,TCIA	486
+Thorax^CTD_01_TH_ROUTINE_NEU (Adult)	CT, SEG, nan	IDC,TCIA	476
+BRAIN^BRAIN	MR, SEG, nan	IDC,TCIA,MIDRC	475
+ACRIN-6698_ISPY2_MRI_T3	MR, SEG, nan	IDC,TCIA	474
+CHEST AP PORTABLE	CR, nan	IDC,TCIA,MIDRC	465
+FLAT PLATE OF ABDOMEN PORTABLE	CR, DX, nan	IDC,TCIA,MIDRC	461
+BRAIN^BRAIN TUMOR	MR, SEG, nan	IDC,TCIA	456
+XR ABDOMEN 1 VIEW	CR, DX	MIDRC	446
+Vascular^PE_STUDY (Adult)	CT	MIDRC	432
+CT CHEST ABDOMEN PELVIS W CONTRAST (ROUTINE)	CT	MIDRC	406
+CT CORONARY ANGIOGRAPHY W AND WO IV CONTRAST	CT	AIMI	398
+MRI BREAST BILATERAL W + W/O	MR, SEG, nan	IDC,TCIA	384
+BREAST PRONE	MR, SEG, nan	IDC,TCIA	382
+CT CHEST PULMONARY ANGIO WITH IV CON	CT, nan	IDC,TCIA,MIDRC	366
+Head^HEAD (Adult)	CT	MIDRC	358
+CT ABD AND PELVIS WITH IV CONT	CT, nan	IDC,TCIA,MIDRC	358
+MR HEAD W AND WO IV CONTRAST	MR, SEG, nan	IDC,TCIA	350
+MR prostaat kanker detectie WDS_mc MCAPRODETW	MR, SEG, nan	IDC,TCIA	346
+CT CHEST ABDOMEN PELVIS W	CT, nan	IDC,TCIA,MIDRC	345
+MR HEAD W AND WO IV CONTRAST TUMOR NEW	MR, SEG, nan	IDC,TCIA	342
+Chest Single View Adult Portable	CR, DX	MIDRC	314
+Avanto RoutineImage Guidance	RTDOSE, RTSTRUCT, RTPLAN, MR, nan	IDC,TCIA	304
+MR BREAS, UNIT	MR, SEG, nan	IDC,TCIA	289
+CT CHEST PULMONARY EMBOLISM W CONTRAST	CT, SEG, nan	IDC,TCIA,MIDRC	284
+Breast^Screen	MR	ACRdart,IDC	279
+CT ABDOMEN PELVIS W CONTRAST (ROUTINE)	CT	MIDRC	278
+MR BREASTUNI UE	MR, SEG, nan	IDC,TCIA	273
+CT ABD AND PELVIS WO IV CONT	CT, nan	IDC,TCIA,MIDRC	271
+CT LUNG SCREEN	CT, SEG, nan	IDC,TCIA	270
+Preinvasive mammary neoplasia	MR, nan	IDC,TCIA	264
+RX SIMULATION	RTSTRUCT, CT, nan	IDC,TCIA	262
+CT CHEST W	CT, SEG, nan	IDC,TCIA,MIDRC	259
+CHEST, PA & LATERAL	DX, nan	IDC,TCIA	256
+CT_CAP	CT, nan	IDC,TCIA	254
+MRI BREAST ABBREVIATED - RESEARCH	MR	ACRdart,IDC	254
+MR prostaat kanker detectie_mc MCAPRODET	MR, SEG, nan	IDC,TCIA	254
+MAM MAMMOGRAPHY SCREENING WITH TOMOSYNTHESIS	MG	ACRdart,IDC	251
+Thorax^CT_PE (Adult)	CT	MIDRC	242
+Breast	US	ACRdart	241
+MRI BREAST BILAT WO/W CONTRAST	MR	ACRdart,IDC	239
+CHEST PORTABLE AP	CR, DX	MIDRC	238
+CT THORAX W/CONTRAST	CT, SEG, nan	IDC,TCIA	236
+CT CHEST HIGH RESOLUTION	CT, nan	IDC,TCIA,MIDRC	232
+CHEST 1V	CR, nan	IDC,TCIA,MIDRC	229
+Pelvic Cavity CT Routine+Enhanced	CT, nan	IDC,TCIA	210
+CT CHEST PULMONARY EMB	CT	MIDRC	209
+CT CHEST WITHOUT IV CONTRAST	CT, nan	IDC,TCIA,MIDRC	209
+CHEST 2 VIEWS	CR, DX	MIDRC	209
+X-RAY CHEST FRONTAL AND LATERAL	CR, DX	MIDRC	203
+MRI BREAST BILATERAL W WO CONTRAST	MR	ACRdart,IDC	202
+Abdomen^24ACRIN_Colo_IRB2415-04 (Adult)	CT, nan	IDC,TCIA	202
+CHEST AP VIEW ONLY	CR, nan	IDC,TCIA,MIDRC	199
+MRI BRAIN W/INJ/MHDI	MR, SEG, nan	IDC,TCIA	198
+CR DIAG-PORTABLE CHEST	CR	MIDRC	195
+Abdomen CT Routine+Enhanced	CT, nan	IDC,TCIA	194
+CT CHEST ABDOMEN PELVIS W CONTRAST	CT, SEG, nan	IDC,TCIA,MIDRC	189
+Thorax^CHEST_WO (Adult)	CT, nan	IDC,TCIA,MIDRC	188
+MAMMO 3D SCREEN BILAT	MG	ACRdart,IDC	188
+CHEST	CR, DX, CT, SEG, nan	IDC,TCIA,MIDRC	188
+MR BREAST RESEARCH EXAM	MR	ACRdart,IDC	187
+Thorax^PE (Adult)	CT	MIDRC	186
+CT CAP	RTSTRUCT, CT, SEG, nan	IDC,TCIA	182
+mediastinal_lymph_nodes	SEG, nan	IDC,TCIA	180
+CT THORAX	CT, SEG, nan	IDC,TCIA,AIMI	179
+CHEST W/CONTRAST (CT)-CS	CT	MIDRC	179
+abdominal_lymph_nodes	SEG, nan	IDC,TCIA	172
+Avanto RoutineHead	RTDOSE, RTSTRUCT, RTPLAN, MR, nan	IDC,TCIA	168
+MRI PROSTATE WITH AND WITHOUT CONTRAST	MR, nan	IDC,TCIA	168
+MAMMO SCREENING DIGITAL BIALTERAL	MG, nan	IDC,TCIA	164
+CT CHEST ABDOMEN PELVIS WO CONTRAST (ROUTINE)	CT	MIDRC	163
+MRI BREAST BI W/WO CONTRAST	MR	ACRdart,IDC	162
+CT CHEST ABDOMEN PELVI	RTSTRUCT, CT, SEG, nan	IDC,TCIA,MIDRC	162
+CT CH/ABD/PEL W/ CONTRAST	CT, SEG, nan	IDC,TCIA	160
+Pancreas	SEG, nan	IDC,TCIA	160
+MC prostaat kliniek detectie-mc MCPROSKL30	MR, SEG, nan	IDC,TCIA	158
+MAMMO SCREENING BREAST TOMOSYNTHESIS	MG, nan	IDC,TCIA	156
+BRST BILAT SCREENING MAMMO W/ TOMO	MG	ACRdart,IDC	155
+MAMMO TOMOGRAPHY SCREENING BILATERAL	MG	ACRdart,IDC	150
+HUP5 PROTOCOLS^BREAST	MR, SEG, nan	IDC,TCIA	144
+Abdomen^ACRIN_COLON_USE (Adult)	CT, nan	IDC,TCIA	142
+MRI BREAST UNI 1ST EXA	MR, nan	IDC,TCIA	142
+Head^DE_HEAD_WITHOUT_Customized (Adult)	CT	MIDRC	141
+MR HEAD W AND WO IV CONTRAST TUMOR HIGH GRADE	MR, SEG, nan	IDC,TCIA	140
+CT CHEST ABDOMEN PELVIS W CONTRAST (TRAUMA)	CT	MIDRC	140
+MRI BREAST SCREENING AB BILATERAL WITH AND WITHOUT CONTRAST	MR	ACRdart,IDC	140
+MAMMOGRAM SCREENING BILATERAL W/TOMOSYNTHESIS	MG	ACRdart,IDC	138
+Abdomen^ABD_PEL_WITH (Adult)	RTSTRUCT, CT, nan	IDC,TCIA,MIDRC	138
+CTA PE CHEST W	CT	MIDRC	137
+MAMMO SCREENING TOMOSYNTHESIS - BILATERAL	MG	ACRdart,IDC	137
+MRM	MR, nan	IDC,TCIA	136
+CHEST INSPIR/EXPIR (RAD)-CS	CR, DX	MIDRC	135
+MRM 6667	MR, nan	IDC,TCIA	134
+MAMMO TOMOSYNTHESIS SCREENING WITH 2D MAMMOGRAM BILATERAL	MG	ACRdart,IDC	133
+3-D Tomo Mammogram	MG	ACRdart,IDC	133
+MRI Breast Bilateral with and without Contrast	MR, nan	IDC,TCIA	132
+Thorax^CHEST_WITHOUT (Adult)	CT	MIDRC	127
+MR BREAST BIL SCREENING WO W CONTRAST	MR	ACRdart,IDC	125
+BREAST^AB-MRI STUDY	MR	ACRdart,IDC	124
+MR HEAD W AND WO IV CONTRAST TUMOR FOLLOWUP WITH PERFUSION PERME	MR, SEG, nan	IDC,TCIA	124
+Diagnostic Pre-Surgery Contrast Enhanced CT	CT, nan	IDC,TCIA	122
+MAMMOGRAM/ULTRASOUND EXAM	US	ACRdart	120
+breast^standard	MR, nan	IDC,TCIA	120
+CT ABDOMEN w & PELVIS w	CT, SEG, nan	IDC,TCIA	120
+CHEST 1 VIEW PA/AP PORTABLE	CR	MIDRC	119
+Head^ROUTINE_DE_HEAD (Adult)	CT	MIDRC	119
+BREAST^ROUTINE DYNAMICS	MR, SEG, nan	IDC,TCIA	118
+Abdomen^02_0_AP_Routine (Adult)	CT, nan	IDC,TCIA	118
+MR BREAST BILAT W OR WO	MR, nan	IDC,TCIA	118
+MAMMO DIAGNOSTIC DIGITAL BILATERAL	MG, nan	IDC,TCIA	116
+Thorax^FLASH_CHEST_WO (Adult)	CT	MIDRC	115
+Preop	MR, SEG	IDC	114
+Intraop	US, MR, SEG	IDC	114
+Radiomics Phantom	nan	TCIA	113
+BRAIN W/O STROKE PROTOCOL-CS	CT	MIDRC	112
+MRI CLINICAL SPECTROSCOPY	MR, SEG, nan	IDC,TCIA	112
+Thorax^DE_CHEST_PE_Customized (Adult)	CT	MIDRC	110
+BREAST  W/O followed by W CONTRAST, BILATERAL	MR, SEG, nan	IDC,TCIA	109
+FDG 5AFOV TORSO	CT, SEG, PT, nan	IDC,TCIA	109
+CT INFUSED CHEST	SEG, nan	IDC,TCIA	108
+Unspecified CT	CT, nan	IDC,TCIA	108
+CT ANGIO CHEST W	CT	MIDRC	108
+CHEST PORTABLE	CR, DX	MIDRC	108
+Head^CT_HEAD_WO (Adult)	CT	MIDRC	107
+CTA CHEST-CS	CT	MIDRC	107
+MR BREASTS ABBREV WO W	MR	ACRdart,IDC	105
+DIG SCR TOMO MAM BIL	MG	ACRdart,IDC	105
+CT ANGIO ABD WITH CH AND PEL	SEG, nan	IDC,TCIA	104
+BREAST^ROUTINE	MR, SEG, nan	IDC,TCIA,ACRdart	104
+THORAX PE	CT, nan	IDC,TCIA,MIDRC	100
+MAMMO DIGITAL TOMOSYNTHESIS SCREENING BILATERAL	MG	ACRdart,IDC	100
+Abdomen^1 ACRIN PRONE COLONOGRAPHY	CT, nan	IDC,TCIA	100
+MAMMO+3D SCREEN	MG	ACRdart,IDC	100
+CT_Chest	CT, nan	IDC,TCIA	99
+01_PM_Thorax_Plain(Adult)	CT	MIDRC	98
+Thorax^AThoraxRoutine (Adult)	CT, nan	IDC,TCIA	98
+PET^03_Wholebody_First_Head (Adult)	CT, SEG, PT, nan	IDC,TCIA	96
+CTA CHEST PULMONARY ANGIOGRAPHY W CONTRAST	CT	MIDRC	96
+CT ABDOMEN PELVIS WO CONTRAST (ROUTINE)	CT	MIDRC	96
+MAMMOGRAPHY-SCREENING-TOMO-BILAT	MG	ACRdart,IDC	95
+Standard Screening - Combo	MG, MR	ACRdart,IDC	95
+MR BREAST BILAT W OR WO CA	MR, nan	IDC,TCIA	94
+CTC	CT, nan	IDC,TCIA	94
+HEAD^ROUTINE	MR, SEG, nan	IDC,TCIA	94
+Abdomen^CT_AP_WITH (Adult)	CT	MIDRC	92
+BREAST^ACRIN STUDY	MR, nan	IDC,TCIA	92
+CT ANGIOGRAM CHEST	CT, nan	IDC,TCIA,MIDRC	90
+three_phase__abdomen	SEG, nan	IDC,TCIA	90
+CT ANGIO CHEST WWO	CT	MIDRC	90
+CHEST 1 VIEW ICU	DX	MIDRC	89
+MR BREAST BILAT W AND W/O CONT-DR	MR, SEG, nan	IDC,TCIA	88
+PET CT with registered MR	RTSTRUCT, CT, PT, MR, nan	IDC,TCIA	88
+MRI BREAST BILATERAL ABBREVIATED STUDY	MR	ACRdart,IDC	87
+BREAST W/O followed by W CONTRAST, UNILAT	MR, SEG, nan	IDC,TCIA	86
+MRI RESEARCH AB BREAST BILAT LIMITED W AND WO CONT ECH	MR	ACRdart,IDC	86
+BREAST MRI	MR, nan	IDC,TCIA	86
+*CT ABDOMEN & PELVIS	CT, nan	IDC,TCIA	86
+CT ABDOMEN w + PELVIS w	CT, SEG, nan	IDC,TCIA	86
+MAMSCTOMO	MG	ACRdart,IDC	85
+BREAST^7 CHANNEL WHITE COIL ROUTINE FOV 320	MR	ACRdart,IDC	84
+Abdomen^3_COLONOGRAPHY	CT, nan	IDC,TCIA	84
+MAMMO TOMO SCREEN BILAT	MG	ACRdart,IDC	84
+CT CHEST W/O CONTRAST	CT, SEG, nan	IDC,TCIA,MIDRC	84
+PET F-18 NaF Bone Scan	CT, PT, nan	IDC,TCIA	82
+CT ANGIOGRAPHY NECK AND HEAD	CT	MIDRC	82
+CT ABD W/CONT  RECONSTRUCTION	CT, nan	IDC,TCIA	82
+0	CR, DX, MG, MR	IDC,MIDRC	81
+MAM Dig Breast Screen Tomosynthesis	MG	ACRdart,IDC	81
+DG CHEST 2V	CR, DX	MIDRC	80
+CHEST 2 VIEW	DX, nan	IDC,TCIA	78
+CT CHEST WO IV CONTRAST	CT	MIDRC,AIMI	78
+XR KUB, FLAT PLATE, ABDOMEN 1 VIEW	CR, DX	MIDRC	78
+MR BREAST BILAT W+WO	MR	ACRdart	78
+MRI BREAST RESEARCH	MR	ACRdart,IDC	77
+BODY^BREAST	MR, nan	ACRdart,TCIA,IDC	74
+abdomen_pelvis__w	SEG, nan	IDC,TCIA	74
+RESSONANCIA MAGNETICA DE ABDOME INFERIOR	MR, nan	IDC,TCIA	74
+MRI BREAST ABBREVIATED BILATERAL W/WO CONTRAST	MR	ACRdart,IDC	74
+BREAST^LESION  DETECTION	MR	ACRdart,IDC	74
+Unspecified CT CHEST	CT, nan	TCIA,MIDRC	74
+Abdomen^14_SUPINE_COLON (Adult)	CT, nan	IDC,TCIA	74
+CTA CHEST ABDOMEN PELVIS WWO	CT	MIDRC	73
+CT ABDOMEN/PELVIS WITH CONTRAST	CT	MIDRC	73
+abdomen__w	SEG, nan	IDC,TCIA	72
+Infinity-1 Treat:Tx Plan	CT, nan	IDC,TCIA	72
+CT ABDOMEN PELVIS W CONT	CT, nan	IDC,TCIA	72
+Thorax^04_0_CAP_Routine (Adult)	CT, SEG, nan	IDC,TCIA	72
+CT CHEST WITH IV CONTRAST	CT	MIDRC	71
+CT CHEST AND UPPER ABD W	CT	MIDRC	70
+LUNG	CT, SEG, PT, nan	IDC,TCIA	68
+CT CHEST ABDOMEN PELVIS WO CONTRAST	CT	MIDRC	68
+PET^01_PThead_lung (Adult)	CT, nan	IDC,TCIA	68
+Chest children	DX	MIDRC	67
+PET/CT Lung Cancer	CT, SEG, nan	IDC,TCIA	66
+MR ACRN STUDY	MR, nan	IDC,TCIA	66
+SCREENING CT COLONOGRA	CT, nan	IDC,TCIA	66
+MR Breast Research Gra	MR, SEG	IDC	66
+Thorax^CT_CAP_WITH (Adult)	CT	MIDRC	65
+CT ABDOMEN	CT, SEG, nan	IDC,TCIA,MIDRC	65
+PR CHEST 1 VIEW	CR	MIDRC	65
+CT CHEST O CONTR	CT, SEG, nan	IDC,TCIA	64
+CT CARDIAC CTA CORONARY	CT, nan	IDC,TCIA	64
+PET^1PETCT_WholeBody (Adult)	CT, SEG, nan	IDC,TCIA	64
+Thorax^ThoraxPETCT1	CT, SEG, PT, nan	IDC,TCIA	64
+CHEST ROUTINE PA AP AND LATERAL	CR, nan	IDC,TCIA,MIDRC	64
+MRMAM	MR	ACRdart,IDC	64
+Standard Screening - ComboHD	MG	ACRdart,IDC	64
+Tomo HD BDS	MG, CT	ACRdart,IDC	63
+Thorax^CHEST_WO_GR (Adult)	CT	MIDRC	62
+CHEST ROUTINE	CR, DX	MIDRC	62
+BREAST^ROUTINE DYNAMIC	MR, SEG, nan	IDC,TCIA	62
+MR PELVIS IMAGE IMPORT	MR, nan	IDC,TCIA	62
+MRI BREAST W/ + W/O CONTRAST BILATERAL	MR	ACRdart,IDC	62
+Thorax^CHEST_WITH (Adult)	CT	MIDRC	61
+Abdomen^ABDOMEN_PELVIS_W_ROUTINE (Adult)	CT	MIDRC	61
+three_phase__abdomen_pelvis	SEG, nan	IDC,TCIA	60
+Research 1^breast	MR, nan	IDC,TCIA	60
+JCCI CT CHEST	CT	MIDRC	60
+MR1	REG, RTSTRUCT, MR, nan	IDC,TCIA	60
+CHEST WO(Adult)	CT	MIDRC	59
+ULTRASOUND	US	ACRdart	59
+Bladder CT	CT, nan	IDC,TCIA	58
+CT CHEST W/O IV CON	CT	MIDRC	58
+CT ANGIO CHEST PULM EMBOLISM	CT	MIDRC	57
+CT THORAX PE EXAM	CT	MIDRC	57
+MRI Breast Bilateral wo then w Contrast	MR	ACRdart,IDC	57
+MR2	RTSTRUCT, REG, MR, nan	IDC,TCIA	56
+GBM_intracranial	MR, nan	IDC,TCIA	56
+PELVIS^PROSTATE	MR, nan	IDC,TCIA	56
+BRAIN BRAIN TUMOR	MR, SEG, nan	IDC,TCIA	56
+Thorax^XL_PE_Customized (Adult)	CT	MIDRC	55
+EC BREAST SCREENING-BILATERAL WITH CAD	MG	ACRdart,IDC	55
+MRI BREAST, BILATERAL WITH T WITHOUT CONTRAST	MR, nan	IDC,TCIA	55
+MR Breast Research Gr?	MR, SEG	IDC	55
+MRI Breast w w o Contrast bilat (Birad)	MR	ACRdart,IDC	55
+CT ABDOMEN AND PELVIS WITH CONTRAST	RTSTRUCT, CT, nan	IDC,TCIA,MIDRC	55
+Abdomen^STONE_STUDY_FULL (Adult)	CT	MIDRC	55
+BREAST^MASS PROTOCAL	MR, nan	IDC,TCIA	54
+MR3	RTSTRUCT, REG, MR, nan	IDC,TCIA	54
+Abdomen^17_Supine_and_Prone_Colon (Adult)	CT, nan	IDC,TCIA	54
+PANCREAS	RTSTRUCT, CT, nan	IDC,TCIA	54
+Thorax^ROUTINE_CHEST_WITHOUT (Adult)	CT	MIDRC	54
+HEAD^BRAIN TUMOR	MR, SEG, nan	IDC,TCIA	54
+CT ANGIO LIVER WITH CH/PEL	SEG, nan	IDC,TCIA	54
+Thorax^GH_ThoraxRoutine (Adult)	CT	MIDRC	53
+MIEDNICA	RTSTRUCT, MR, nan	IDC,TCIA	52
+CT AbdPelvis	CT, nan	IDC,TCIA	52
+Abdomen^1_ACRIN_COLON (Adult)	CT, nan	IDC,TCIA	52
+CT, COLONOGRAPHY SCREE	CT, nan	IDC,TCIA	52
+Abdomen^02_0_Abdomen_Routine (Adult)	CT, nan	IDC,TCIA	52
+CT Chest	CT, SEG, nan	IDC,TCIA	52
+Thorax^CHEST_ABD_PEL_WITH (Adult)	CT	MIDRC	52
+CT PE CHEST	CT, nan	IDC,TCIA,MIDRC	51
+DIGITAL MAMM SCREENING W/ TOMO	MG	ACRdart,IDC	51
+Thorax^FLASH_PE (Adult)	CT	MIDRC	51
+CT CHEST ABDOMEN PELVIS WO	CT	MIDRC	50
+66671F	MR, nan	IDC,TCIA	50
+CT CH/AB/PEL KIDNEY PROTOCOL	CT, SEG, nan	IDC,TCIA	50
+Thorax^CT_CHEST_WITHOUT (Adult)	CT	MIDRC	50
+MR BREAST FAST BILATERAL	MR	ACRdart,IDC	50
+BRAIN^STEALTH	MR, SEG, nan	IDC,TCIA	50
+lung+c	CT, SEG, nan	IDC,TCIA	50
+MR HEAD FUNCTIONAL MOTOR LANGUAGE	MR, SEG, nan	IDC,TCIA	50
+Abdomen^22 COLON SUPINE	CT, nan	IDC,TCIA	50
+Abdomen^Brzuch_3fazy_Adult (Adult)	RTSTRUCT, CT, nan	IDC,TCIA	50
+MRI Prostate ERC	MR, nan	IDC,TCIA	50
+MR BREAST BILATERAL WITH/WITHOUT CONTRAST	MR	ACRdart,IDC	49
+Thorax^ROUTINE_CHEST_ABD_PEL_WITH (Adult)	CT	MIDRC	48
+LUNG+C	CT, SEG, nan	IDC,TCIA	48
+CT THORAX W/O DYE	SEG, nan	IDC,TCIA	48
+ACRIN6667-RESEARCH	MR, nan	IDC,TCIA	48
+MRI Abd wo&w	MR, nan	IDC,TCIA	48
+ABDOMEN SUPINE KUB	CR, DX, nan	IDC,TCIA,MIDRC	48
+CT_AbdPel	CT, nan	IDC,TCIA	48
+CT CHEST W CONT	CT, nan	IDC,TCIA,MIDRC	48
+MAMM TOMO SCREEN DIGITAL BILAT	MG	ACRdart,IDC	47
+PET CT MID BODY	CT, SEG, PT, nan	IDC,TCIA	47
+Thorax^XL_PE (Adult)	CT	MIDRC	47
+Head^DE_HEAD_WITHOUT (Adult)	CT	MIDRC	47
+BREAST^LESION	MR, nan	ACRdart,TCIA,IDC	47
+H DIGITAL SCREEN/TOMO, CVIEW & CAD	MG	ACRdart,IDC	46
+Abdomen^1_ROUTINE_CAP (Adult)	CT	MIDRC	46
+CT CODE STROKE (BRAIN WO, CTA, PERFUSION)	CT	MIDRC	46
+IMR BREAST W/O & W/BILATERAL	MR, nan	IDC,TCIA	46
+MR PELVIS, OUTSIDE IMAGING	SEG, nan	IDC,TCIA	46
+TRANSTHORACIC ECHO	US	MIDRC	46
+CT_AbdPelvis	CT, nan	IDC,TCIA	46
+CT FACE SINUSES WO CONTRAST	CT	MIDRC	45
+CT CHEST W IV CONTRAST	RTSTRUCT, CT, nan	IDC,TCIA,MIDRC	44
+Abdomen^01ACRINColonographySupine	CT, nan	IDC,TCIA	44
+CT GUIDED LUNG B	CT, SEG, nan	IDC,TCIA	44
+CT RENAL Mass	CT, SEG, nan	IDC,TCIA	44
+Abdomen^1_COLONOGRAPHY (Adult)	CT, nan	IDC,TCIA	44
+LUNG CA	CT, SEG, PT, nan	IDC,TCIA	44
+CT Thorax	CT, SEG, nan	IDC,TCIA	44
+MRI BREAST ABBREVIATED	MR	ACRdart,IDC	44
+Unknown	US	ACRdart	43
+MR BREAST, BILATERAL W/WO CONT	MR	ACRdart,IDC	43
+RT^RT_RespLowBreathRateRNS (Adult)	RWV, CT, PT, nan	IDC,TCIA	42
+MR BREAST	MR, SEG, nan	IDC,TCIA	42
+THORAX/ABDOMEN/PELVIS + CONT	CT, nan	IDC,TCIA,MIDRC	42
+lung	CT, SEG, PT, nan	IDC,TCIA	42
+MR BREAST BILAT W AND W-O CONT -DR	MR, SEG, nan	IDC,TCIA	42
+MRI BRAIN WITH INJ - MHDI	MR, SEG, nan	IDC,TCIA	42
+CHEST 2 VIEWS (ROUTINE)	CR	MIDRC	42
+CCR Phantom	nan	TCIA	41
+Thorax^CHEST_ABD_PEL_WO (Adult)	CT	MIDRC	41
+XR P PORT ABDOMEN AP 1 VIEW	CR	MIDRC	41
+Thorax^XL_CHEST_WO (Adult)	CT	MIDRC	41
+Breast CE	MR, nan	IDC,TCIA	40
+HEAD^FUNCTIONAL	MR, SEG, nan	IDC,TCIA	40
+Spine^SPINE_BONE_SBRT (Adult)	CT, SEG, nan	IDC,TCIA	40
+CT AB/PEL KIDNEY PROTOCOL	CT, SEG, nan	IDC,TCIA	40
+MR Breast Bi w/wo contrast	MR	ACRdart,IDC	40
+Abdomen^12_0_Liver_BiPhase (Adult)	CT, SEG, nan	IDC,TCIA	40
+CT THORAX WITH CONTRAST	RTSTRUCT, CT, SEG, nan	IDC,TCIA,MIDRC	40
+PET/CT	CT, SEG, PT, nan	IDC,TCIA	40
+PET CT LUNG CANCER	SEG, nan	IDC,TCIA	40
+_t1of3  External Images for PACS	MR, nan	IDC,TCIA	40
+PET1	CT, PT, nan	IDC,TCIA	40
+PET2	CT, PT, nan	IDC,TCIA	40
+MAM Tomo Screening	MG	ACRdart,IDC	40
+PET^03_CBM_Wholebody_First_Head (Adult)	CT, SEG, PT, nan	IDC,TCIA	40
+CT Thorax W/ Contrast	CT	MIDRC	39
+BREAST^16 Channel Coil	MR	ACRdart,IDC	39
+CTA CORONARY	CT	MIDRC	39
+BREAST^EA1141 - AB MRI ECOG-ACRIN	MR	ACRdart,IDC	39
+MA MAMMOGRAM SCREENING BILATERAL W/TOMO	MG	ACRdart	39
+CT DIAGN VIRT COLONOSCOPY	CT, nan	IDC,TCIA	38
+CT COLONOGRAPHY SCREEN	CT, nan	IDC,TCIA	38
+MR SCREENING BREAST WANDW/O CONTRAST	MR	ACRdart,IDC	38
+CTA PULMONARY EMBOLUS	CT	MIDRC	38
+PET3	CT, PT, nan	IDC,TCIA	38
+X-RAY LUMBOSACRAL SPINE 2 OR 3 VIEWS	CR, DX	MIDRC	38
+FORFILE CT ABD AND/OR PEL - CD	CT, SEG, nan	IDC,TCIA	38
+Abdomen^ABD_PEL_WO (Adult)	CT	MIDRC	38
+CT CHEST	CT, SEG, nan	IDC,TCIA,MIDRC	37
+MRI BREAST BILATERAL	MR, SEG, nan	IDC,TCIA,ACRdart	37
+CT ABDOMEN PELVIS WO CONTRAST (STONE)	CT	MIDRC	37
+CTA CHEST PULMONARY EMBOLISM	CT	MIDRC	37
+Thorax^DE_PE (Adult)	CT	MIDRC	37
+MRI ABD W+WO CONT	MR, nan	IDC,TCIA	36
+PETCT SUBSEQUENT TREAT	SEG, nan	IDC,TCIA	36
+TX AS	CT, nan	IDC,TCIA	36
+MG. Mammo Digital Screening Bilateral	MG	ACRdart,IDC	36
+CT ABD PELVIS(WITH CHEST IMAGES) WO IV CON	CT, nan	IDC,TCIA,MIDRC	36
+PET IMAGE W/CT, SKULL-	SEG, PT, nan	IDC,TCIA	36
+CT THORAX WO IV CONTRA	CT, SEG, nan	IDC,TCIA	36
+FDG PET CT Clinical Wh	SEG, nan	IDC,TCIA	36
+WB PET/CT	CT, SEG, PT, nan	IDC,TCIA	36
+CT ANGIO ABD AND PEL WWO IV CONT	CT, nan	IDC,TCIA,MIDRC	36
+Thorax^DE_CHEST_PE (Adult)	CT	MIDRC	36
+abdomen__w_and_wo	SEG, nan	IDC,TCIA	36
+TOMOSYNTHESIS MAMMO DIGITAL SCREENING BILATERAL	MG	ACRdart,IDC	36
+Abdomen^7MCV_VIRTUAL_COLONOSCOPY	CT, nan	IDC,TCIA	36
+PET/CT WHOLE BODY	CT, SEG, PT, nan	IDC,TCIA	36
+MR prostaat detectie PCMAPS_mc MCAPCMAPS	MR, SEG, nan	IDC,TCIA	36
+MAM MAMMOGRAPHY SCREENING WITH TOMOSYNTHESIS BILATERAL	MG	ACRdart,IDC	35
+BREAST	US, MR, SEG, nan	IDC,TCIA,ACRdart	35
+CT CHEST W/O	CT, SEG, nan	IDC,TCIA,MIDRC	35
+CT, ABDOMEN W&W/O CONT	CT, SEG, nan	IDC,TCIA	34
+BREAST^EA1141 RESEARCH STUDY	MR	ACRdart,IDC	34
+Thorax^CT_CHEST_WITH (Adult)	CT	MIDRC	34
+CT ABDOMEN AND PELVIS	RTSTRUCT, CT, SEG, nan	IDC,TCIA,MIDRC	34
+MRM/6667	MR, nan	IDC,TCIA	34
+CT ABDOMEN & PELVIS ENHANCED=AB	RTSTRUCT, CT, nan	IDC,TCIA	34
+X-RAY ABDOMEN SINGLE VIEW	CR, DX	MIDRC	34
+CT LEVEL CHEST ABDOMEN PELVIS W ED	CT	MIDRC	34
+CT AB/PEL W/ CONTRAST	CT, SEG, nan	IDC,TCIA	34
+CT ABD PELVIS(WITH CHEST IMAGES) W IV CON	CT, nan	IDC,TCIA,MIDRC	33
+Vascular^CTA_HEAD_NECK (Adult)	CT	MIDRC	33
+MR BREAST BILATERAL W/WO CONT	nan	TCIA	33
+CT Angio Pulmonary	CT	MIDRC	33
+ABD SERIES FLAT AND ERECT PORTABLE	CR, DX, nan	IDC,TCIA,MIDRC	33
+CHEST AP CENTRAL LINE PL PORTABLE	CR, nan	IDC,TCIA,MIDRC	33
+Thorax^ROUTINE_CHEST_WO (Adult)	CT	MIDRC	33
+XR LEFT FOOT 3+ VIEWS	CR, DX	MIDRC	32
+PET^02_CBM_Wholebody_Only (Adult)	CT, SEG, PT, nan	IDC,TCIA	32
+CT Thorax w/Contrast	SEG, nan	IDC,TCIA	32
+PET^08_Wholebody_Only (Adult)	CT, SEG, PT, nan	IDC,TCIA	32
+XR CERVICAL SPINE 2-3 VIEWS	CR, DX	MIDRC	32
+PET^CCF_WholeBody_PETCT (Adult)	CT, SEG, PT, nan	IDC,TCIA	32
+Outside Read or Comparison BODY CT	CT, SEG, nan	IDC,TCIA	32
+CT C	CT, nan	IDC,TCIA	32
+PCAMPMRI	SEG, nan	IDC,TCIA	32
+MAMMO SCREENING TOMOSYNTHESIS - BILATERAL TOMO CC	MG	ACRdart,IDC	31
+Screening Mammogram Bilateral W Tomo	MG	ACRdart,IDC	31
+MRI LUMBAR SPINE W/O CONTRAST	MR	MIDRC	31
+<NONE>	CR, DX, MR	MIDRC	31
+BR DBT Screening Mammography-Digital	MG	ACRdart,IDC	31
+PET/CT NSCLC RESTAGING	SEG, nan	IDC,TCIA	30
+CT Chest with	CT, nan	IDC,TCIA	30
+BR MRI BREAST, BILATERAL W/O-W CONTRAST	MR	ACRdart,IDC	30
+CT ANGIO CHEST W&W/O C	CT, SEG, nan	IDC,TCIA	30
+K9 BRAIN	MR, nan	IDC,TCIA	30
+BREAST^ROUTINE_DYNAMICS	MR, SEG, nan	IDC,TCIA	30
+CT ABDOMEN/PELVIS WITHOUT CONTRAST	CT	MIDRC	30
+HEAD^SMALL ANIMAL	MR, nan	IDC,TCIA	30
+BILAT/ATTN LEFT	MR, nan	IDC,TCIA	30
+MRI Abdomen	MR, nan	IDC,TCIA	30
+MR BREAST WO/W CONT	MR, SEG, nan	IDC,TCIA	30
+F-18 FDG PETWhole Bod	SEG, PT, nan	IDC,TCIA	30
+PT CT WHOLE BODY-BODY	SEG, PT, nan	IDC,TCIA	30
+*MRI - ABDOMEN	MR, nan	IDC,TCIA	30
+F-18 FDG PET(Whole Bod	CT, SEG, PT, nan	IDC,TCIA	30
+Lung	SEG, PT, nan	IDC,TCIA	30
+Abdomen^1WBPETCT	SEG, PT, nan	IDC,TCIA	30
+CONTRABREAST (RIGHT)	MR, nan	IDC,TCIA	30
+^BRAIN RESEARCH	MR, SEG, nan	IDC,TCIA	30
+DPCXR	DX	MIDRC	29
+XR RIGHT FOOT 3+ VIEWS	CR, DX	MIDRC	29
+AS AI	CT, nan	IDC,TCIA	29
+BREAST^LESION EVALUATION	MR	ACRdart,IDC	29
+Thorax^CHEST_WITH_GR (Adult)	CT	MIDRC	29
+CT THORAX W/DYE	SEG, nan	IDC,TCIA	29
+ECOG-ACRIN^ECOG-ACRIN	MR	ACRdart,IDC	29
+BR MRI BREAST BILATERAL WITH CONTRAST FULL PROTOCOL	MR	ACRdart,IDC	29
+PET/CT Sk-Th	CT, SEG, nan	IDC,TCIA	28
+MR ABDOMEN W/WO CONTRAST	MR, SEG, nan	IDC,TCIA	28
+*CT Chest,Abdomen,Pelv	CT, nan	IDC,TCIA	28
+BRAIN BRAIN	MR, SEG, nan	IDC,TCIA	28
+BRAIN	MR, nan	IDC,TCIA	28
+BREAST^GENERAL	MR, SEG, nan	IDC,TCIA	28
+CT CHEST W/O CONT-DESC	SEG, nan	IDC,TCIA	28
+CT Chest Reference Only	CT, SEG, nan	IDC,TCIA	28
+RM CHEST 1 VIEW PORTABLE	DX	MIDRC	28
+CT NON-INFUSED CHEST	SEG, nan	IDC,TCIA	28
+CT ABDOMEN NONENH & ENHANCED=AB	RTSTRUCT, nan	IDC,TCIA	28
+PET/CT SKULL BASE TO M	CT, SEG, PT, nan	IDC,TCIA	28
+Abdomen^01_WB_PETCT	SEG, nan	IDC,TCIA	28
+BREAST W/WO	MR, nan	IDC,TCIA	28
+XR LUMBAR SPINE 2-3 VIEWS	CR, DX	MIDRC	28
+Abdomen^1 AP ROUTINE	CT, nan	IDC,TCIA	28
+_t3of3  MRI IAMS	MR, nan	IDC,TCIA	28
+CT ANGIOGRAPHY NECK	CT	MIDRC	27
+CT Angio Chest	CT	MIDRC	27
+Head^HEAD_ROUTINE (Adult)	CT	MIDRC	27
+MAMMO 3D TOMO SCREENING BILATERAL	MG	ACRdart,IDC	27
+Abdomen^1_ROUTINE_CAP_WO (Adult)	CT	MIDRC	27
+MAMMO SCREENING BILATERAL TOMOSYNTHESIS	MG	ACRdart,IDC	27
+HIGH RES CHEST(Adult)	CT	MIDRC	27
+Vascular^CTA_PE_GR (Adult)	CT	MIDRC	27
+Study De-Identified for Patient Confidentiality	US, CT, nan	ACRdart,TCIA,IDC	27
+XR LEFT SHOULDER 2+ VIEWS	CR, DX	MIDRC	27
+MAMMO SCREEN BILAT/TOMO/CAD	MG	ACRdart,IDC	26
+abdomen_pelvis__w_and_wo	SEG, nan	IDC,TCIA	26
+CT THORAX W/O CONTRAST	CT, SEG, nan	IDC,TCIA	26
+BRAIN^HEAD	MR, SEG, nan	IDC,TCIA	26
+MR HEAD W AND WO IV CONTRAST FOLLOWUP WITH PERFUSION PERMEABILIT	MR, SEG, nan	IDC,TCIA	26
+CT COLONOGRAPHY	CT, nan	IDC,TCIA	26
+CT BRAIN WITHOUT CONTRAST	CT	MIDRC	26
+CT SCREENING VIRT COLONOSCOPY	CT, nan	IDC,TCIA	26
+PET/CT LUNG CA	SEG, nan	IDC,TCIA	26
+MRI BREAST RESEARCH BILAT WO/W CONTRAST	MR	ACRdart,IDC	26
+PROSTATE	CT, MR, nan	IDC,TCIA	26
+PET^NEW_03_CBM_Wholebody_First_Head (Adult)	CT, SEG, nan	IDC,TCIA	26
+CT Rad Onc Lmtd.	CT, nan	IDC,TCIA	26
+XRAY-MAMMOGRAM SCREENING TOMO	MG	ACRdart,IDC	25
+CT ANGIO CHEST (NON-CO	SEG, nan	IDC,TCIA	25
+XR RIGHT ANKLE 3+ VIEWS	CR, DX	MIDRC	25
+MRI RESEARCH GRANT	MR, SEG	IDC	25
+MR prostaat kanker detectie ND_mc MCAPRODETN	MR, SEG, nan	IDC,TCIA	24
+CTA CHEST PULMONARY AN	CT	MIDRC	24
+MRI^BREAST	MR	ACRdart,IDC	24
+CT ANGIO ABD WITH PEL	SEG, nan	IDC,TCIA	24
+Abdomen^01_AP_Routine (Adult)	CT, nan	IDC,TCIA	24
+CT CHEST CONTRAST	CT, nan	IDC,TCIA	24
+Thorax^02_CAP_Routine (Adult)	CT, nan	IDC,TCIA	24
+CT ABDOMEN w	CT, SEG, nan	IDC,TCIA	24
+PET^07_PThead_lung (Adult)	CT, nan	IDC,TCIA	24
+CTA CHEST PULMONARY EMBOLUS W/IVCON	CT	MIDRC	24
+SCREENING MAMMOGRAM WITH TOMOSYNTHESIS	MG	ACRdart,IDC	24
+CHEST 1 VIEW (INCLUDING PORTABLE)	CR	MIDRC	24
+CT Chest with contrast	CT, nan	IDC,TCIA	24
+Abdomen^DE_ROUTINE_AP_WITH_OVER_50_Customized (Adult)	CT	MIDRC	24
+MAMMOGRAM DIGITAL SCREENING BILATERAL W/TOMO	MG	ACRdart,IDC	24
+Chest CT routine	CT, nan	IDC,TCIA	24
+ABDOMEN	CT, MR, nan	IDC,TCIA	24
+CT COLONOSCOPY	CT, nan	IDC,TCIA	24
+Thorax^ROUTINE_CHEST_ABD_PELVIS_W (Adult)	CT	MIDRC	24
+CT CHEST W/ CONT	CT, SEG, nan	IDC,TCIA	24
+BREAST^ROUTINE CA	MR, SEG, nan	IDC,TCIA	24
+MAMMO DIAGNOSTIC BREAST TOMOSYNTHESIS BILATERAL	MG, nan	IDC,TCIA	24
+Thorax^C_A_P_WITH_GR (Adult)	CT	MIDRC	23
+Thorax^FLASH_CHEST_WITH_ (Adult)	CT	MIDRC	23
+Abdomen^ABD_WITH_GR (Adult)	CT	MIDRC	23
+MRI BREAST BILAT CAD WWO	MR, nan	ACRdart,TCIA,IDC	23
+LEFT BREAST	MR, SEG, nan	IDC,TCIA	23
+Thorax^CHEST_ABD_PELVIS_W (Adult)	CT	MIDRC	23
+CT CHEST PE WITH CONTRAST	CT	MIDRC	23
+DX CXR 1 View-Post Procedure	CR, DX	MIDRC	23
+MRI Breast w/ + w/o Contrast Bil Abbrev	MR	ACRdart,IDC	23
+PELVIS	RTSTRUCT, CT, nan	IDC,TCIA	22
+CHEST PA - LAT	CR, DX, nan	IDC,TCIA	22
+Chest 1V	CR	MIDRC	22
+CHEST PE(Adult)	CT	MIDRC	22
+BREAST^ECOG-ACRIN	MR	ACRdart,IDC	22
+Abdomen^2_ROUTINE_AP (Adult)	CT	MIDRC	22
+ABDOMEN 1 VIEW	CR, DX	MIDRC	22
+CH+C	SEG, nan	IDC,TCIA	22
+WI-MR BREAST BILAT W+WO	MR	IDC	22
+MR BRAIN WITH AND WITHOUT CONTRAST	MR	MIDRC	22
+CONTRABREAST (LEFT)	MR, nan	IDC,TCIA	22
+Vascular^DISSECTION_CTA_CAP (Adult)	CT	MIDRC	22
+XR LEFT HAND 3+ VIEWS	CR, DX	MIDRC	22
+CT ABD PELV EN	CT, nan	IDC,TCIA	22
+BILAT/ATTN RIGHT	MR, nan	IDC,TCIA	22
+MR SPINE LUMBAR WO CONTRAST	MR	MIDRC	22
+CT CHEST ABD PELVIS W/ CONTR	CT, nan	IDC,TCIA	22
+PROTOCOLS^BREAST	MR, nan	IDC,TCIA	22
+Outside Read or Comparison MRI	MR, nan	IDC,TCIA	22
+CT ABDOMEN WITH CONTRA	CT, SEG, nan	IDC,TCIA	22
+Abdomen^CT_UROGRAM_STONE_STUDY (Adult)	CT	MIDRC	22
+CT UROGRAM	CT, nan	IDC,TCIA,MIDRC	22
+PET CT SKULL BASE TO MID-THIGH	CT, PT, nan	IDC,TCIA	22
+CT ABDOMEN/PELVIS W IV CONTRAST	RTSTRUCT, CT, nan	IDC,TCIA,MIDRC	22
+LUNG DELAYS	SEG, nan	IDC,TCIA	22
+TX AS AI	CT, nan	IDC,TCIA	22
+MRI CLINICAL SPECTROSCOPY - MRSPC	MR, SEG, nan	IDC,TCIA	22
+CAP_WITH(Adult)	CT	MIDRC	22
+PETCT_WholeBody	CT, PT, nan	IDC,TCIA	22
+SL2 Treatment:Tx Plan	CT, nan	IDC,TCIA	22
+_t2of3  MRI IAMS	MR, nan	IDC,TCIA	22
+XR RIGHT SHOULDER 2+ VIEWS	CR, DX	MIDRC	21
+X-RAY SHOULDER COMPLETE MIN 2 VIEWS - RIGHT	DX	MIDRC	21
+XR RIGHT KNEE 3 VIEWS (PAIN/ARTHRITIS)	CR, CR,DX, DX	MIDRC	21
+CT ABDOMEN AND PELVIS W/O CONTRAST	CT	MIDRC	21
+MAMMO SCREEN BILAT+TOMO	MG	ACRdart,IDC	21
+XR LEFT KNEE 3 VIEWS (PAIN/ARTHRITIS)	CR, DX	MIDRC	21
+X-RAY KNEE 3 VIEWS - RIGHT	DX	MIDRC	21
+CAP	CT, SEG, nan	IDC,TCIA,MIDRC	21
+Abdomen^2_ROUTINE_AP_WO (Adult)	CT	MIDRC	21
+CT CHEST REFERENCE ONLY	CT, nan	IDC,TCIA,AIMI	21
+NMPET/CT trunk	CT, PT, nan	IDC,TCIA	20
+Abd	US, nan	IDC,TCIA	20
+CT CHEST   W/CONTRAST	CT, nan	IDC,TCIA	20
+Abdomen^ABDOMEN (Adult)	CT, SEG, nan	IDC,TCIA	20
+BRAIN^FUNCTIONAL	MR, SEG, nan	IDC,TCIA	20
+CT CHEST W IV CON	CT	MIDRC	20
+CT C-SPINE W/O CONTRAST	CT	MIDRC	20
+CT Dynamic Chest Routi	CT, nan	IDC,TCIA	20
+CT PULMONARY W/CONTRAST	CT	MIDRC	20
+XR RIGHT KNEE 1-2 VIEWS	CR, DX	MIDRC	20
+CT chest upper low abdomen and pelvic+c	CT, nan	IDC,TCIA	20
+XR LEFT WRIST 3+ VIEWS	CR, DX	MIDRC	20
+PETCT SKULL-THIGH	SEG, PT, nan	IDC,TCIA	20
+DG CHEST 1V PORT	CR	MIDRC	20
+TomoHD Screening	MG	ACRdart,IDC	20
+LT BREAST	MR, nan	IDC,TCIA	20
+MM Mammogram Screening Digital DDI	MG	ACRdart,IDC	20
+BREAST^ACRIN RESEARCH	MR	ACRdart,IDC	20
+BREAST ROUTINE	MR, SEG, nan	IDC,TCIA	20
+CT ABD PELVIS W/ CONTRAST	OT, CT, nan	IDC,TCIA	20
+PET^02_Wholebody_Only (Adult)	CT, SEG, PT, nan	IDC,TCIA	20
+MR BREAST UNI U	MR, SEG, nan	IDC,TCIA	20
+Abdomen^ROUTINE_ABD_PEL_WITH (Adult)	CT	MIDRC	20
+RT BREAST	MR, nan	IDC,TCIA	20
+MR PELVIS WO+W CONTRAST	nan	TCIA	20
+PETCT Skull-MidThigh	CT, PT, nan	IDC,TCIA	20
+MR HEAD W AND WO IV CONTRAST TUMOR NAVIGATION	MR, SEG, nan	IDC,TCIA	20
+RESSONANCIA MAGNETICA DE PELVE	MR, nan	IDC,TCIA	20
+Thorax^FLASH_CAP_WITH (Adult)	CT	MIDRC	19
+CT CHEST PULMONARY ANGIOGRAM (ACUTE)	CT	MIDRC	19
+CT P CHEST ABDOMEN PELVIS W	CT	MIDRC	19
+CT CHEST WO CONTRAST (LOW DOSE FOR NODULE FOLLOW UP)	CT	MIDRC	19
+CT CHEST WITHOUT CONTR	RTSTRUCT, CT, SEG, nan	IDC,TCIA,MIDRC	19
+breast^general	MR, nan	ACRdart,TCIA,IDC	19
+Abdomen^ROUTINE_AP_WO_Customized (Adult)	CT	MIDRC	19
+CTA CHEST FOR PE	CT	MIDRC	19
+RIGHT BREAST	MR, nan	IDC,TCIA	19
+NM_WholeBody	NM, nan	IDC,TCIA	19
+PET LYMPHOMA NON HODGKINS (W/LOW DOSE CT)	PT,CT	MIDRC	19
+Thorax^ROUTINE_CHEST_WITH (Adult)	CT	MIDRC	19
+Thorax^PE_STUDY (Adult)	CT	MIDRC	19
+CT CT-Thorax for Pulmonary Embolism W/Cont	CT	MIDRC	19
+CT COLONOGRAP C	CT, nan	IDC,TCIA	18
+NPETSB	CT, SEG, nan	IDC,TCIA	18
+CT CHEST LUNG CANCER SCREENING WITHOUT CONTRAST ANNUAL	CT	MIDRC	18
+CT CHEST BIOPSY	CT	MIDRC	18
+Abdomen^14_Supine_and_Prone_Colon (Adult)	CT, nan	IDC,TCIA	18
+CT CHEST ABDOMEN W CONTRAST (ROUTINE)	CT	MIDRC	18
+CT CHEST ABDOMEN PELVIS W WO CONTRAST	CT, SEG, nan	IDC,TCIA,MIDRC	18
+CT CHEST w	CT, nan	IDC,TCIA	18
+CT CH/AB/PEL WITH LIVER TRIPHASIC	SEG, nan	IDC,TCIA	18
+BR-Breast US BI	US	ACRdart	18
+CT HIP W/O CONTRAST,BILAT	CT, nan	IDC,TCIA	18
+CT ABDOMEN W/O CONT	CT, nan	IDC,TCIA	18
+CT PET with registered MR	RTSTRUCT, CT, PT, MR, nan	IDC,TCIA	18
+MRI PELVIS W WO CONTRAST	SEG	IDC	18
+CT THORAX ENHANCED	CT, nan	IDC,TCIA	18
+MRI_Abdomen	MR, nan	IDC,TCIA	18
+CTA CHEST W CONTRAST	CT	MIDRC	18
+CHEST_WITH(Adult)	CT	MIDRC	18
+CHEST/ABD/PELVIS	CT, SEG, nan	IDC,TCIA	18
+Abdomen CT Enhanced	CT, nan	IDC,TCIA	18
+FOREIGN CD CT AB/PEL	CT, nan	IDC,TCIA	18
+CHEST CT	CT, nan	IDC,TCIA	18
+MR Breast Bilateral	MR	ACRdart,IDC	18
+MR BREAST LT W/WO	MR, nan	IDC,TCIA	18
+CT THORAX  WITHOUT CON	CT, SEG, nan	IDC,TCIA	18
+with DCE	MR, nan	IDC,TCIA	18
+Spontaneous Brain Tumor Model	MR, nan	IDC,TCIA	18
+*MRI - BREAST	MR, nan	IDC,TCIA	18
+Pancreas CT Enhanced	CT, nan	IDC,TCIA	18
+PET IMAGE W/CT SKULL-T	SEG, nan	IDC,TCIA	18
+Pio Xll001^Pelve	MR, nan	IDC,TCIA	18
+PET CT SKULL BASE TO MID THIGH	CT, SEG, nan	IDC,TCIA	18
+PET CT Clinical Body Reference Only	CT, SEG, PT, nan	IDC,TCIA	18
+Standard Screening -  COMBO HD	MG	ACRdart,IDC	17
+MRI BREAST BILATERAL WITH T WITHOUT CONTRAST	nan	TCIA	17
+IR CT CHEST TUBE	CT	MIDRC	17
+XR RIGHT WRIST 3+ VIEWS	CR, DX	MIDRC	17
+Head^head_wo_GR (Adult)	CT	MIDRC	17
+Head^HEAD_WO (Adult)	CT	MIDRC	17
+MR BREAST BILAT W OR WO SCCA	MR, SEG	IDC	17
+CTA CHEST AND ABDOMEN (THORACOABDOMNAL DISSECTION) WWO CONTRAST	CT	MIDRC	17
+MR BRST BI BIRAD W WO CNTRST	MR	ACRdart,IDC	17
+CT C/A/P	CT, SEG, nan	IDC,TCIA	16
+Abdomen^DUO_TX_AS_VOL (Adult)	CT, nan	IDC,TCIA	16
+KUB (RAD)-CS	CR, DX	MIDRC	16
+CT ANGIO ABDOMEN W & W/O CONT	SEG, nan	IDC,TCIA	16
+MR SPECTROSCOPY	MR, SEG, nan	IDC,TCIA,MIDRC	16
+CT Chest, Abdomen + Pelvis	CT, SEG, nan	IDC,TCIA	16
+Ribs L	CR	MIDRC	16
+CT Chest Pre OP (Post Contrast)	CT, nan	IDC,TCIA	16
+MRI_LSpine	MR, nan	IDC,TCIA	16
+XR LEFT ANKLE 3+ VIEWS	CR, DX	MIDRC	16
+CT ANGIOGRAM PULMONARY W CONTRAST	CT	MIDRC	16
+CTA CHEST (THORACIC DISSECTION) WWO CONTRAST	CT	MIDRC	16
+Abdomen^CT_AP_WO (Adult)	CT	MIDRC	16
+PET^NEW_02_CBM_Wholebody_Only (Adult)	CT, SEG, PT, nan	IDC,TCIA	16
+MRI BREAST BILATERAL WITH AND WITHOUT CONTRAST	MR, SEG, nan	IDC,TCIA	16
+MRI BREAST BILATERAL WO THEN W CONTRAST	MR	ACRdart,IDC	16
+MRI Pelvis with contrast	MR, nan	IDC,TCIA	16
+Cardiac^LA_MODEL (Adult)	CT	MIDRC	16
+MRI Pelvis W/WO Contrast=A	REG, RTSTRUCT, MR, nan	IDC,TCIA	16
+Abdomen^01Abdomen_Routine (Adult)	CT, nan	IDC,TCIA	16
+X-RAY KNEE 3 VIEWS - LEFT	CR, DX	MIDRC	16
+PET/CT LUNG NODULE	SEG, nan	IDC,TCIA	16
+Head^DE_CTA_HEAD_NECK (Adult)	CT	MIDRC	16
+CT CHEST W/ CONTRAST	CT, SEG, nan	IDC,TCIA	16
+CT CAP (LIV)	CT, SEG, nan	IDC,TCIA	16
+BIOPSY	MR, nan	IDC,TCIA	16
+MR PELVIS OUTSIDE IMAGING	SEG, nan	IDC,TCIA	16
+MAMMO SCREENING BILATERAL TOMOSYNTHESIS (BILATERAL DIAGNOSTIC AN	MG	ACRdart	16
+CT ABDOMEN wo&w	CT, nan	IDC,TCIA	16
+*CT ABDOMEN	CT, SEG, nan	IDC,TCIA	16
+MR BRAIN WO+W CONTRAST	MR, nan	IDC,TCIA	16
+BREAST 2017^BREAST LESION 2017	MR	ACRdart	16
+CT ABDOMEN W CO	CT, nan	IDC,TCIA	16
+C+C	SEG, nan	IDC,TCIA	16
+two_phase__abdomen	SEG, nan	IDC,TCIA	16
+X-RAY BONE OUTSIDE IMAGE	CR, DX	MIDRC	16
+_t1of3External Images for PACS	MR, nan	IDC,TCIA	16
+MR ABD IMAGE IMPORT	MR, nan	IDC,TCIA	16
+MG Tomosynthesis Breast Screening Bilateral	MG	ACRdart,IDC	16
+Thorax^CT_CAP_WITHOUT (Adult)	CT	MIDRC	16
+Breast^Bil tumor ax	MR, nan	IDC,TCIA	16
+CT THORAX W/CONT	CT, SEG, nan	IDC,TCIA	16
+OSI CT CHEST ABDOMEN PELVIS	CT, SEG, nan	IDC,TCIA	16
+CT ABDOMEN NONENH & ENHANCED-BODY	RTSTRUCT, CT, SEG, nan	IDC,TCIA	16
+MR ABBREVIATED BREAST	MR	ACRdart,IDC	16
+CT CHEST PELVIS W ABDOMEN WWO	CT, nan	IDC,TCIA,MIDRC	15
+BRST TOMOSYNTHESIS BILAT	MG	ACRdart,IDC	15
+Head^Perfusion (Adult)	CT	MIDRC	15
+CT CHEST WITH CONTRAST (PETCT)	CT	MIDRC	15
+THORAX PE + LOW DOSE	CT, nan	IDC,TCIA,MIDRC	15
+CT CHEST W/CON	SEG, nan	IDC,TCIA	15
+MR	MR	ACRdart,IDC	15
+CT CHEST LOW DOSE SCREENING	CT	MIDRC	15
+CT CHEST ABDOMEN PELVIS W IV CON	CT	MIDRC	15
+MR Breast Bilat WWO Contrast	MR	ACRdart,IDC	15
+Abdomen^STONE (Adult)	CT	MIDRC	15
+MRIBB3	MR	ACRdart,IDC	15
+PROSTATE/EMPTYAKL	nan	TCIA	15
+MAMM SCR TOMO ECOG ACRIN CLINICAL RSRCH	MG	ACRdart,IDC	15
+CT ESOPHAGRAM	CT	MIDRC	15
+PENN IMAGE EXCHANGE IMPORT	CR, DX	MIDRC	15
+BREAST (S) US UNIL-BILAT MAMMO	US	ACRdart	15
+PET CT FDG IMAG SKULL TO THIGH	OT, CT, PT, OT,PT, nan	IDC,TCIA,MIDRC	15
+CT LUNG CANCER SCREENING	CT	MIDRC,AIMI	15
+CT Chest W/O Contrast	CT, nan	IDC,TCIA,MIDRC	14
+MR LUMBAR SPINE WITHOUT CONTRAST	MR	MIDRC	14
+MR HEAD W IV CONTRAST	MR, SEG, nan	IDC,TCIA	14
+CT THORAX W/O CONT	SEG, nan	IDC,TCIA	14
+PET/CT NSCLC Restaging	SEG, nan	IDC,TCIA	14
+XR THORACIC SPINE 2 VIEWS	CR, DX	MIDRC	14
+RT BREAST STUDY	MR, nan	IDC,TCIA	14
+PET/CT Body Reference Only	SEG, PT, nan	IDC,TCIA	14
+MRI CERVICAL SPINE W/O CONTRAST	MR	MIDRC	14
+CT CHEST W/CONT	SEG, nan	IDC,TCIA	14
+BI BREAST SCREENING BILATERAL WITH TOMOSYNTHESIS	MG	ACRdart,IDC	14
+PET Reference Only	SEG, nan	IDC,TCIA	14
+CT ABDOMEN/PELVIS WO IV CONTRAST	CT	MIDRC	14
+Thorax^2 CAP ROUTINE	CT, nan	IDC,TCIA	14
+MR NONE HEAD W AND WO IV CONTRAST	MR, SEG, nan	IDC,TCIA	14
+Chest  3D IMR	CT, nan	IDC,TCIA	14
+CT KIDNEY PROTOCOL W/ CH/PEL	CT, SEG, nan	IDC,TCIA	14
+PET^CCF_WholeBody_PETCT_CAP (Adult)	CT, SEG, nan	IDC,TCIA	14
+CTA TRAUMA THORACIC AORTA W/O & W/ IV CONTRAST	CT	MIDRC	14
+CT PE PROTOCOL	CT	MIDRC	14
+XR RIGHT HAND 3+ VIEWS	CR, DX	MIDRC	14
+MR BREAST BILATERAL WITHOUT AND WITH IV CONTRAST	MR	ACRdart,IDC	14
+MRI BREAST BILAT WWO	MR, nan	ACRdart,TCIA,IDC	14
+Abdomen^BrzuchMiednica_ (Adult)	RTSTRUCT, CT, nan	IDC,TCIA	14
+MRI BREAST BILATERAL EXAM	MR	ACRdart,IDC	14
+MRI BREAST UNI 2ND EXA	MR, nan	IDC,TCIA	14
+CT Chest, Abdomen + Pe	CT, SEG, nan	IDC,TCIA	14
+4DCT THORAX	RTSTRUCT, CT	IDC	14
+PETCT_SkullMidThigh	CT, nan	IDC,TCIA	14
+CT THORAX WITH	CT, nan	IDC,TCIA	14
+CARDIAC OP	CT	MIDRC	14
+CT Chest routine	CT, nan	IDC,TCIA	14
+chest_abdomen_pelvis__w	SEG, nan	IDC,TCIA	14
+MR BREAST UNILAT	MR, SEG	IDC	14
+Mammo-Digital Screening BILAT w/ Tomosynthesis	MG	ACRdart,IDC	14
+CT CHEST AND UPPER ABD WO	CT	MIDRC	14
+CT CARDIAC CTA CORONARY W CAL	CT, nan	IDC,TCIA	14
+MR_LT BREAST	MR, nan	IDC,TCIA	14
+MRI PELVIS WO/W CONTRAST	MR, nan	IDC,TCIA	14
+HEAD^BRAIN	MR, SEG, nan	IDC,TCIA,MIDRC	14
+FOREIGN CT AB/PEL	CT, nan	IDC,TCIA	14
+MRI PELVIS W+WO CONT	MR, nan	IDC,TCIA	14
+ABD W/&W/O CONT	MR, nan	IDC,TCIA	14
+X-RAY CERVICAL SPINE 2 OR 3 VIEWS	CR, DX	MIDRC	14
+MRI Prostate With and Without Contrast	MR, nan	IDC,TCIA	14
+fubu	CT, nan	IDC,TCIA	14
+two_phase__abdomen_pelvis	SEG, nan	IDC,TCIA	14
+X-RAY FOOT COMPLETE MINIMUM 3 VIEWS - RIGHT	CR, DX	MIDRC	13
+Head^CODE_STROKE (Adult)	CT	MIDRC	13
+X-RAY KNEE 1 OR 2 VIEWS - RIGHT	CR, CR,DX, DX	MIDRC	13
+MRIBB3/4054	MR	ACRdart,IDC	13
+ACUTE ABDOMINAL SERIES	CR, DX	MIDRC	13
+X-RAY SHOULDER COMPLETE MIN 2 VIEWS - LEFT	CR, DX	MIDRC	13
+CT CHEST ANGIOGRAM WITH IV CONTRAST	CT	MIDRC	13
+PELVIS 1 OR 2 VIEWS	CR, DX	MIDRC	13
+Mammography Tomography Screening	MG	ACRdart,IDC	13
+CCTA HEART W CONTRAST+CT CHEST WO CONTRST-CT SURGERY	CT	MIDRC	13
+FL PHARYNX/SWALLOWING EVAL WITH FLUORO	XA, RF	MIDRC	13
+Thorax^CHEST_WITHOUT_Customized (Adult)	CT	MIDRC	13
+BREAST SCREENING-BILATERAL WITH CAD	MG	ACRdart	13
+Abdomen^ABDOME_2_FASESVOL (Adult)	CT, nan	IDC,TCIA	13
+MR ABD, OUTSIDE IMAGING	SEG, nan	IDC,TCIA	13
+X-RAY HAND MINIMUM 3 VIEWS - RIGHT	CR, DX	MIDRC	13
+NM MYOCARDIAL PHARM STRESS TEST	CT, NM, NM,CT	MIDRC	13
+MAMMOGRAM SCREENING BILATERAL W / TOMO	MG	IDC	13
+X-RAY HIP UNILATERAL WITH PELVIS 2 OR 3 VIEWS - LEFT	CR, DX	MIDRC	13
+XR REFERENCE IMPORT	CR, DX	MIDRC	13
+CT CHEST W/	CT, SEG, nan	IDC,TCIA	13
+CT CHEST W/O CON	CT, SEG, nan	IDC,TCIA	13
+X-RAY HIP UNILATERAL WITH PELVIS 2 OR 3 VIEWS - RIGHT	DX	MIDRC	13
+Head^CODE_STROKE_Customized (Adult)	CT	MIDRC	13
+chest	DX, CT, nan	IDC,TCIA,MIDRC	13
+MAMMO TOMO SCREENING BILATERAL	MG	ACRdart,IDC	13
+CHEST PA AND LAT	CR, DX	MIDRC	13
+ABD PEL/	CT, nan	IDC,TCIA	12
+BODY^MIEDNICA	RTSTRUCT, nan	IDC,TCIA	12
+XR RIGHT HAND 1-2 VIEWS	CR, DX	MIDRC	12
+_t4of7MRI IAMS	MR, nan	IDC,TCIA	12
+MRI BR UNILAT W&WO CONT RIGHT	MR, SEG	IDC	12
+Abdomen^DE_ROUTINE_AP_WITH_UNDER_50_Customized (Adult)	CT	MIDRC	12
+MR ABDOMEN NONENHANCED & ENHANCED-BODY	MR, SEG, nan	IDC,TCIA	12
+Thorax^CHEST_LOW_DOSE_NODULE_FUP_WO (Adult)	CT	MIDRC	12
+77067TS Scr Mamm bil 2v w/TOMO	MG	ACRdart	12
+MRI RT. BREAST	MR, nan	IDC,TCIA	12
+BREAST LEFT	MR, nan	IDC,TCIA	12
+SCRN TOMO SCRM MAMMO DIGT BILAT	MG	ACRdart,IDC	12
+PELVIS^PELVIS	RTSTRUCT, MR, nan	ACRdart,TCIA,IDC	12
+AS	CT, nan	IDC,TCIA	12
+PET^CC_PETWB (Adult)	CT, SEG, nan	IDC,TCIA	12
+Unspecified MR	MR, SEG, nan	IDC,TCIA	12
+Thorax^LUNG_CANCER_SCRN_LOW_DOSE_CM (Adult)	CT	MIDRC	12
+PET^1_PETCT_WholeBody (Adult)	SEG, nan	IDC,TCIA	12
+CT Thorax w/o Contrast	CT, nan	TCIA,MIDRC	12
+MR PROSTATE W ENDORECTAL COIL WO+W CONTRAST	nan	TCIA	12
+CTA CORONARY ARTERY	CT, nan	IDC,TCIA	12
+PRONE BREAST	SEG, nan	IDC,TCIA	12
+XR LEFT KNEE 1-2 VIEWS	CR, DX	MIDRC	12
+CT ANGIO CHEST FOR PE	CT	MIDRC	12
+CHEST WO CONTRAST CT	CT	MIDRC	12
+Thorax^ILD (Adult)	CT	MIDRC	12
+MA SURGICAL SPECIMEN	MG, nan	IDC,TCIA	12
+CT ABDOMEN wo & PELVIS wo	CT, nan	IDC,TCIA	12
+CT CHEST w + 3D Depend WS	CT, SEG, nan	IDC,TCIA	12
+PTUMOR	SEG, nan	IDC,TCIA	12
+CT KIDNEY PROTOCOL W/WO CONTRAST	CT, nan	IDC,TCIA	12
+RESEARCH^BREAST RESEARCH	MR, nan	IDC,TCIA	12
+Abdomen^Jama_Brzuszna_3_Fazy_Opoznione (Adult)	RTSTRUCT, nan	IDC,TCIA	12
+PET CT BODY	SEG, PT, nan	IDC,TCIA	12
+_t2of3  MRI Head	MR, nan	IDC,TCIA	12
+MRI ABDOMEN PELVIS W+WO CONT	MR, nan	IDC,TCIA	12
+MR BREAST RT W/WO	MR, nan	IDC,TCIA	12
+penqctzengq	CT, nan	IDC,TCIA	12
+Vascular^3_PULMONARY_VEIN (Adult)	CT	MIDRC	12
+MRI W/WO CONT BILBR	MR, nan	IDC,TCIA	12
+_t3of3  MRI Head	MR, nan	IDC,TCIA	12
+XR LUMBAR SPINE AP AND LATERAL 2 OR 3 VIEWS	DX	MIDRC	12
+CT ABD AND PELVIS WITH IV CONTRAST	CT, nan	IDC,TCIA,MIDRC	12
+CT ABDOMEN PELVIS WO CONT	CT, nan	IDC,TCIA	12
+MG Screening Digital BL w/Tomo/CAD	MG	ACRdart,IDC	12
+CONTRABREAST	MR, nan	IDC,TCIA	12
+FORFILE CD MR ABDOMEN	MR, nan	IDC,TCIA	12
+UNAVAILABLE	CT, nan	IDC,TCIA	12
+MRI BREAST W&WO/CONTRA	MR, nan	IDC,TCIA	12
+CT CHEST ABD PELVIS WITH CON	CT, SEG, nan	IDC,TCIA	12
+CT CHEST WITHOUT CONTRAST (S)	CT	MIDRC	12
+Chest  3D	CT, nan	IDC,TCIA	12
+PET/RT planningWhole	CT, SEG, PT, nan	IDC,TCIA	12
+CT Brain	CT, nan	IDC,TCIA	12
+Tomografia komputerowa klatki piersiowej	CT, nan	IDC,TCIA	12
+CT Pelvis with	CT, nan	IDC,TCIA	12
+Abdomen^02_0_Abdomen_Pelvis_Routine (Adult)	CT, nan	IDC,TCIA	12
+PETCT LIMITED VERTEX TO MID THIGH	CT, PT	MIDRC	12
+MRI BREAST UNI 2ND EX?	MR, nan	IDC,TCIA	12
+PETCT CONTRAST ENHANCE	SEG, nan	IDC,TCIA	12
+CT CAP LIVER	CT, SEG, nan	IDC,TCIA	12
+MAMMO-DIGITAL SCREENING BILAT W/ TOMOSYNTHESIS	MG	ACRdart,IDC	12
+CT ABDOMEN W&WO	CT, SEG, nan	IDC,TCIA	12
+CT CHEST W/CONTRAST	CT, SEG, nan	IDC,TCIA	12
+PET/CT LUNG MASS	SEG, nan	IDC,TCIA	12
+Abdomen^1AbdomenPETCT	SEG, nan	IDC,TCIA	12
+PET/CT LUNG SPN	SEG, nan	IDC,TCIA	12
+Whole-body PET	PT, nan	IDC,TCIA	12
+Abdomen^ABD_WO_GR (Adult)	CT	MIDRC	12
+PET SKULL-THIGH PLUS D	CT, PT, nan	IDC,TCIA	12
+Thorax^01ROUTINECHEST (Adult)	CT, SEG, nan	IDC,TCIA	12
+X-RAY PELVIS 1 OR 2 VIEWS	DX	MIDRC	11
+CT ABDOMEN PELVIS WWO (UROGRAM)	CT	MIDRC	11
+CT CARD CORONARY CALCM SCRE WO CON	CT	MIDRC	11
+CT CHEST WITH AND WITHOUT CONTRAST	CT	MIDRC	11
+Pelvis^PELVIS_HIP (Adult)	CT	MIDRC	11
+MRI PROSTATE W ENDORECTAL COIL	SEG	IDC	11
+RIGHT Unilateral with Tomo	MG	ACRdart,IDC	11
+BRST TOMOSYNTHESIS BILATERAL	MG	ACRdart,IDC	11
+XR LEFT HAND 1-2 VIEWS	CR, DX	MIDRC	11
+CT ANGIO CHEST	CT, nan	IDC,TCIA,MIDRC	11
+CT Chest w/o IV Contrast	CT	MIDRC	11
+BREAST^ROUTINE FOR MASS	MR	IDC	11
+Thorax^CTA_AAA_Customized (Adult)	CT	MIDRC	11
+RT^RCCT_THORAX_8F_High (Adult)	RTSTRUCT, CT	IDC	11
+Thorax^ROUTINE_CHEST_ABD_PEL_WITHOUT (Adult)	CT	MIDRC	11
+CT CHEST/ABD/PELVIS	CT, SEG, nan	IDC,TCIA	11
+CT ABDOMEN/PELVIS WITH CONTRAST (PETCT)	CT	MIDRC	11
+PET LYMPHOMA HODGKINS (W/LOW DOSE CT)	PT,CT	MIDRC	11
+JCCI CT CHEST WITHOUT	CT	MIDRC	11
+PET LYMPHOMA NON HODGK	PT,CT	MIDRC	11
+CT CORONARY CALCIUM SCORE	CT	MIDRC	11
+CHEST, PA AND LAT	CR	MIDRC	11
+Thorax^XL_CHEST_WITH (Adult)	CT	MIDRC	11
+CT CAP W CONTRAST	CT	MIDRC	11
+CT CHEST PE PROTOCOL	CT, nan	IDC,TCIA,MIDRC	11
+CT THORAX WITHOUT CONTRAST	CT, nan	TCIA,MIDRC	11
+Thorax^ROUTINE_CHEST_HR (Adult)	CT	MIDRC	11
+MRI BREAST BILAT W+ OR WO CONT	MR	IDC	11
+MA Surgical Specimen	MG, nan	IDC,TCIA	10
+59-1-59-2-B	SR, nan	IDC,TCIA	10
+Scanner-Philips_Exp-100_Pitch-1.2_SlCol-16x0.75mm	CT, nan	IDC,TCIA	10
+MAMMO diagnostic digital right	MG, nan	IDC,TCIA	10
+58-2-58-1-B	SR, nan	IDC,TCIA	10
+Thorax^C_A_P_WITH (Adult)	CT	MIDRC	10
+27-1-27-2-B	SR, nan	IDC,TCIA	10
+28-2-28-1-B	SR, nan	IDC,TCIA	10
+05-2-05-1-B	SR, nan	IDC,TCIA	10
+CT ABDOMEN wo&w& PELVIS w	CT, nan	IDC,TCIA	10
+ABD/PELVIS	CT, SEG, nan	IDC,TCIA	10
+SPINE^CTL	MR, SEG, nan	IDC,TCIA	10
+Thorax^1ThoraxPETCT	CT, SEG, nan	IDC,TCIA	10
+24-2-24-1-B	SR, nan	IDC,TCIA	10
+PET / CT TUMOR IMAGING	RTSTRUCT, SEG, nan	IDC,TCIA	10
+68-1-68-2-B	SR, nan	IDC,TCIA	10
+26-1-26-2-B	SR, nan	IDC,TCIA	10
+SL4 Treatment:Tx Plan	CT, nan	IDC,TCIA	10
+CT HEAD W/O CM	CT	MIDRC	10
+MR BREAST UNILAT LEFT	MR, SEG	IDC	10
+25-1-25-2-B	SR, nan	IDC,TCIA	10
+OSI PET CT SKULL TO MID THIGH	SEG, nan	IDC,TCIA	10
+67-1-67-2-B	SR, nan	IDC,TCIA	10
+SPECT^SPECT 3D	MR, SEG, nan	IDC,TCIA	10
+69-2-69-1-B	SR, nan	IDC,TCIA	10
+CT ABDOMEN W/ CONTRAST	CT, SEG, nan	IDC,TCIA	10
+29-2-29-1-B	SR, nan	IDC,TCIA	10
+66-2-66-1-B	SR, nan	IDC,TCIA	10
+CT ABDOMEN PELVIS WWO CONTRAST (ISCHEMIA)	CT	MIDRC	10
+_t1of9External Images for PACS	MR, nan	IDC,TCIA	10
+CALCIUM SCORING(Adult)	CT	MIDRC	10
+CT Pelvis w/o	CT, nan	IDC,TCIA	10
+XR RIGHT HIP 2-3 VIEWS (UNILATERAL) WITH PELVIS WHEN PERFORMED	CR, DX	MIDRC	10
+55-2-55-1-B	SR, nan	IDC,TCIA	10
+54-2-54-1-B	SR, nan	IDC,TCIA	10
+53-2-53-1-B	SR, nan	IDC,TCIA	10
+23-1-23-2-B	SR, nan	IDC,TCIA	10
+CHEST/ABDOMEN CT	CT, nan	IDC,TCIA	10
+Specials^2415_04_Colonography_ACRIN (Adult)	CT, nan	IDC,TCIA	10
+Thorax^CHEST_CONTRAST (Adult)	CT, SEG, nan	IDC,TCIA	10
+52-1-52-2-B	SR, nan	IDC,TCIA	10
+FORFILE CT CH/AB/PEL - CD	CT, SEG, nan	IDC,TCIA	10
+02-1-02-2-B	SR, nan	IDC,TCIA	10
+51-1-51-2-B	SR, nan	IDC,TCIA	10
+56-1-56-2-B	SR, nan	IDC,TCIA	10
+03-1-03-2-B	SR, nan	IDC,TCIA	10
+65-1-65-2-B	SR, nan	IDC,TCIA	10
+CT ABDOMEN WO/W CONT	CT, nan	IDC,TCIA	10
+64-2-64-1-B	SR, nan	IDC,TCIA	10
+63-1-63-2-B	SR, nan	IDC,TCIA	10
+62-1-62-2-B	SR, nan	IDC,TCIA	10
+57-2-57-1-B	SR, nan	IDC,TCIA	10
+61-2-61-1-B	SR, nan	IDC,TCIA	10
+BRONCHOSCOPY	RF	MIDRC	10
+04-1-04-2-B	SR, nan	IDC,TCIA	10
+BRAIN^3T ADVANCED IMAGING	MR, nan	IDC,TCIA	10
+60-2-60-1-B	SR, nan	IDC,TCIA	10
+CT Urogram w 3D	CR, CT, nan	IDC,TCIA	10
+01-2-01-1-B	SR, nan	IDC,TCIA	10
+_t2of3  External Images for PACS	MR, nan	IDC,TCIA	10
+CT ABDOMEN w & PELVIS	CT, nan	IDC,TCIA	10
+CT CHEST ABDOMEN & PELVIS ENHANCED=AB	RTSTRUCT, nan	IDC,TCIA	10
+Scanner-Philips_Exp-200_Pitch-1.2_SlCol-16x0.75mm	CT, nan	IDC,TCIA	10
+SCREENING MAMMO/TOMO BIL	MG	ACRdart,IDC	10
+Head^CTA_HEAD_NECK (Adult)	CT	MIDRC	10
+XR LEFT CLAVICLE	CR, DX	MIDRC	10
+09-2-09-1-B	SR, nan	IDC,TCIA	10
+30-1-30-2-B	SR, nan	IDC,TCIA	10
+MRI BREAST RT	MR, nan	IDC,TCIA	10
+CT ANGIO LIVER WITH PEL	SEG, nan	IDC,TCIA	10
+CT Chest routine (cont	CT, nan	IDC,TCIA	10
+CT Abdomen with	CT, nan	IDC,TCIA	10
+Chest 2 Views Frontal and Lat	CR, CR,DX, DX	MIDRC	10
+15-2-15-1-B	SR, nan	IDC,TCIA	10
+Abdomen^ROUTINE_ABD_PEL_WITHOUT (Adult)	CT	MIDRC	10
+17-1-17-2-B	SR, nan	IDC,TCIA	10
+X-RAY THORACIC SPINE 2 VIEWS	DX	MIDRC	10
+16-1-16-2-B	SR, nan	IDC,TCIA	10
+_t3of3MRI Stereo Gamma Knife	MR, nan	IDC,TCIA	10
+CT CHEST ANGIO W OR W AND WO IV CONTRAST	CT	MIDRC	10
+08-2-08-1-B	SR, nan	IDC,TCIA	10
+Abdomen^STONE_STUDY (Adult)	CT	MIDRC	10
+CT_Biopsy	CT, nan	IDC,TCIA	10
+CT ANGIOGRAM CHEST (S)	CT	MIDRC	10
+MRI Pelvis w/ + w/o Contrast-Prostate	MR	ACRdart	10
+_t6of6  MRI IAMS	MR, nan	IDC,TCIA	10
+31-2-31-1-B	SR, nan	IDC,TCIA	10
+Abdomen^BrzuchMiednica (Adult)	RTSTRUCT, CT, nan	IDC,TCIA	10
+MRI BREAST BIL ABBREVIATED W WO CONTRAST WO CAD (77059) [IMG1150	MR	ACRdart	10
+14-1-14-2-B	SR, nan	IDC,TCIA	10
+70-1-70-2-B	SR, nan	IDC,TCIA	10
+12-1-12-2-B	SR, nan	IDC,TCIA	10
+CT Abdomen	CT, nan	IDC,TCIA	10
+CT_Biopsy_BoneMarrow	CT, nan	IDC,TCIA	10
+PET LUNG CANCER OR PUL	PT,CT	MIDRC	10
+CT ABD LIVER	SEG, nan	IDC,TCIA	10
+11-2-11-1-B	SR, nan	IDC,TCIA	10
+PETCT_Skull_MidThigh	CT, nan	IDC,TCIA	10
+32-1-32-2-B	SR, nan	IDC,TCIA	10
+MRI BREAST LT	MR, nan	IDC,TCIA	10
+10-2-10-1-B	SR, nan	IDC,TCIA	10
+HEAD^SPECTROSCOPY	MR, SEG, nan	IDC,TCIA	10
+Abdomen^TRIO_TX_AS_AIVOL (Adult)	CT, nan	IDC,TCIA	10
+HEAD^BTP/STEALTH/SPECT	MR, SEG, nan	IDC,TCIA	10
+PET WB LOW BMI	CT, PT, nan	IDC,TCIA	10
+06-2-06-1-B	SR, nan	IDC,TCIA	10
+PET NON-SMALL CELL LUNG RESTAGING	SEG, nan	IDC,TCIA	10
+MR HEAD W AND WO IV CONTRAST TUMOR FOLLOWUP	MR, SEG, nan	IDC,TCIA	10
+RESEARCH MRI PELVIS	MR	ACRdart	10
+MR HEAD W AND WO IV CONTRAST METASTASIS	MR, SEG, nan	IDC,TCIA	10
+LUNG LW DOSE_LUNG SCREEN(Adult)	CT	MIDRC	10
+06. Chest, Abdomen CE	CT, SEG, nan	IDC,TCIA	10
+chest_abdomen__w	SEG, nan	IDC,TCIA	10
+_t2of3_MR IAM's	MR	IDC	10
+21-1-21-2-B	SR, nan	IDC,TCIA	10
+22-2-22-1-B	SR, nan	IDC,TCIA	10
+MR CERVICAL SPINE WITHOUT CONTRAST	MR	MIDRC	10
+coffee break exam - t+0 mins	MR, nan	IDC,TCIA	10
+MR Breast WWO Research ECOG-ACRIN	MR	ACRdart,IDC	10
+coffee break exam - t+15 mins	MR, nan	IDC,TCIA	10
+20-2-20-1-B	SR, nan	IDC,TCIA	10
+13-2-13-1-B	SR, nan	IDC,TCIA	10
+Adult Chest - 1 View	DX	MIDRC	10
+UPPER GI	RTDOSE, RTSTRUCT, CT, nan	IDC,TCIA	10
+_t2of3_MR IAMs	nan	TCIA	10
+19-1-19-2-B	SR, nan	IDC,TCIA	10
+_t3of3  External Images for PACS	MR, nan	IDC,TCIA	10
+DIGITAL MAMMOGRAM, BILATERAL	MG, nan	IDC,TCIA	10
+RESEARCH001^BREAST RESEARCH	MR, nan	IDC,TCIA	10
+ch+c	CT, SEG, nan	IDC,TCIA	10
+18-2-18-1-B	SR, nan	IDC,TCIA	10
+MRI_L_Spine	MR, nan	IDC,TCIA	10
+07-1-07-2-B	SR, nan	IDC,TCIA	10
+X-RAY KNEE 1 OR 2 VIEWS - LEFT	CR, DX	MIDRC	10
+CHEST PE IP	CT, nan	IDC,TCIA,MIDRC	9
+CT CHEST W O CONTRAST	CT	MIDRC	9
+CT CHEST W IVCON PE	CT	MIDRC	9
+CT CHEST W/ CON	SEG, nan	IDC,TCIA	9
+CT CHEST WO IVCON	CT	MIDRC	9
+CT CHEST ABDOMEN PELVIS W CONTRAST (PANCREAS)	CT	MIDRC	9
+PET LUNG CANCER OR PULMONARY NODULE (W/LOW DOSE CT)	PT,CT	MIDRC	9
+BRST BILAT DIAGNOSTIC MAMMO W/ TOMO	MG	ACRdart,IDC	9
+Ultrasound	US	ACRdart	9
+THORAX + CONT	CT, nan	IDC,TCIA,MIDRC	9
+CT ABDOMEN PELVIS W CONTRAST	CT	MIDRC	9
+ABDOMEN 1 VW(PORTABLE) - FEEDING (NG/PEG) TUBE CHK WO INJ BY RAD	CR, DX	MIDRC	9
+CT PULMONARY W/CONTRAS	CT	MIDRC	9
+MRI BREAST UNI/MBRU	MR, SEG	IDC	9
+Thorax^CAP_WITH_Customized (Adult)	CT	MIDRC	9
+JOINY CT CHEST WO	CT	MIDRC	9
+XR RIGHT FOREARM 2 VIEWS	CR, DX	MIDRC	9
+Thorax^FLASH_CAP_WO (Adult)	CT	MIDRC	9
+Abdomen^HEMATURIA_OVER_45 (Adult)	CT	MIDRC	9
+ABD UPRT VIEWONLY	CR, DX, nan	IDC,TCIA,MIDRC	9
+MR BREAST BILAT W WO CONTRAST	MR	ACRdart,IDC	9
+XR RIGHT FOOT 1-2 VIEWS	CR, DX	MIDRC	9
+CT Thorax W/O Contrast	CT	MIDRC	9
+MR BREAST UNILAT RIGHT	MR, SEG	IDC	9
+CHEST - 2 VIEW	CR	MIDRC	9
+MR CARDIAC FUNCTION / MORPHOLOGY WITH AND WITHOUT CONTRAST	MR	MIDRC	9
+CT VIRTUAL COLONSCOPY SCREENING	CT, nan	IDC,TCIA	9
+MR Breast Research Grant Study	MR, SEG	IDC	9
+LUNG PERFU SION IMAGING	CT, NM, nan	IDC,TCIA,MIDRC	9
+CT ABD AND PELVIS WO CONTRAST-CS	CT	MIDRC	9
+FOOT LEFT COMPLETE MIN 3 VIEWS	CR, DX	MIDRC	9
+CT, LUNG, MED, PLEURA	SEG, nan	IDC,TCIA	8
+CR DIAG-CHEST PA OR AP	CR	MIDRC	8
+X-RAY FOOT COMPLETE MINIMUM 3 VIEWS - LEFT	CR, DX	MIDRC	8
+X-RAY ANKLE COMPLETE MINIMUM 3 VIEWS - LEFT	DX	MIDRC	8
+Thorax^CHEST_ABD_PELVIS_WO (Adult)	CT	MIDRC	8
+CT ABD & PELVIS W/O &	CT, SEG, nan	IDC,TCIA	8
+HEAD^ BRAIN	SEG, nan	IDC,TCIA	8
+MAMMO WITH TOMOSYNTHESIS SCREENING BILATERAL	MG	ACRdart,IDC	8
+US	US	ACRdart	8
+CT THORAX W/O	CT, SEG, nan	IDC,TCIA	8
+CONTRABREAST - RT	MR, nan	IDC,TCIA	8
+CT ABD/PEL EXTERNAL IMAGING	RTSTRUCT, nan	IDC,TCIA	8
+CTA CHEST	CT	MIDRC	8
+Vascular^THORACIC_DISSECTION_CTA (Adult)	CT	MIDRC	8
+CAP IV IP	CT	MIDRC	8
+CT  C/A/P  LIVER	CT, SEG, nan	IDC,TCIA	8
+LUMBAR SACRAL SPINE 2/3 VIEWS	CR, DX	MIDRC	8
+Thorax^Thorax+abdo (Adult)	CT, nan	IDC,TCIA	8
+C/A/P LIVER	SEG, nan	IDC,TCIA	8
+Thorax^NEWHIRES_WO _2019 (Adult)	CT	MIDRC	8
+MAMMO DIGITAL SCREENING BILATERAL WITH TOMOSYNTHESIS_CAD	MG	ACRdart,IDC	8
+CT_Biopsy_Lung	CT, nan	IDC,TCIA	8
+CT AB/PEL WITH LIVER TRIPHASIC	SEG, nan	IDC,TCIA	8
+MAMMO DIGITAL SCREENING BILAT WITH TOMOSYNTHESIS_CAD	MG	ACRdart,IDC	8
+CT ABDOMEN + PELVIS AUGMENTED=AB	RTSTRUCT, CT, nan	IDC,TCIA	8
+CABI MRI	MR	ACRdart	8
+FDG 5AFOV LUNG	SEG, PT, nan	IDC,TCIA	8
+XR LEFT FOOT 1-2 VIEWS	CR, DX	MIDRC	8
+XR LEFT KNEE 4+ VIEWS (NON-TRAUMA, PAIN/ARTHRITIS)	CR, DX	MIDRC	8
+CHEST/ABDOMEN W CONTRA	CT, nan	IDC,TCIA	8
+CTA CHEST WO/W CONT	CT, nan	IDC,TCIA	8
+KT KLATKI PIERSIOWEJ ZE WZMOCNIENIEM KONTRASTOWYM	CT, nan	IDC,TCIA	8
+Thorax^CTA_CAP (Adult)	CT	MIDRC	8
+CTA CHEST WAND WITHOUT C AND RECONS	CT	MIDRC	8
+CBC	CT, nan	IDC,TCIA	8
+XR LEFT HUMERUS	CR, DX	MIDRC	8
+Thorax^HI_RES (Adult)	CT	MIDRC	8
+ULTRASOUND T0 INITIAL	US	ACRdart	8
+CHEST WITH	CT, SEG, nan	IDC,TCIA	8
+MRI ABDOMEN + PELVIS WO/W CONTRAST	MR	MIDRC	8
+MR RENAL PROTOCOL W/WO CONTRAST	MR, nan	IDC,TCIA	8
+PTCTSKTHPET / CT TUMOR	SEG, nan	IDC,TCIA	8
+MRI BREAST BIL/MBRB	MR, SEG	IDC	8
+_t5of8MRI IAMS	MR, nan	IDC,TCIA	8
+_t5of8  MRI IAMS	MR, nan	IDC,TCIA	8
+Abdomen^01_Abd_Pelvis_Routine (Adult)	CT, nan	IDC,TCIA	8
+MRI BREAST	MR, nan	IDC,TCIA	8
+CT ANGIOGRAPHY HEAD	CT	MIDRC	8
+CT ANGIOGRAPHY CHEST	CT, nan	TCIA,MIDRC	8
+MRI Pelvis	MR, nan	IDC,TCIA	8
+CT Chest W/ Non Ionic	CT, nan	IDC,TCIA	8
+CT CHEST NON CON	SEG, nan	IDC,TCIA	8
+MRI ABDOMEN W AND W/O GADOLINIUM	RTSTRUCT, MR, nan	IDC,TCIA	8
+Abdomen^ROUTINE_AP_WITH_OVER_50_OVER_250_Customized (Adult)	CT	MIDRC	8
+CT GUIDED LUNG BIOPSY	CT, SEG, nan	IDC,TCIA	8
+MR SCREENING BREAST W&W/O CONTRAST	MR	ACRdart,IDC	8
+CT Biopsy	CT, nan	IDC,TCIA	8
+CT Chest/Abdomen/Pelvis +C	CT, nan	IDC,TCIA	8
+Abdomen^urogram_gr (Adult)	CT	MIDRC	8
+MR PELVIS WITH + WITHOUT IV CONTRAST	MR	ACRdart	8
+AgilityS Treatme:Tx Plan	CT, nan	IDC,TCIA	8
+RESEARCH PET PLUS CT N	CT, nan	IDC,TCIA	8
+RT  BREAST	MR, nan	IDC,TCIA	8
+MR HEAD W AND WO IV CONTRAST POST-OP	SEG, nan	IDC,TCIA	8
+MR GUIDED BREAST BIOPSY; FIRST LESION	MR	ACRdart,IDC	8
+Ribs R	CR	MIDRC	8
+Thorax^1Chest_Abdomen (Adult)	CT, nan	IDC,TCIA	8
+Abdomen^01_Abdomen_Routine (Adult)	CT, nan	IDC,TCIA	8
+CT CHEST/ABD/PELV W CONTRAST	CT	MIDRC	8
+CT Abdo Un+En	OT, CT, nan	IDC,TCIA	8
+PET/CT CHEST	SEG, PT, nan	IDC,TCIA	8
+PET-CT	SEG, PT, nan	IDC,TCIA	8
+Abdomen^12_CTA_CAP (Adult)	CT	MIDRC	8
+CT CHEST WITH	CT, SEG, nan	IDC,TCIA	8
+PET/CT NSCLC INITIAL S	SEG, nan	IDC,TCIA	8
+CT Biopsy BoneMarrow	CT, nan	IDC,TCIA	8
+Abdomen^12_0_Liver_Biphase (Adult)	CT, SEG, nan	IDC,TCIA	8
+_t9of9MRI IAMS	MR, nan	IDC,TCIA	8
+_t8of8_MRI IAMS	MR, nan	IDC,TCIA	8
+CT Abdomen/Pelvis	US, DX, CT, nan	IDC,TCIA	8
+Abdomen^4_BOWEL_ISCHEMIA (Adult)	CT	MIDRC	8
+CT Abdomen w/ + w/o Contrast	CT, nan	IDC,TCIA	8
+PETCT SKULL BASE TO MI	CT, PT, nan	IDC,TCIA	8
+Abdomen^ABDOMEN_PELVIS_WO_ROUTINE (Adult)	CT	MIDRC	8
+CT CHEST WO W CONT	CT, nan	IDC,TCIA	8
+PETCT WholeBody	CT, PT, nan	IDC,TCIA	8
+PETCT_Skull-MidThigh	CT, nan	IDC,TCIA	8
+MRI BREAST BILATERAL WWO CONTRAST W 3D	SEG, nan	IDC,TCIA	8
+PET^01_Wholebody_First_Body (Adult)	CT, SEG, nan	IDC,TCIA	8
+CT CHEST wo	CT, SEG, nan	IDC,TCIA	8
+MRI BREAST BILATERAL W W/O CONTRAST	MR	ACRdart,IDC	8
+PET^1PETCT_LUNGS (Adult)	CT, PT, nan	IDC,TCIA	8
+mammogram/ultrasound exam	US	ACRdart	8
+SCREENING MAMMOGRAM PLUS TOMO	MG	ACRdart,IDC	8
+ch	CT, SEG, nan	IDC,TCIA	8
+CT ABDOMEN W/WO CONTRAST	CT, SEG, nan	IDC,TCIA	8
+Specials^1_PETCT_WB_HEADtoFEET	SEG, nan	IDC,TCIA	8
+MR ABDOMEN NONENHANCED & ENHANCED=AB	RTSTRUCT, MR, nan	IDC,TCIA	8
+BREAST^BREAST MRI	MR	ACRdart,IDC	8
+ACRIN 6667 RESEARCH	MR, nan	IDC,TCIA	8
+NM WB Bone	NM, nan	IDC,TCIA	8
+Scanner-Philips_Exp-25_Pitch-0.9_SlCol-16x0.75mm	CT, nan	IDC,TCIA	8
+ACRIN 6667 CONTRALAT B	MR, nan	IDC,TCIA	8
+MR ABD/PEL W&W/O CONT	MR, nan	IDC,TCIA	8
+Scanner-Philips_Exp-200_Pitch-0.9_SlCol-16x0.75mm	CT, nan	IDC,TCIA	8
+CT Neck	CT, nan	IDC,TCIA	8
+Scanner-Philips_Exp-25_Pitch-1.2_SlCol-16x0.75mm	CT, nan	IDC,TCIA	8
+MR_BREAST-RT	MR, nan	IDC,TCIA	8
+ABD/PEL	CT, nan	IDC,TCIA	8
+BREAST- BREAST MASS	MR, nan	IDC,TCIA	8
+Screening- Bilateral Mammography TomoHD	MG	ACRdart,IDC	8
+MR BREAST BI	MR, nan	IDC,TCIA	8
+ABDOMEN/PELVIS	MR, CT, nan	IDC,TCIA	8
+CT CHEST ABDOMEN PELVIS	CT, nan	IDC,TCIA	8
+CT KIDNEY PROTOCOL W/ PELVIS	CT, nan	IDC,TCIA	8
+CT THORAX  WITH CONTRA	CT, nan	IDC,TCIA	8
+MR BREAST BILAT W/WO C	MR, SEG	IDC	8
+6667 CONTRALAT. BREAST	MR, nan	IDC,TCIA	8
+MG Screen Bilat W/Tomo/CAD Stnd Protocol	MG	ACRdart,IDC	8
+CT ABDOMEN, COMBINED,NON & ENH-BODY	CT, SEG, nan	IDC,TCIA	8
+Scanner-Philips_Exp-100_Pitch-0.9_SlCol-16x0.75mm	CT, nan	IDC,TCIA	8
+XR_Biopsy_BoneMarrow	XA, nan	IDC,TCIA	8
+MRI_Pelvis	MR, nan	IDC,TCIA	8
+Thorax^01_CHEST	CT, nan	IDC,TCIA	8
+/BD/PRO   Pelvis w&w/oCon	SEG, nan	IDC,TCIA	8
+CHEST 1 VIEW PA OR AP	CR, DX	MIDRC	7
+CT ABDOMEN PELVIS W CONTRAST(PANCREAS)	CT	MIDRC	7
+XR RIGHT KNEE 4+ VIEWS (NON-TRAUMA, PAIN/ARTHRITIS)	CR, DX	MIDRC	7
+US PELVIC TRANSABD/TRANSVAG COMBINATION	US	MIDRC	7
+Head^DE_CTA_HEAD_NECK_Customized (Adult)	CT	MIDRC	7
+JCCI CT C/A/P	CT	MIDRC	7
+Thorax^NEWHIRES_WO_GR_2019 (Adult)	CT	MIDRC	7
+CT CHEST WO IV CONTRAST LUNG NODULE FOLLOW UP	CT	AIMI	7
+MAMMO SCREENING BI(DIAG&BI US IF NEEDED)	MG	ACRdart,IDC	7
+XR CERVICAL SPINE 1 VIEW	CR, DX	MIDRC	7
+BREAST^AB MRI	MR	ACRdart	7
+CT CHEST WO IV CONTRAST LUNG PARENCHYMA	CT	MIDRC	7
+X-RAY ANKLE COMPLETE MINIMUM 3 VIEWS - RIGHT	CR, DX	MIDRC	7
+US KIDNEY COMPLETE	US	MIDRC	7
+MRI KNEE WITHOUT CONTRAST - LEFT	MR	MIDRC	7
+CHEST PA AND LATERAL	CR, DX, nan	IDC,TCIA,MIDRC	7
+CHEST,SINGLE VIEW	CR	MIDRC	7
+CHEST PA/LT	CR	MIDRC	7
+ABDOMEN SERIES FLAT AND ERECT	CR, nan	IDC,TCIA,MIDRC	7
+FL C-ARM (PAIN MANAGMENT ONLY)	RF, XA	MIDRC	7
+ABDOMEN PELVIS WO(Adult)	CT	MIDRC	7
+Thorax^XL_CHEST_WO_Customized (Adult)	CT	MIDRC	7
+FOOT RIGHT COMPLETE MIN 3 VIEWS	CR, DX	MIDRC	7
+MR BRAIN WITHOUT CONTRAST	MR	MIDRC	7
+CT ANGIOGRAM ABDOMEN/PELVIS WITH AND WITHOUT CONTRAST	CT	MIDRC	7
+ACRIN ABR BREAST	MR	ACRdart,IDC	7
+ADULT CHEST - 1 VIEW	CR, DX	MIDRC	7
+XR LEFT HIP 2-3 VIEWS (UNILATERAL) WITH PELVIS WHEN PERFORMED	DX	MIDRC	7
+CTA CHEST W/O & W IV CON	CT	MIDRC	7
+Thorax^FLASH_PE_Customized (Adult)	CT	MIDRC	7
+Thorax^CTA_CHEST_ABDOMEN (Adult)	CT	MIDRC	7
+Mammo 3D Tomo Screening Bilateral	MG	ACRdart,IDC	7
+CT CHEST ABDOMEN WO CONTRAST (ROUTINE)	CT	MIDRC	7
+CT FACE SINUSES W CONTRAST	CT	MIDRC	7
+MR CERVICAL SPINE WITH AND WITHOUT CONTRAST	MR	MIDRC	7
+X-RAY HAND 2 VIEWS - LEFT	CR, DX	MIDRC	7
+Thorax^CTA_AAA (Adult)	CT	MIDRC	7
+CT ABD PELVIS WITH CONTRAST-CS	CT	MIDRC	7
+CT ABDOMEN/PELVIS ANGIO W OR W AND WO IV CONTRAST	CT	MIDRC	7
+JHN CHEST WO OP	CT	MIDRC	7
+CT CERVICAL SPINE WITHOUT CONTRAST	CT	MIDRC	7
+MRI BR UNI W/IN/MBUI	MR, SEG	IDC	7
+CT CERVICAL SPINE WO IV CONTRAST	RTSTRUCT, CT, nan	IDC,TCIA,MIDRC	7
+Head^BRAIN_LAB_HEAD (Adult)	CT	MIDRC	7
+CT CHEST ABDOMEN PELVIS W IV CONTRAST	RTSTRUCT, CT, nan	IDC,TCIA,MIDRC	7
+X-RAY HAND MINIMUM 3 VIEWS - LEFT	CR, DX	MIDRC	7
+RADIATION ONCOLOGY CT TREATMENT PLAN	CT	MIDRC	7
+CT CARDIAC MORPHOLOGY WO/W	CT, nan	IDC,TCIA	6
+CODE_T_CT_THOR_LMBR_SPINAL_REFORMATS	CT, nan	IDC,TCIA,MIDRC	6
+*CT Colonography	CT, nan	IDC,TCIA	6
+CT CHEST ABDOMEN & PELVIS ENHANCED-BODY	CT, nan	IDC,TCIA	6
+X-RAY FOOT 2 VIEWS - RIGHT	DX	MIDRC	6
+no comment	PT, nan	IDC,TCIA	6
+CHEST/ABD/PEL	SEG, nan	IDC,TCIA	6
+CT CAP WO CONTRAST	CT	MIDRC	6
+CONTRA BREAST (LEFT)	MR, nan	IDC,TCIA	6
+CT CHEST ANGIOGRAPH W IV CONTRAST PULMONAR EMBOLISM	CT	MIDRC	6
+CONTRA BREAST RIGHT	MR, nan	IDC,TCIA	6
+CT C/A	CT, SEG, nan	IDC,TCIA	6
+CT CAP W	SEG, nan	IDC,TCIA	6
+CT C/A/P LIVER PR.	SEG, nan	IDC,TCIA	6
+ct ap	CT, nan	IDC,TCIA	6
+X-RAY HAND 2 VIEWS - RIGHT	CR, DX	MIDRC	6
+CODE_T_CT_ANGIO_ABD_AND_PEL_WITH_IV_CON_WITH_CHEST_IMAG	CT, nan	IDC,TCIA,MIDRC	6
+CODE T CHEST AP PORTABLE	CR, nan	IDC,TCIA,MIDRC	6
+XR SPINE LUMBAR (AP+LAT)	CR, DX	MIDRC	6
+cap	CT, nan	IDC,TCIA	6
+_t1of7  External Images for PACS	MR, nan	IDC,TCIA	6
+CT HEAD WO(Adult)	CT	MIDRC	6
+CT, ABDOMEN W/O CONTRA	CT, nan	IDC,TCIA	6
+CT ABD/PELV W CONTRAST	CT, nan	IDC,TCIA	6
+XR RIBS, RIGHT	DX	MIDRC	6
+CT UPPER ABD AND PELVIS WWO	CT, nan	IDC,TCIA	6
+CT ABDOMEN  W/CONTRAST	CT, nan	IDC,TCIA	6
+CT LUNG SCREEN WO CONTRAST	CT	MIDRC	6
+CT NECK/THYROID W CONTRAST	CT	MIDRC	6
+CT ABDOMEN WITH IV CON	CT, nan	IDC,TCIA	6
+_t1of8External Images for PACS	MR, nan	IDC,TCIA	6
+CT TRAUMA T-SPINE RECONSTRUCT (RAD ONLY)	CT	MIDRC	6
+CT ABDOMEN WITH AND WI	CT, nan	IDC,TCIA	6
+_t1of6  External Images for PACS	MR, nan	IDC,TCIA	6
+CT ABD/PEL	CT, SEG, nan	IDC,TCIA	6
+CT ABDOMEN AND PELVIS ANGIOGRAM=AB	RTSTRUCT, nan	IDC,TCIA	6
+CT P CHEST W	CT	MIDRC	6
+CT PELVIS W CONTRAST (ROUTINE)	CT	MIDRC	6
+CT PELVIS WO CONTRAST (ROUTINE)	CT	MIDRC	6
+CT ABDOMEN W IV CONTRAST	RTSTRUCT, CT, nan	IDC,TCIA,MIDRC	6
+CT ABDOMEN W CONTRAST (ROUTINE)	CT	MIDRC	6
+_t1of3_MR IAMs	nan	TCIA	6
+_t1of3_MR IAM's	MR	IDC	6
+_t1of2  External Images for PACS	MR, nan	IDC,TCIA	6
+CT THORAX  WITHOUT CONTRAST	CT, nan	IDC,TCIA	6
+CT ABDOMEN PELVIS W CONT (2)	CT, nan	IDC,TCIA	6
+CT THORAX W CONT FIC	CT, nan	IDC,TCIA	6
+CT ABDOMEN/PELVIS WITH CONTRAST (S)	CT	MIDRC	6
+CT ABD+PELVIS W/WO 74178	CT, nan	IDC,TCIA	6
+CT CHEST W/O IV CONTRAST	RTSTRUCT, CT, nan	IDC,TCIA	6
+CT ABD & PELVIS W/CONTRAST	nan	TCIA	6
+X-RAY KNEE COMPLETE 4 OR MORE VIEWS - RIGHT	CR, DX	MIDRC	6
+X-RAY LUMBOSACRAL SPINE MINIMUM 4 VIEWS	CR, DX	MIDRC	6
+CT CHEST WITH IV CONT	CT, nan	IDC,TCIA,MIDRC	6
+_t9of9MRI IAMS post Gad	MR, nan	IDC,TCIA	6
+Chest 3D	CT, nan	IDC,TCIA	6
+X-RAY WRIST COMPLETE MINIMUM 3 VWS - RIGHT	CR, DX	MIDRC	6
+CT CHEST WWO CONTRAST	CT, nan	IDC,TCIA,MIDRC	6
+CT_biopsylung	CT, nan	IDC,TCIA	6
+CT_Pelvisbonebiopsy	CT, nan	IDC,TCIA	6
+CT Abdomen W/O, W/Contrast	CT, nan	IDC,TCIA	6
+CT_Pelvis	CT, nan	IDC,TCIA	6
+CT CHEST/ABD (LIVER)	CT, SEG, nan	IDC,TCIA	6
+CT Abd/Pelvis	CT, nan	IDC,TCIA	6
+CT ABD WO IV CONT	CT, nan	IDC,TCIA,MIDRC	6
+CT_Abdomen	CT, nan	IDC,TCIA	6
+_t5of9MRI Stereo Gamma Knife	MR, nan	IDC,TCIA	6
+CTCH2	CT, nan	IDC,TCIA	6
+_t4of7  MRI IAMS	MR, nan	IDC,TCIA	6
+XR LEFT ELBOW 3+ VIEWS	CR, DX	MIDRC	6
+_t4of6MRI IAMS	MR, nan	IDC,TCIA	6
+CT Chest Abdomen and Pelvis With Contrast	RTSTRUCT, nan	IDC,TCIA	6
+CT ANGIOGRAM CHEST PULMONARY EMBOLISM W CONTRAST	CT	MIDRC	6
+CT Chest w/ IV Contrast	CT	MIDRC	6
+CT Chest without contrast	CT, SEG, nan	IDC,TCIA	6
+_t3of3MRI Stereo Gamma Knife gad	MR, nan	IDC,TCIA	6
+_t3of3MRI Head	MR, nan	IDC,TCIA	6
+CT ABD (LIVER)	SEG, nan	IDC,TCIA	6
+Outside Read or Comparison NEURO CT	CT, nan	IDC,TCIA	6
+Thorax^NON_CONTRAST_CHEST (Adult)	CT, nan	IDC,TCIA	6
+Thorax^1ROUTINECHEST (Adult)	CT, nan	IDC,TCIA	6
+Thorax^CHEST_WITHOUT_WITH_HI_RES_CUTS (Adult)	CT	MIDRC	6
+Thorax^CHEST_ROUTINE (Adult)	CT, nan	IDC,TCIA	6
+PET RESEARCH	CT, nan	IDC,TCIA	6
+Thorax^CHEST_LIVER (Adult)	CT, nan	IDC,TCIA	6
+C/A ADRENAL CHAR	CT, nan	IDC,TCIA	6
+PET TUM SKULL/MID-THIGH-CT W/O	SEG, nan	IDC,TCIA	6
+MRI CERVICAL SPINE WO/W IV CONTRAST	MR	MIDRC	6
+Thorax^1_CHEST_WITH (Adult)	CT, nan	IDC,TCIA	6
+Abdomen^1CAP_WC (Adult)	CT, nan	IDC,TCIA	6
+MRI KNEE WITHOUT CONTRAST - RIGHT	MR	MIDRC	6
+MRI Bladder	MR, nan	IDC,TCIA	6
+Thorax^1ChestRoutine (Adult)	CT, nan	IDC,TCIA	6
+MRI BREAST/UNILAT WO/WITH CON	MR	IDC	6
+BRZUCH+C	RTSTRUCT, SEG, nan	IDC,TCIA	6
+MRI BREAST, BILATERAL	MR	IDC	6
+PET/CT SPN	SEG, nan	IDC,TCIA	6
+PET/CT Tumor Img. Skull Base to Mid-thigh	CT, SEG, nan	IDC,TCIA	6
+Thorax^02CAP_Routine (Adult)	CT, nan	IDC,TCIA	6
+Thorax^CHEST_WITH_Customized (Adult)	CT	MIDRC	6
+MRI ABD W WO CON	MR, nan	IDC,TCIA	6
+AP	CT, nan	IDC,TCIA	6
+LT BREAST STUDY	MR, nan	IDC,TCIA	6
+Abdomen	US, DX, SEG, nan	ACRdart,TCIA,IDC,MIDRC	6
+JHN CHEST OP	CT	MIDRC	6
+JOIEN CT CHEST	CT	MIDRC	6
+Abdomen acute series	CR	MIDRC	6
+Abdomen^01 ABD_PEL	CT, nan	IDC,TCIA	6
+PET Lung Cancer Restage I	SEG, nan	IDC,TCIA	6
+L SPINE	SEG, nan	IDC,TCIA	6
+LEFT THIGH C+	MR, nan	IDC,TCIA	6
+PET MULTIPLE MYELOMA (W/LOW DOSE CT)	PT,CT	MIDRC	6
+Abdomen^04 CA one Run	CT, nan	IDC,TCIA	6
+CAP WITH	CT, SEG, nan	IDC,TCIA	6
+LUNG MASS	PT, nan	IDC,TCIA	6
+MRI PELVIS wo&w	MR, nan	IDC,TCIA	6
+CAP W/O	CT, nan	IDC,TCIA	6
+Abdomen^02_0_AP_Routine_Abdomen_Pelvis (Adult)	CT, nan	IDC,TCIA	6
+MRI PELVIS	MR, nan	IDC,TCIA	6
+CAP LIVER	CT, SEG, nan	IDC,TCIA	6
+Thorax^CTA_CHEST_THORACIC_DISSECTION (Adult)	CT	MIDRC	6
+Thorax^01_NONCONCHEST (Adult)	SEG, nan	IDC,TCIA	6
+Thorax^01_CHEST.ABD W-ABD.W	CT, nan	IDC,TCIA	6
+Thorax^01 CHEST .75 COLLIMATOR	CT, nan	IDC,TCIA	6
+MR PELVIS WITH AND WITHOUT CONTRAST	RTSTRUCT, nan	IDC,TCIA	6
+PET^WHOLEBODY_LD90 (Adult)	RTSTRUCT, PT, nan	IDC,TCIA	6
+PET^WHOLEBODY_LONG_LD90 (Adult)	CT, PT, nan	IDC,TCIA	6
+Abdomen^DE_ROUTINE_AP_WITH_OVER_50 (Adult)	CT	MIDRC	6
+MR BREAST, BIL	MR, SEG, nan	IDC,TCIA	6
+MR BREAST, UNILATERAL W/WO CONT	MR	ACRdart,IDC	6
+Research	RTSTRUCT, SEG, nan	IDC,TCIA	6
+MRI Abdomen WWO Contrast	SEG, nan	IDC,TCIA	6
+MR NONE SPECTROSCOPY	MR, SEG, nan	IDC,TCIA	6
+RECTUM	CT, nan	IDC,TCIA	6
+TRAUMA CT ABD PEL 2PHASE WITH IV CON WITH CHEST IMAGES	CT, nan	IDC,TCIA,MIDRC	6
+MR PROSTATE WO CONTRAST	SEG, nan	IDC,TCIA	6
+R-BREAST	MR, nan	IDC,TCIA	6
+MR Research wo w 30 minutes	MR	ACRdart,IDC	6
+Abdomen^ROUTINE_AP_WITH_UNDER_50_OVER_250_Customized (Adult)	CT	MIDRC	6
+MRI ABDOMEN W+WO CONTRAST	MR, SEG, nan	IDC,TCIA	6
+Pelvis^CT_PELVIS_WITH (Adult)	CT	MIDRC	6
+PROSTATE BOOST	CT, nan	IDC,TCIA	6
+MRI ABD WWO IV CONT	MR, nan	IDC,TCIA,MIDRC	6
+Scanner-Philips_Exp-100_Pitch-1.2_SlCol-16x1.5mm	CT, nan	IDC,TCIA	6
+Abdomen^CA.AP W (Adult)	CT, nan	IDC,TCIA	6
+Abdomen^BRZUCH_3_FAZOWY (Adult)	RTSTRUCT, nan	IDC,TCIA	6
+FOREIGN CT ABD AND/OR PEL - CD	CT, nan	IDC,TCIA	6
+MM MAMMOGRAM SCREENING DIGITAL DDI	MG	ACRdart,IDC	6
+Abdomen^23NIH_COLO_IRB1221-00 (Adult)	CT, nan	IDC,TCIA	6
+PETCT FDG VERTEX TO MID THIGH (NON DIAGNOSTIC CT)	CT, PT	MIDRC	6
+TAVR OP	CT	MIDRC	6
+T/A/P W/C	CT, SEG, nan	IDC,TCIA	6
+BREAST^BREAST MASS	MR, nan	IDC,TCIA	6
+PETCT INITIAL TREATMEN	SEG, nan	IDC,TCIA	6
+Abdomen^7MCV_VIRTUAL_COLONOSCOPY (Adult)	CT, nan	IDC,TCIA	6
+T SPINE	CT, SEG, nan	IDC,TCIA	6
+Specials^1PETCT_WholeBody	SEG, nan	IDC,TCIA	6
+PETCT LUNG NOD	SEG, nan	IDC,TCIA	6
+PETCT SUBSEQUENT TREATMENT STRATEGY [IMG15078]	SEG, nan	IDC,TCIA	6
+PET^1PETCTMATCH_TX_WholeBody (Adult)	SEG, nan	IDC,TCIA	6
+PET^1PETCTMATCH_WholeBody (Adult)	CT, SEG, nan	IDC,TCIA	6
+BREAST LESION	MR	IDC	6
+Abdomen^BRZUCH (Adult)	RTSTRUCT, CT, nan	IDC,TCIA	6
+Scanner-Philips_Exp-200_Pitch-1.2_SlCol-16x1.5mm	CT, nan	IDC,TCIA	6
+CH/ABD/PELVIS	SEG, nan	IDC,TCIA	6
+CAP (LIVER)	CT, SEG, nan	IDC,TCIA	6
+Pelvic Cavity CT Enhanced	CT, nan	IDC,TCIA	6
+UROGRAM OVER 35(Adult)	CT	MIDRC	6
+Thorax^PEDS__CAP_WITH (Child)	CT	MIDRC	6
+Vascular^CH03C_FLASH_CHST_W_PE (Adult)	CT	MIDRC	6
+PELVIS FULL	CT, nan	IDC,TCIA	6
+MRI W/WO CONT UN	MR, nan	IDC,TCIA	6
+US_Abdomen	US, CT, XA, nan	IDC,TCIA	6
+CHEST PULMONARY EMBOLISM CTA	CT	MIDRC	6
+Mamm bil 2v w/TOMO	MG	IDC	6
+Head^CODE_STROKE_CTA_WITH_PERFUSION_WS (Adult)	CT	MIDRC	6
+MR_BREAST-LT	MR, nan	IDC,TCIA	6
+CHEST IV IP	CT	MIDRC	6
+CHEST W/CONTRAST	CT, nan	IDC,TCIA	6
+Head^FACE_WITHOUT (Adult)	CT	MIDRC	6
+Thorax^PEDS__CHEST_WITHOUT (Child)	CT	MIDRC	6
+MRM-6667	MR, nan	IDC,TCIA	6
+ANUS	CT, nan	IDC,TCIA	6
+PET BREAST CANCER (W/LOW DOSE CT)	PT,CT	MIDRC	6
+MRI_T_Spine	MR, nan	IDC,TCIA	6
+ACRIN6667	MR, nan	IDC,TCIA	6
+Thorax^XL_CAP_WO (Adult)	CT	MIDRC	6
+MRI_CSpine	MR, nan	IDC,TCIA	6
+MRI T Spine	MR, nan	IDC,TCIA	6
+ACRIN6667 RESEARCH	MR, nan	IDC,TCIA	6
+ABD/PEL (LIVER)	SEG, nan	IDC,TCIA	6
+FORFILE CD CT ABD WITHOUT CONTRAST	CT, nan	IDC,TCIA	6
+Thorax^LUNG_CANCER_SCREENING_CHEST_WO (Adult)	CT	MIDRC	6
+Group-487 Cells	MR, nan	IDC,TCIA	6
+WB FDG LUNG	SEG, PT, nan	IDC,TCIA	6
+OSF CT ABDOMEN	CT, SEG, nan	IDC,TCIA	6
+Head^FACE_WITHOUT_Customized (Adult)	CT	MIDRC	5
+RM CHEST PA AND LEFT LATERAL ONLY	DX	MIDRC	5
+CT ANGIOGRAM FOR PULMONARY EMBOLISM [CH]	CT	MIDRC	5
+CHEST IP	CT, nan	IDC,TCIA,MIDRC	5
+MG	MG	ACRdart	5
+CT ABDOMEN PELVIS WO C	CT	MIDRC	5
+CT CHEST WITH CONTRAST (S)	CT	MIDRC	5
+CT ABDOMEN PELVIS W WO CONTRAST	CT, SEG, nan	IDC,TCIA,MIDRC	5
+MR BREAST BILAT	MR	IDC	5
+CT BRAIN WITHOUT CONTRAST (S)	CT	MIDRC	5
+MRI BONE OUTSIDE IMAGE	MR	MIDRC	5
+Head^Maxillofacial1 (Adult)	CT	MIDRC	5
+Abdomen^HEMATURIA_GR_OVER45 (Adult)	CT	MIDRC	5
+Abdomen^12_CTA_AAA (Adult)	CT	MIDRC	5
+MRI Breast w/w/o Contrast bilat (Birad)	MR	ACRdart,IDC	5
+Thorax^CHEST_ABD_PELVIS (Adult)	RTSTRUCT, CT, nan	IDC,TCIA,MIDRC	5
+X-RAY WRIST COMPLETE MINIMUM 3 VWS - LEFT	DX	MIDRC	5
+CT ABDOMEN AND PELVIS WITHOUT CONTRAST	CT, nan	IDC,TCIA,MIDRC	5
+Frozen	CT	IDC	5
+XR RIGHT KNEE 4+ VIEWS (TRAUMA)	CR, DX	MIDRC	5
+Bilateral Ribs	CR	MIDRC	5
+MRI BR BILAT W&WO CONTRAST	MR	IDC	5
+X-RAY KNEE COMPLETE 4 OR MORE VIEWS - LEFT	CR, DX	MIDRC	5
+HIP COMPLETE LEFT MIN 2 VWS	CR, DX	MIDRC	5
+Vascular^CT_PE (Adult)	CT	MIDRC	5
+CHEST W/O	CT, nan	IDC,TCIA,MIDRC	5
+PORT - CXR	CR, DX	MIDRC	5
+ABDOMEN PELVIS WITH(Adult)	CT	MIDRC	5
+CT HEART CALCIUM SCORE WITHOUT CONTRAST	CT	MIDRC	5
+/PRO/BD Pelvis w	nan	TCIA	5
+NM PET CANCER ANY SITE	PT,CT	MIDRC	5
+BREAST RESEARCH	MR, SEG, nan	IDC,TCIA,ACRdart	5
+CT CT PULMONARY ANGIOGRAPHY	CT	MIDRC	5
+Abdomen^ABD_PELVIS_WITH (Adult)	CT	MIDRC	5
+TomoHD bds	CT, MG	ACRdart,IDC	5
+PRO/BD Pelvis w	SEG	IDC	5
+CT HEAD W CONTRAST	CT	MIDRC	5
+CT CT-CHEST W/O CONTRAST	CT	MIDRC	5
+X-RAY FOOT 2 VIEWS - LEFT	DX	MIDRC	5
+PETCT FDG VERTEX TO TOES (NON DIAGNOSTIC CT)	NM,PT, CT, PT	MIDRC	5
+BREAST^BREAST 8.25.14	MR	ACRdart	5
+SHOULDER 3 VIEWS LEFT	CR, DX	MIDRC	5
+CT PELVIS WO CONTRAST (CYSTOGRAM)	CT	MIDRC	5
+X-RAY ESOPHAGUS DOUBLE CONTRAST W/CXR1V	DX	MIDRC	5
+TO - INITIAL ULTRASOUND	US	ACRdart	5
+CHEST PA	CR	MIDRC	5
+BREAST ULTRASOUND	US	ACRdart	5
+CT CHEST LUNG CANCER S	CT	MIDRC	5
+XR EG TUBE PLACEMENT	CR, DX	MIDRC	5
+CAP COMBO IP	CT	MIDRC	5
+CH-CHEST 1V CR	CR	MIDRC	5
+XR KNEE LT 3 VIEWS	CR, DX	MIDRC	5
+CT CHEST W IVCON	CT	MIDRC	5
+CT_Neck	CT, nan	IDC,TCIA	5
+Thorax^LOW_DOSE_CHEST_UNDER_30_BMI (Adult)	CT	MIDRC	5
+CT ABD-PELV W/ CM	CT	MIDRC	5
+XR FOOT RIGHT (ROUTINE: AP,LAT,OBL)	CR, DX	MIDRC	5
+JCCI CT CAP COMB	CT	MIDRC	5
+Thorax^LARGE_CHEST_WITH_IV_CONTRAST (Adult)	nan	TCIA	5
+XR LEFT FOREARM 2 VIEWS	CR, DX	MIDRC	5
+XR LEFT HIP 1 VIEW PORTABLE	CR, DX	MIDRC	5
+KNEE 3 VIEWS RIGHT	CR, DX	MIDRC	5
+MRI SHOULDER WO CONTRAST - RIGHT	MR	MIDRC	5
+Thorax^C_A_P_WO_GR (Adult)	CT	MIDRC	5
+CT ABD/PEL RENAL STONE LOW DOSE W/O CONTRAST	CT	MIDRC	5
+LCMC CT CHEST PE PROTOCOL	CT	MIDRC	5
+XR ABDOMEN (W/UPRIGHT)	CR, DX	MIDRC	5
+Thorax^PEDS__CHEST_WITH (Child)	CT	MIDRC	5
+MAMMO SCREEN BILAT DIGITAL	MG	ACRdart,IDC	5
+PET MULTIPLE MYELOMA (	PT,CT	MIDRC	5
+Thorax^FLASH_CHEST_WITH (Adult)	CT	MIDRC	5
+CTA CHEST FOR PULMONARY EMBOLUS WITH CONTRAST	CT	MIDRC	5
+XR LEFT SHOULDER 1 VIEW	CR, DX	MIDRC	5
+XR RIGHT ANKLE 2 VIEWS	CR, DX	MIDRC	5
+MA MAMMOGRAM SCREENING BILATERAL W / TOMO	MG	ACRdart	5
+MAMMO 3D DIAG LEFT	MG	ACRdart,IDC	5
+CT CHEST W, ABDOMEN PELVIS WWO	CT	MIDRC	5
+Thorax^XL_CAP_WITH (Adult)	CT	MIDRC	5
+MRI HIP WITHOUT CONTRAST-RIGHT	MR	MIDRC	5
+CHEST - 2 VIEWS	CR	MIDRC	5
+MAM MAMMOGRAPHY UNILATERAL WITH TOMOSYNTHESIS	MG	ACRdart,IDC	5
+Thorax^LOW_DOSE_LUNG_OVER_30_BMI (Adult)	CT	MIDRC	5
+Cardiac^LAMODELTEST (Adult)	CT	MIDRC	5
+IR CHEST TUBE PLACEMENT (ORERABLE BY IR SERVICE ONLY)	US, CT	MIDRC	5
+OS CT CHEST COMPARE-NO READ	CT, nan	IDC,TCIA	4
+MRI Spine	MR, nan	IDC,TCIA	4
+MRI Pelvis W/O&W Contrast	MR	ACRdart	4
+_t4of5  External Images for PACS	MR, nan	IDC,TCIA	4
+Outside Digital Media	CT, nan	IDC,TCIA	4
+_t5of8MRI Stereo Gamma Knife	MR, nan	IDC,TCIA	4
+CT COLONGRAPHY	CT, nan	IDC,TCIA	4
+CT Chest Without Contrast	CT, nan	IDC,TCIA	4
+_t5of9MRI Stereo Gamma Knife gad	MR, nan	IDC,TCIA	4
+MRI BREAST BILAT W-WO-RH	SEG, nan	IDC,TCIA	4
+CT CHEST & ABDOMEN-CHEST	CT, nan	IDC,TCIA	4
+CT CHEST/THORAX W/CON	CT, nan	IDC,TCIA	4
+CT CHEST NO CONTRAST	CT, nan	IDC,TCIA	4
+CT CHEST & ABDOMEN, ENHANCED-CHEST	CT, nan	IDC,TCIA	4
+CT CHEST/ABDOMEN W/CON	CT, nan	IDC,TCIA	4
+_t3of6  MRI IAMS	MR, nan	IDC,TCIA	4
+PET^CC_PETWB_CT_CAP (Adult)	CT, SEG, nan	IDC,TCIA	4
+CT CORONARY ANGIO	CT	AIMI	4
+POS	CT, nan	IDC,TCIA	4
+_t5of5  MRI IAMS	MR, nan	IDC,TCIA	4
+Neck^DE_CTA_NECK (Adult)	CT	MIDRC	4
+MRI ABDOMEN W/WO CONTRAST (74183)	MR, nan	IDC,TCIA	4
+CT Chest W/ Contrast	CT	MIDRC	4
+OS STDY CT BODY INTERPRET	CT, SEG, nan	IDC,TCIA	4
+_t4of6  MRI Head	MR, nan	IDC,TCIA	4
+OSF CT ABD	SEG, nan	IDC,TCIA	4
+PRONE PELVIS	CT, nan	IDC,TCIA	4
+CT CHEST ABDOMEN AND PELVIS WO CONTRAST	CT	MIDRC	4
+CT CHEST OUTSIDE IMAGE	CT	MIDRC	4
+PET ENDOMETRIAL OR CER	PT,CT	MIDRC	4
+MRI Right Breast with and without Contrast	MR, nan	IDC,TCIA	4
+PORTABLE CHEST - 1 VIEW	CR	MIDRC	4
+_t4of7  External Images for PACS	MR, nan	IDC,TCIA	4
+PET CT Wholebody	CT, nan	IDC,TCIA	4
+CT CHEST PE	CT, SEG, nan	IDC,TCIA	4
+CT Chest With Contrast	CT, nan	IDC,TCIA	4
+CT CHEST ENHANCED=CH	RTSTRUCT, nan	IDC,TCIA	4
+MRI ABDOMEN W/O CONTRAST	MR	MIDRC	4
+NSCL CA RESTG	SEG, nan	IDC,TCIA	4
+POST CHEST	SEG, nan	IDC,TCIA	4
+MRI Abd wo	MR, nan	IDC,TCIA	4
+_t6of11  MRI IAMS	MR, nan	IDC,TCIA	4
+MRI ELBOW W/O CONTRAST-LEFT	MR	MIDRC	4
+MRI BREAST BILATERAL - WITH AND WITHOUT CONTRAST	MR	ACRdart,IDC	4
+MRM-6667-	MR, nan	IDC,TCIA	4
+MRI Left Breast with and without Contrast	MR, nan	IDC,TCIA	4
+PET REFERENCE ONLY	SEG, nan	IDC,TCIA	4
+MRI LT. BREAST	MR, nan	IDC,TCIA	4
+PET/CT Sk-Thigh	SEG, nan	IDC,TCIA	4
+MRI LOWER EXTREMITY NOT JOINT WITHOUT CONTRAST RIGHT	MR, nan	IDC,TCIA	4
+MRI L Spine	MR, nan	IDC,TCIA	4
+a p	CT, nan	IDC,TCIA	4
+MRM - 6667	MR, nan	IDC,TCIA	4
+MRI BREAST W/CONTRAST	MR, nan	IDC,TCIA	4
+ap	CT, nan	IDC,TCIA	4
+PET/CT NCAP	SEG, nan	IDC,TCIA	4
+MRI_WholeBody	MR, nan	IDC,TCIA	4
+PET/CT LUNGS	SEG, nan	IDC,TCIA	4
+PET CT TUMOR, WHOLE BO	CT, nan	IDC,TCIA	4
+MRI_TSpine	MR, nan	IDC,TCIA	4
+PET/CT LUNG NODULES	SEG, nan	IDC,TCIA	4
+MRI Kidneys	MR, nan	IDC,TCIA	4
+PET CARDIAC FLOW	CT, nan	IDC,TCIA	4
+MRI_Brain	MR, nan	IDC,TCIA	4
+MRI INTERPRETATION OF OUTSIDE ABDOMINAL IMAGES	SEG, nan	IDC,TCIA	4
+MRI C Spine	MR, nan	IDC,TCIA	4
+CT CHEST AND ABDOMEN W	CT, nan	IDC,TCIA	4
+PET TUMOR METABOLISM	SEG, PT, nan	IDC,TCIA	4
+MRI GUIDED BREAST BIOPSY AUT VAC ROT LEFT	MR	ACRdart,IDC	4
+MRI FOREIGN IMAGES	MR, nan	IDC,TCIA	4
+PET/CT WB	SEG, nan	IDC,TCIA	4
+ct cap	CT, nan	IDC,TCIA	4
+CT CHEST/ABD/PEL LIVER	CT, SEG, nan	IDC,TCIA	4
+_t8of8_MRI HEAD	MR, nan	IDC,TCIA	4
+PET NON-SMALL CELL LUNG INITIAL STAGING	SEG, nan	IDC,TCIA	4
+NM PET SCAN RADIATION	RTSTRUCT, CT	IDC	4
+CT CHEST-CHEST	CT, nan	IDC,TCIA	4
+NM PET CT Routine Skull to Thigh 18 FDG Solid Tumor	CT, PT, nan	IDC,TCIA	4
+PET^02_CBM_Lung_Only (Adult)	CT, SEG, nan	IDC,TCIA	4
+PET NSC LUNG INIT STG	SEG, nan	IDC,TCIA	4
+MRI BREAST RESEARCH ECOG ACRIN W WO CONTRAST	MR	ACRdart,IDC	4
+PET NSC LUNG RESTAGE R	SEG, nan	IDC,TCIA	4
+MRI BREAST UNI 1ST EX?	MR, nan	IDC,TCIA	4
+Mammogram Screening Digital	MG	ACRdart	4
+MRI-PELVIS	RTSTRUCT, nan	IDC,TCIA	4
+MSK - Thigh (C+)	RTSTRUCT, MR, nan	IDC,TCIA	4
+lung3D	SEG, nan	IDC,TCIA	4
+PET CT WHOLE BODY	CT, SEG, nan	IDC,TCIA	4
+lung+c GSI	CT, nan	IDC,TCIA	4
+CT CHEST ABDOMEN PELVIS W/O IV CON	CT	MIDRC	4
+_t7of7  MRI IAMS	MR, nan	IDC,TCIA	4
+CT CHEST W CON	CT, SEG, nan	IDC,TCIA,MIDRC	4
+_t7of7MRI Head	MR, nan	IDC,TCIA	4
+CT CHEST ABDOMEN PELVIS W/WO CONTRAST	CT, SEG, nan	IDC,TCIA	4
+_t7of7MRI IAMS	MR, nan	IDC,TCIA	4
+PET PHILIPS	PT, nan	IDC,TCIA	4
+_t7of7_MRI IAMS	MR, nan	IDC,TCIA	4
+e+1 ACRIN 6667 CONTRAL	MR, nan	IDC,TCIA	4
+_t8of8MRI IAMS	MR, nan	IDC,TCIA	4
+_t9of9_MRI HEAD	MR, nan	IDC,TCIA	4
+Whole-Body PET	PT, nan	IDC,TCIA	4
+PT706B/READ	SEG, nan	IDC,TCIA	4
+CT THORAX WO CONTRAST	CT	MIDRC	4
+LUNG NODULE	PT, nan	IDC,TCIA	4
+CTA CHEST ABDOMEN PELVIS ANGIO	CT	MIDRC	4
+Thorax^FLASH_CTA_CHEST (Adult)	CT	MIDRC	4
+LTRC	CT, nan	IDC,TCIA	4
+LEFT Unilat Mammogram with Tomo	MG	ACRdart,IDC	4
+L I V E R	SEG, nan	IDC,TCIA	4
+KT klatki piersiowej bez i z CE z ujeciem nadbrzusza	CT, nan	IDC,TCIA	4
+Thorax^LARGE_CHEST_LOW_DOSE (Adult)	nan	TCIA	4
+KLP +C	CT, nan	IDC,TCIA	4
+JOINY CT C/A/P WITH	CT	MIDRC	4
+JHN CAP W/WO IP	CT	MIDRC	4
+JHN CAP W IP	CT	MIDRC	4
+CTABDPELW	RTSTRUCT, nan	IDC,TCIA	4
+JCCI CT LUNG SCREENING	CT	MIDRC	4
+CT_Abd/Pel	CT, nan	IDC,TCIA	4
+XR LEFT ANKLE 2 VIEWS	CR, DX	MIDRC	4
+XR KUB 1V PORTABLE	CR	MIDRC	4
+JCCI CT CHEST ENHANCED	CT	MIDRC	4
+Thorax^LOW_DOSE_LUNG_UNDER_30_BMI (Adult)	CT	MIDRC	4
+XR RIBS RIGHT - 2 VIEWS	CR	MIDRC	4
+CTA ABDOMEN PELVIS WWO CONTRAST (AORTA)	CT	MIDRC	4
+CT008   CT ABDOMEN W CO	CT, nan	IDC,TCIA	4
+CT UROGRAM WITHOUT 3D RECONSTRUCTIONS	RTSTRUCT, CT, nan	IDC,TCIA	4
+MAMMO DIAGNOSTIC DIGITAL LEFT	MG, nan	IDC,TCIA	4
+Thorax^CHEST_W_CONTRAST (Adult)	SEG, nan	IDC,TCIA	4
+MAMMO 3D DIAG RIGHT	MG	ACRdart,IDC	4
+CT Thorax w/ Contrast	CT	MIDRC	4
+XR RIGHT FINGERS	CR, DX	MIDRC	4
+XR RIGHT ELBOW 3+ VIEWS	CR, DX	MIDRC	4
+CT Thorax with Contrast	SEG, nan	IDC,TCIA	4
+CT UROGRAM WITH CHEST	CT, nan	IDC,TCIA	4
+CT UROGRAPHY CT ABDOME	RTSTRUCT, SEG, nan	IDC,TCIA	4
+CT/C-A-P	CT, SEG, nan	IDC,TCIA	4
+CT Urogram (1)	CT, nan	IDC,TCIA	4
+Thorax^CT_CA_WITH (Adult)	CT	MIDRC	4
+XR RIBS, LEFT	DX	MIDRC	4
+Lung V/Q Scan	NM, nan	IDC,TCIA	4
+XR RIBS, BILATERAL	DX	MIDRC	4
+Lung Perfusion Scan	CT, nan	IDC,TCIA	4
+CT,ABDOMEN W&W/O CONTRAST	CT, nan	IDC,TCIA	4
+CT-CH/A/P	CT, SEG, nan	IDC,TCIA	4
+Thorax^LOW_DOSE_NODULE_FU_WO_CM (Adult)	CT	MIDRC	4
+Thorax^LungRoutine	CT, nan	IDC,TCIA	4
+Implant Screening - ComboHD	MG, nan	IDC,TCIA	4
+Vascular^NEW_PE_CTA_ 22 (Adult)	CT	MIDRC	4
+DIGITAL MAMMOGRAM,UNILATERAL	MG, nan	IDC,TCIA	4
+Diagnostic Acquisition	PT, nan	IDC,TCIA	4
+Diagnostic Mammography	MG	ACRdart,IDC	4
+Upper-Abdomen +c	CT, nan	IDC,TCIA	4
+Diagnostic Mammography Combo	MR, MG	ACRdart	4
+Vascular^02_PE (Adult)	CT, nan	IDC,TCIA	4
+Digital Right Mammogram Diagnostic	MG, nan	IDC,TCIA	4
+Vascular^DISSECTION_CAP_CTA (Adult)	CT	MIDRC	4
+X-RAY CERVICAL SPINE MINIMUM 4 VIEWS	CR, DX	MIDRC	4
+US PELVIS W TRANSVAGINAL	US, nan	IDC,TCIA	4
+F/U	CT, nan	IDC,TCIA	4
+FDG 5 AFOV TORSO	CT, SEG, nan	IDC,TCIA	4
+H DIGITAL SCREEN/TOMO,CVIEW & CAD	MG	ACRdart,IDC	4
+H DIGITAL SCREEN TOMO CVIEW AND CAD	MG	ACRdart,IDC	4
+WB PET-CT	CT, SEG, nan	IDC,TCIA	4
+WB PET/CT W/ DELAYS	SEG, nan	IDC,TCIA	4
+WB emission scan 2i/8s	PT, nan	IDC,TCIA	4
+FL ESOPHAGRAM	RF	MIDRC	4
+USABDLCON/4228	US, nan	IDC,TCIA	4
+US Kidney	US, nan	IDC,TCIA	4
+Outside Read or Comparison PET	SEG, PT, nan	IDC,TCIA	4
+Trio RoutineHead	RTPLAN, nan	IDC,TCIA	4
+XR ABDOMEN 1 VW	DX	MIDRC	4
+CT_LSpine	CT, nan	IDC,TCIA	4
+CT_LungBiopsy	CT, nan	IDC,TCIA	4
+CT_biopsybonemarrow	CT, nan	IDC,TCIA	4
+CT_biopsyliver	CT, nan	IDC,TCIA	4
+Thyroid	US	ACRdart	4
+TomoHD Unilateral Right	MG, nan	IDC,TCIA,ACRdart	4
+Tomoscintigrafia PET t	SEG, PT, nan	IDC,TCIA	4
+Head^HEAD_Routine (Adult)	CT	MIDRC	4
+Head^CT_MAXILLOFACIAL_WITH (Adult)	CT	MIDRC	4
+Chest CT Routine	CT, nan	IDC,TCIA	4
+Chest Contrast	CT, nan	IDC,TCIA	4
+Chest PA+LAT	DX	MIDRC	4
+X-RAY SACRUM AND COCCYX MINIMUM 2 VIEWS	DX	MIDRC	4
+UNKNOWN	US	ACRdart	4
+Chest With Contrast	CT, nan	IDC,TCIA	4
+Head^DE_CTA_NECK_Customized (Adult)	CT	MIDRC	4
+US Biopsy Liver	US, nan	IDC,TCIA	4
+MAMMO DIGITAL TOMOSYNTHESIS DIAGNOSTIC BILATERAL	MG	ACRdart,IDC	4
+XR RIGHT KNEE 3 VIEWS	CR, DX	MIDRC	4
+_t3of5MRI IAMS	MR, nan	IDC,TCIA	4
+CT THORAX WITH CONTRAS	RTSTRUCT, CT, nan	IDC,TCIA	4
+SPINE PROTOCOLS^SMALL ANIMAL	MR, nan	IDC,TCIA	4
+SPINE^L-SPINE	MR	MIDRC	4
+SV	US	ACRdart	4
+CT HEAD WWO CONTRAST	CT	MIDRC	4
+CT HEART FOR CONGENITAL HEART DISEASE	CT	MIDRC	4
+CT HI RES CHEST	CT, nan	IDC,TCIA	4
+Scanner-Philips_Exp-100_Pitch-0.9_SlCol-16x0.75	CT, nan	IDC,TCIA	4
+Scanner-Philips_Exp-100_Pitch-0.9_SlCol-16x1.5	CT, nan	IDC,TCIA	4
+Scanner-Philips_Exp-100_Pitch-0.9_SlCol-16x1.5mm	CT, nan	IDC,TCIA	4
+Scanner-Philips_Exp-100_Pitch-1.2_SlCol-16x0.75	CT, nan	IDC,TCIA	4
+MR BREAST BI UE	MR, nan	IDC,TCIA	4
+Scanner-Philips_Exp-100_Pitch-1.2_SlCol-16x1.5	CT, nan	IDC,TCIA	4
+Scanner-Philips_Exp-200_Pitch-0.9_SlCol-16x0.75	CT, nan	IDC,TCIA	4
+Scanner-Philips_Exp-200_Pitch-0.9_SlCol-16x1.5	CT, nan	IDC,TCIA	4
+Scanner-Philips_Exp-200_Pitch-0.9_SlCol-16x1.5mm	CT, nan	IDC,TCIA	4
+_t2of2  MRI IAMS	MR, nan	IDC,TCIA	4
+Scanner-Philips_Exp-200_Pitch-1.2_SlCol-16x0.75	CT, nan	IDC,TCIA	4
+_t2of2  External Images for PACS	MR, nan	IDC,TCIA	4
+CT LUNG BIOPSY	CT, nan	IDC,TCIA	4
+SOFT TISSUE NECK	CR	MIDRC	4
+MR BREAST UNILATERAL W/WO CONT	nan	TCIA	4
+CT HEAD (BRAINLAB) WO CONTRAST PRE-OP	CT	MIDRC	4
+MR PELVIS W/WO CONTRAST	MR, nan	IDC,TCIA	4
+_t3of5  External Images for PACS	MR, nan	IDC,TCIA	4
+Pelvic Cavity CT Routine	CT, nan	IDC,TCIA	4
+MR TOTAL SPINE WITH AND WITHOUT CONTRAST	MR	MIDRC	4
+Performed Desc	CR, DX	MIDRC	4
+CT Chest-w/Contrast	CT, nan	IDC,TCIA	4
+Port - CXR	DX	MIDRC	4
+_t3of3  MRI Stereo Gamma Knife	MR, nan	IDC,TCIA	4
+CT Chest/Abdomen	CT, nan	IDC,TCIA	4
+MR LT BREAST WO/W CONT 6667	MR, nan	IDC,TCIA	4
+SCREENING MAMMO/TOMO BIL W CAD	MG	ACRdart,IDC	4
+_t2of3External Images for PACS	MR, nan	IDC,TCIA	4
+MR LT BREAST WO/W CONT	MR, nan	IDC,TCIA	4
+RT BREAST BIOPSY	MR, nan	IDC,TCIA	4
+RT^RCCT_THORAX_8F (Adult)	RTSTRUCT, CT	IDC	4
+MR DIAGNOSTIC BILAT BREAST WANDW/O CONTRAST	MR	ACRdart,IDC	4
+MR CHOLANGIOPANCREATOGRAPHY	MR	MIDRC	4
+CT GUIDED BIOPSY:  KIDNEY	CT, nan	IDC,TCIA	4
+RoutineImage Guidance	RTDOSE, RTSTRUCT, nan	IDC,TCIA	4
+CT LUNG BX	CT, nan	IDC,TCIA	4
+Scanner-Philips_Exp-25_Pitch-0.9_SlCol-16x0.75	CT, nan	IDC,TCIA	4
+CT NECK SOFT TISSUE  W/ CONTR	CT, nan	IDC,TCIA	4
+Thorax^13_0_Chest_Biphase_Liver (Adult)	SEG, nan	IDC,TCIA	4
+CT THORAX  WITH AND WI	CT, nan	IDC,TCIA	4
+MC prostaat kliniek stadiering_mc MCPROSKL45	MR, nan	IDC,TCIA	4
+_t11of11_MRI IAMS WITH CONTRAST	MR, nan	IDC,TCIA	4
+Thorax^09_0_Chest_PE_Study (Adult)	CT, nan	IDC,TCIA	4
+_t11of11_MRI IAMS	MR, nan	IDC,TCIA	4
+Thorax^1 Chest Routine	CT, nan	IDC,TCIA	4
+XR_biopsybonemarrow	XA, nan	IDC,TCIA	4
+CT THORAX W CONT	CT, SEG, nan	IDC,TCIA	4
+XR WRIST LEFT (ROUTINE: AP,LAT,OBL)	CR, DX	MIDRC	4
+CT STONE STUDY(Adult)	CT	MIDRC	4
+MAMMOGRAM/ULTRASOUND	US	ACRdart	4
+CT THORAX W IV CONTRAS	SEG, nan	IDC,TCIA	4
+MAMMOGRAM SCREENING BILATERAL W/TOMO	MG	IDC	4
+Thorax^CAP_WITHOUT_Customized (Adult)	CT	MIDRC	4
+Thorax^CHEST_ABD_PEL (Adult)	CT, nan	IDC,TCIA	4
+XR RIGHT WRIST 1-2 VIEWS	CR, DX	MIDRC	4
+XR RIGHT TIBIA FIBULA 2 VIEWS	CR, DX	MIDRC	4
+MAMMO TOMO SCREEENING BILATERAL	MG	ACRdart,IDC	4
+_t1of1  MRI IAMS	MR, nan	IDC,TCIA	4
+_t1of11  External Images for PACS	MR, nan	IDC,TCIA	4
+Scanner-Philips_Exp-25_Pitch-0.9_SlCol-16x1.5	CT, nan	IDC,TCIA	4
+_t1of5  External Images for PACS	MR, nan	IDC,TCIA	4
+Scanner-Philips_Exp-25_Pitch-0.9_SlCol-16x1.5mm	CT, nan	IDC,TCIA	4
+_t1of8  External Images for PACS	MR, nan	IDC,TCIA	4
+MR ABDOMEN/PELVIS WITH AND WITHOUT CONTRAST	MR	MIDRC	4
+MR ABDOMEN WITHOUT CONTRAST	MR, nan	IDC,TCIA,MIDRC	4
+CT OUTSIDE IMAGING, REFERENCE ONLY	CT, nan	IDC,TCIA	4
+CT Outside CD Import	SEG, nan	IDC,TCIA	4
+Scanner-Philips_Exp-25_Pitch-1.2_SlCol-16x1.5mm	CT, nan	IDC,TCIA	4
+CT P CHEST WO	CT	MIDRC	4
+MR 6667 BREAST WO/W CONT	MR, nan	IDC,TCIA	4
+TRIPLE RO	CT, nan	IDC,TCIA	4
+CT PELVIS W/ CONTRAST, CT ABDOMEN W/WO CONTRAST	CT, SEG, nan	IDC,TCIA	4
+TAP W/C	SEG, nan	IDC,TCIA	4
+TK JAMY BRZUSZNE	RTSTRUCT, nan	IDC,TCIA	4
+_t1of4  External Images for PACS	MR, nan	IDC,TCIA	4
+TK jamy brzusznej	RTSTRUCT, nan	IDC,TCIA	4
+_t1of3_MRI External Films	MR, nan	IDC,TCIA	4
+CT Pelvis w/ Contrast	CT, nan	IDC,TCIA	4
+TOMOGRAFIA KLATKI PIER	CT, nan	IDC,TCIA	4
+Scanner-Philips_Exp-200_Pitch-1.2_SlCol-16x1.5	CT, nan	IDC,TCIA	4
+#NAME?	MR	ACRdart	4
+CT ABDOMEN/PELVIS WITHOUT CONTRAST (S)	CT	MIDRC	4
+CT ANGIO KIDNEY WITH CH/PEL	CT, SEG, nan	IDC,TCIA	4
+CAP W	SEG, nan	IDC,TCIA	4
+CT Abd and Pelvis with cont	CT, nan	IDC,TCIA	4
+A-P	CT, nan	IDC,TCIA	4
+CAP IP	CT	MIDRC	4
+A/P	CT, nan	IDC,TCIA	4
+A/P LIVER	SEG, nan	IDC,TCIA	4
+CT C/A/P LIVER PROT	SEG, nan	IDC,TCIA	4
+ABD (ADRENAL SURG )	CT, SEG, nan	IDC,TCIA	4
+CT C/A/P W/O WITH	SEG, nan	IDC,TCIA	4
+Breast^Bilateral Tumor	MR, nan	IDC,TCIA	4
+CT ABDOMEN & PELVIS ENHANCED-BODY	CT, nan	IDC,TCIA	4
+ABD (ADRENAL)	CT, SEG, nan	IDC,TCIA	4
+ABD CT W&W/OC	CT, nan	IDC,TCIA	4
+Breast-Left	MR, SEG	IDC	4
+Biopsy_Liver	CT, nan	IDC,TCIA	4
+CT ABDOMEN +/- AUGMENT=AB	RTSTRUCT, nan	IDC,TCIA	4
+BRZUCH	RTSTRUCT, nan	IDC,TCIA	4
+ABD/PELVIS WITH	CT, nan	IDC,TCIA	4
+CT ABDOMEN AND PELVIS WITH AND WITHOUT CONTRAST	RTSTRUCT, CT, nan	IDC,TCIA	4
+BREAST^RESEARCH STUDY	MR	ACRdart	4
+CT CAP LIVER PROTO	SEG, nan	IDC,TCIA	4
+CT ABDOMEN PELVIS WITH	RTSTRUCT, CT, nan	IDC,TCIA	4
+CT CAP ROUTINE	CT, SEG, nan	IDC,TCIA	4
+BREAST RIGHT	MR, nan	IDC,TCIA	4
+CT ABDOMEN PELVIS WWO CONTRAST	CT	MIDRC	4
+ABDOMEN W/WO	CT, nan	IDC,TCIA	4
+BREAST (L)	MR, nan	IDC,TCIA	4
+ACRIN 6667	MR, nan	IDC,TCIA	4
+BR-BreastBwc MR	MR, nan	IDC,TCIA	4
+CAP W CONTRAST	SEG, nan	IDC,TCIA	4
+CAP(ADRENAL)	CT, nan	IDC,TCIA	4
+CAP/LIVER W.WO	CT, nan	IDC,TCIA	4
+CT BIOPSY	CT, nan	IDC,TCIA	4
+CT Abdomen and Pelvis W/ Contrast	CT	MIDRC	4
+CONTRA BREAST LEFT	MR, nan	IDC,TCIA	4
+CHEST/ABDOMEN/PELVIS CT	CT, nan	IDC,TCIA	4
+CONTRABREAST  LEFT	MR, nan	IDC,TCIA	4
+CONTRABREAST LEFT	MR, nan	IDC,TCIA	4
+CHEST+C	CT, SEG, nan	IDC,TCIA	4
+CHEST WO OP	CT	MIDRC	4
+CHEST WO - nodule or mass with ion(Adult)	CT	MIDRC	4
+CT Abdomen, Pelvis, w/contrast	SEG, nan	IDC,TCIA	4
+CHEST W/WO CONTRAST (CT)-CS	CT	MIDRC	4
+5AFOV LUNGS	PT, nan	IDC,TCIA	4
+CT A/P	CT, SEG, nan	IDC,TCIA	4
+6667 CONTRA LATERAL	MR, nan	IDC,TCIA	4
+6667 CONTRA-LATERAL	MR, nan	IDC,TCIA	4
+CT Biopsy Retroperitoneal	CT, nan	IDC,TCIA	4
+CT BIOPSY LUNG OR MEDI	CT, nan	IDC,TCIA	4
+6667CONTRALAT. BREAST	MR, nan	IDC,TCIA	4
+CT A/P LIVER PROT	SEG, nan	IDC,TCIA	4
+CT ABD & PELVIS W/ + W/O CONTRAST	CT, nan	IDC,TCIA	4
+CHEST 1 VIEW PA/AP	CR	MIDRC	4
+CHEST (THORAX) WITHOUT	CT, nan	IDC,TCIA	4
+CT ABD PELVIS W/ CONTRAST, CT ABD PELVIS W/O CONTRAST	CT, nan	IDC,TCIA	4
+CT BRAIN W+WO CNTRST	CT, nan	IDC,TCIA	4
+CH	CT, SEG, nan	IDC,TCIA	4
+CBCC	CT, nan	IDC,TCIA	4
+CARDIAG GATING	CT, nan	IDC,TCIA	4
+CT ABD&PELVIS W/O C COLON TECHNIQUE	CT, nan	IDC,TCIA	4
+CT Biopsy Lung	CT, nan	IDC,TCIA	4
+ACRIN 6667-RESEARCH	MR, nan	IDC,TCIA	4
+CT ABDOMEN PELVIS ENHANCED	CT, nan	IDC,TCIA	4
+COLOGRAPHY SCREENING	CT, nan	IDC,TCIA	4
+Abdomen^02_CAP_ONERUN (Adult)	CT, nan	IDC,TCIA	4
+Abdomen^01ACRIN_Colonography _Prone	CT, nan	IDC,TCIA	4
+CT CARD W/CON PULMNARY VEIN	CT	MIDRC	4
+Abdomen^01APRoutine (Adult)	CT, nan	IDC,TCIA	4
+CT ABDOMEN/PELVIS  (RENAL COLIC)	CT, nan	IDC,TCIA	4
+CT ABDOMEN WITHOUT CONTRAST	CT	MIDRC	4
+B MRI-RT THIGH	RTSTRUCT, MR, nan	IDC,TCIA	4
+Abdomen^02 Chest-Abd-Pelvis 2	CT, nan	IDC,TCIA	4
+CT CH/ABD/PEL(LIVER)	SEG, nan	IDC,TCIA	4
+CT CH/ABD/PEL (LIVER)	CT, SEG, nan	IDC,TCIA	4
+CT ABDOMEN wo	CT, nan	IDC,TCIA	4
+Abdomen^1_ABD-PELV	CT, nan	IDC,TCIA	4
+Abdomen^1CAP_WO_WC (Adult)	CT, nan	IDC,TCIA	4
+Abdomen^01 ABD-PEL	CT, nan	IDC,TCIA	4
+Abdomen^02_Chest_Abd (Adult)	CT, nan	IDC,TCIA	4
+B LT THIGH	RTSTRUCT, nan	IDC,TCIA	4
+Abdomen^04_CA (Adult)	CT, nan	IDC,TCIA	4
+Abdomen^05_CAP (Adult)	CT, nan	IDC,TCIA	4
+Abdomen^07_2_ACRIN COLONOGRAPHY (Adult)	CT, nan	IDC,TCIA	4
+CT CH/AB/PEL	CT, SEG, nan	IDC,TCIA	4
+CT CH/AB/PEL W/O CONTRAST	CT, nan	IDC,TCIA	4
+Abdomen^urogram_STONE_gr (Adult)	CT	MIDRC	4
+Abdomen^12_9_Liver_HCC_Hepatoma_Triphase (Adult)	SEG, nan	IDC,TCIA	4
+CT CH/AB/PELVIS	CT, SEG, nan	IDC,TCIA	4
+Abdomen^UROGRAM_2 (Adult)	RTSTRUCT, CT, nan	IDC,TCIA	4
+Abdomen^1_CA	CT, nan	IDC,TCIA	4
+CT ABDOMEN WITHOUT CON	CT, nan	IDC,TCIA	4
+CT CAP W/WO	CT, SEG, nan	IDC,TCIA	4
+Abdomen^2 BIPHASE LIVER_PANC	SEG, nan	IDC,TCIA	4
+CT ABDOMEN W/WO CONTRA	CT, nan	IDC,TCIA	4
+3607 MR BREAST WO/W CONT	MR, SEG	IDC	4
+/PRO/BD   Pelvis w&w/oCon	SEG, nan	IDC,TCIA	4
+*MRI - PELVIS	MR, nan	IDC,TCIA	4
+CT ABDOMEN/PELVIS W AND W/O IV CONTRAST	RTSTRUCT, nan	IDC,TCIA	4
+ACRIN6667/CONTRALAT BR	MR, nan	IDC,TCIA	4
+ACRIN 6701 MRT Prostata Follow UP	PR, MR	ACRdart	4
+ANKLE LEFT MIN 3 VIEWS	CR, DX	MIDRC	4
+CT ABD AND PELVIS WWO IV CONT	CT, nan	IDC,TCIA,MIDRC	3
+CT HEAD (BRAINLAB) W CONTRAST PRE-OP	CT	MIDRC	3
+DUAL ABDOMEN(Adult)	CT	MIDRC	3
+DX	DX	MIDRC	3
+XR PELVIS 1-2 VIEWS	CR, DX	MIDRC	3
+Cardiac^TAVR_BOLUSTRACKAdult (Adult)	CT	MIDRC	3
+XR SCOLIOSIS STUDY 2 OR 3 VIEWS	DX	MIDRC	3
+Thorax^LARGE_CHEST_WITHOUT_IV_CONTRAST (Adult)	nan	TCIA	3
+CR XR PORTABLE FEEDING TUBE X-RAY	CR	MIDRC	3
+CTA Chest W Embolus	CT	MIDRC	3
+XR SPINE CERVICAL (AP + LAT)	CR, DX	MIDRC	3
+CT FACE/SINUSES (BRAINLAB) WO CONTRAST	CT	MIDRC	3
+CTA CHEST(Adult)	CT	MIDRC	3
+Thorax^LOW_DOSE_CHEST_OVER_30_BMI (Adult)	CT	MIDRC	3
+XR RIBS LEFT - 2 VIEWS	CR	MIDRC	3
+CT ABD AND PELVIS WO IV CONTRAST	CT, nan	IDC,TCIA,MIDRC	3
+XR RIGHT HIP 2+ VIEWS ORTHOPEDICS PRE OPERATIVE	CR, DX	MIDRC	3
+Cardiac^DANIELS_ROUTINE (Adult)	CT	MIDRC	3
+Cardiac^COR_HR_LESS_THAN_65 (Adult)	CT	MIDRC	3
+Thorax^CTA_CHEST_Adult_Customized (Adult)	CT	MIDRC	3
+XR LUMBAR SPINE 4+ VIEWS	DX	MIDRC	3
+DCUABDNGPL	DX	MIDRC	3
+CT HEART WITH CONTRAST	CT	MIDRC	3
+XR RIGHT HUMERUS	CR, DX	MIDRC	3
+Chest Post Line/Tube/ETT Init	CR	MIDRC	3
+Cardiac^COR_HR_65to75 (Adult)	CT	MIDRC	3
+Cardiac^CORONARY_PROSPECTIVE_MORE_PAD (Adult)	CT	MIDRC	3
+DE ABDOMEN PELVIS(Adult)	CT	MIDRC	3
+CT HEAD (PERFUSION ONLY)	CT	MIDRC	3
+DG CHEST 1V	CR	MIDRC	3
+Thorax^HI_RESOLUTION_CHEST (Adult)	CT	MIDRC	3
+XR PELVIS 1 VIEW	CR, DX	MIDRC	3
+X-RAY SHOULDER 1 VIEW - RIGHT	DX	MIDRC	3
+CTA CHEST WITH CONTRAST - PE PROTOCOL	CT	MIDRC	3
+Vascular^CTA_HEAD (Adult)	CT	MIDRC	3
+XR HIP RIGHT 2-3 VIEWS WWO PELVIS	CR, DX	MIDRC	3
+TUMOR LOCALWHOLE BODY SINGLE	NM, nan	IDC,TCIA,MIDRC	3
+Vascular^Pre_AAA_STENT_ (Adult)	CT	MIDRC	3
+CT THORAX W CONTRAST	CT	MIDRC	3
+CT ABDOMEN PELVIS W CONTRAST (ENTEROGRAPHY)	CT	MIDRC	3
+CT P ANGIO CHEST WWO	CT	MIDRC	3
+X-RAY ABDOMEN POST TUBE PLACEMENT	DX	MIDRC	3
+X-RAY BONE LENGTH STUDIES	DX	MIDRC	3
+CT SPINE CERVICAL WO CONTRAST	CT	MIDRC	3
+XR FOOT LEFT (ROUTINE: AP,LAT,OBL)	CR, DX	MIDRC	3
+XR CERVICAL SPINE 4-5 VIEWS	CR, DX	MIDRC	3
+X-RAY ELBOW 2 VIEWS - RIGHT	DX	MIDRC	3
+X-RAY ELBOW COMPLETE MIN 3 VWS - RIGHT	DX	MIDRC	3
+X-RAY ENTIRE SPINE SCOLIOSIS 2 OR 3 VIEWS	DX	MIDRC	3
+X-RAY FEMUR MINIMUM 2 VIEWS - LEFT	DX	MIDRC	3
+CT ABDOMEN W AND WO IV CONTRAST	CT	MIDRC	3
+CT ABDOMEN W CONTRAST (CIRRHOSIS)	CT	MIDRC	3
+X-RAY HIPS BILATERAL WITH PELVIS 2 VIEWS	DX	MIDRC	3
+3607 MR RT BREAST WO/W CONT	MR, SEG	IDC	3
+Vascular^CTA_PE (Adult)	CT	MIDRC	3
+Vascular^CTA_CHEST_GR (Adult)	CT	MIDRC	3
+CTA CHEST WITH CONTRAS	CT	MIDRC	3
+CT Thorax w/Cont	SEG, nan	IDC,TCIA	3
+XR LOWER LEG (TIBIA/FIBULA) LEFT	CR, DX	MIDRC	3
+XR LEFT TIBIA FIBULA 2 VIEWS	CR, DX	MIDRC	3
+CT ABD-PELV W/O CM	CT	MIDRC	3
+CTA CHEST AND CT ABDOMEN AND PELVIS W CONT	CT	MIDRC	3
+Thorax^TRAUMA_CHEST_ABD_PEL_WITH (Adult)	CT	MIDRC	3
+CTA CERVICAL CAROTIDS-CS	CT	MIDRC	3
+X-RAY TOE(S) MINIMUM 2 VIEWS - LEFT	CR, DX	MIDRC	3
+XR LEFT KNEE 3 VIEWS	CR, DX	MIDRC	3
+Thorax^XL_CTA_CHEST (Adult)	CT	MIDRC	3
+CTA ABDOMEN AND PELVIS	CT	MIDRC	3
+ULTRASOUND T1 F/U 1	US	ACRdart	3
+US ABDOMEN LIMITED	US	MIDRC	3
+US LOWER EXTREMITY VENOUS DUPLEX LTD	US	MIDRC	3
+US SOFT TISSUE HEAD/NECK	US	MIDRC	3
+CT UROGRAPHY	CT	MIDRC	3
+Ultrasound Guided Core Biopsy	US	ACRdart	3
+CT LUNG NODULE F/U	CT	MIDRC	3
+CT ABDOMEN WO CONTRAST (ROUTINE)	CT	MIDRC	3
+XR LEFT ELBOW 1-2 VIEWS	CR, DX	MIDRC	3
+XR LEFT KNEE 4+ VIEWS (TRAUMA)	CR, DX	MIDRC	3
+MRI MRCP	MR, nan	IDC,TCIA,MIDRC	3
+TRAUMA CHEST AP PORTABLE	CR, nan	IDC,TCIA,MIDRC	3
+Mg. Mammo Digital Screening Bilateral	MG	ACRdart	3
+MRI THORACIC SPINE W/O CONTRAST	MR	MIDRC	3
+MRI THORACIC SPINE WO/W IV CONTRAST	MR	MIDRC	3
+BR SV	US	ACRdart	3
+ACRIN 6701 MRT Prostata Baseline	PR, MR	ACRdart	3
+BR-BX BrstCoreL	US	ACRdart	3
+BR-BX BrstCoreR	US	ACRdart	3
+BR-Breast US_RT	US	ACRdart	3
+ABOVE 30 BMI LUNG LOW DOSE(Adult)	CT	MIDRC	3
+MR BREAST BI W O W CONTRAST	MR	ACRdart,IDC	3
+Mammo-Digital Screening Employee w/ Tomo	MG	ACRdart,IDC	3
+MR BRAIN WITHOUT CONTRAST (S)	MR	MIDRC	3
+MRI SHOULDER WO CONTRAST - LEFT	MR	MIDRC	3
+MR BRAIN WITH AND WITHOUT CONTRAST (S)	MR	MIDRC	3
+NM LUNG VENTILATION/PERFUSION SCAN	NM	MIDRC	3
+NM MYOCARDIAL EXERCISE TREADMILL STRESS ECG	NM, NM,CT	MIDRC	3
+ABDOMEN SERIES FLAT AND ERECT PORTABLE	CR, nan	IDC,TCIA,MIDRC	3
+MR ABDOMEN WITH AND WITHOUT CONTRAST	MR	MIDRC	3
+BREAST-LEFT	MR, nan	IDC,TCIA	3
+NUC MED BONE/JOINT IMAGING WHOLE BODY	NM	MIDRC	3
+Normal	CT	IDC	3
+ABDOMEN 1 VIEW KUB	CR	MIDRC	3
+MMSCRCOMBO	MG	ACRdart,IDC	3
+MRI SPINE SURVEY WO/W IV CONTRAST	MR	MIDRC	3
+MRI PROSTATE WO/W CONTRAST	MR	MIDRC	3
+BRST TOMO BILAT MAMMO	MG	ACRdart	3
+Abdomen^ROUTINE_AP_WITH_UNDER_50_OVER_250 (Adult)	CT	MIDRC	3
+MRI ABDOMEN WO/W CONTRAST	MR	MIDRC	3
+MRI BREAST BILAT COMPLETE O/P	MR	ACRdart,IDC	3
+MRI BREAST BILAT PRE&POST INF	MR	IDC	3
+MRI ABD WO IV CONT	MR, nan	IDC,TCIA,MIDRC	3
+MRI BREAST BILATERAL WO/W CONTRAST	MR	MIDRC	3
+Abdomen^ABD_PELVIS_WITHOUT (Adult)	CT	MIDRC	3
+Abdomen^AB20_LOWER_GIB (Adult)	CT	MIDRC	3
+Abdomen^6_DUAL_PHASE (Adult)	CT	MIDRC	3
+MR THORACIC SPINE WITH AND WITHOUT CONTRAST (S)	MR	MIDRC	3
+MR THORACIC SPINE WITH AND WITHOUT CONTRAST	MR	MIDRC	3
+Abdomen^ROUTINE_AP_WO (Adult)	CT	MIDRC	3
+BI BREAST SCREENING BILATERAL	MG	ACRdart,IDC	3
+MR Research Grant Stu?	MR, SEG	IDC	3
+MRI CARDIAC WO/W CONTRAST	MR	MIDRC	3
+Abdomen^11_ADRENAL (Adult)	CT	MIDRC	3
+MR PROSTATE WITH AND WITHOUT CONTRAST	MR	MIDRC	3
+Abdomen^XL_AP_WITH (Adult)	CT	MIDRC	3
+MRI HIP WITHOUT CONTRAST-LEFT	MR	MIDRC	3
+MRI LUMBAR SPINE WO/W IV CONTRAST	MR	MIDRC	3
+MRI PELVIS BONE W/O CONTRAST	MR	MIDRC	3
+BD/PRO Pelvis w	SEG, nan	IDC,TCIA	3
+BELOW 30 BMI LUNG LW DOSE_LUNG SCREEN(Adult)	CT	MIDRC	3
+BREAST^SENTINELLE  COIL	MR	ACRdart,IDC	3
+MG MAMMO+3D SCREEN	MG	ACRdart,IDC	3
+TRANSESOPHAGEAL ECHO	US	MIDRC	3
+HIP RIGHT 2 VIEWS LATERAL AND AP PELVIS (ROUTINE)	CR	MIDRC	3
+JCCI CT CHEST/PELVIS	CT	MIDRC	3
+CHEST 1 VIEW PORTABLE	CR, DX	MIDRC	3
+RIGHT MAMMO DIGITAL DIAGNOSTIC	MG	ACRdart,IDC	3
+CHEST AP INFANT PORTABLE	CR, nan	IDC,TCIA,MIDRC	3
+Head^Maxillofacial (Adult)	CT	MIDRC	3
+CHEST OP	CT	MIDRC	3
+CHEST OVER PENETRATED PA AP PORTABLE	CR, nan	IDC,TCIA,MIDRC	3
+Head^CTA_HEAD (Adult)	CT	MIDRC	3
+CHEST PORT LINE PLACEMENT	CR	MIDRC	3
+Head	CT	MIDRC	3
+HIP LEFT 2 VIEWS LATERAL AND AP PELVIS (ROUTINE)	CR	MIDRC	3
+JHN CAP OP	CT	MIDRC	3
+HIP COMPLETE RIGHT MIN 2 VWS	CR, DX	MIDRC	3
+CHEST ROUTINE PA/AP AND LATERAL	CR, nan	IDC,TCIA,MIDRC	3
+HAND LEFT 3 VIEWS MIN	CR, DX	MIDRC	3
+CHEST WO IP	CT	MIDRC	3
+Screen digital breast tomosynthesis bil	MG	ACRdart	3
+T0 - Ultra	US	ACRdart	3
+THORAX LOW DOSE	CT, nan	IDC,TCIA,MIDRC	3
+CHEST-PA AND LATERAL VIEWS	CR, DX	MIDRC	3
+CHEST-PA ONLY	CR, DX	MIDRC	3
+FOOT	CR, MR	MIDRC	3
+XR SPINE LUMBAR (AP+LAT+OBLIQUES)	CR, DX	MIDRC	3
+JHN CHEST W/ OP	CT	MIDRC	3
+MG 3D TOMO HD DX LT	MG	ACRdart,IDC	3
+MAMMO DIAGNOSTIC W OR WO CAD WITH TOMOSYNTHESIS - BI	MG	ACRdart	3
+BX MRI RT	MR	ACRdart,IDC	3
+ABD SUPINE LATERAL	CR, nan	IDC,TCIA,MIDRC	3
+MAMMO-DIGITAL SCREENING EMPLOYEE W/ TOMO	MG	ACRdart,IDC	3
+BlueCoral	DX, CT	MIDRC	3
+Breast-Right	MR	IDC	3
+C-ARM FLUOROSCOPY UP TO 1 HOUR	RF, XA	MIDRC	3
+C-ARM FLUOROSCOPY UP TO 2 HOURS	RF, XA	MIDRC	3
+C/A/P IP	CT	MIDRC	3
+MAMMO DIGITAL DIAGNOSTIC RIGHT	MG	ACRdart,IDC	3
+MAMMO DIAGNOSTIC W OR WO CAD WITH TOMOSYNTHESIS - LT	MG	ACRdart,IDC	3
+MAMMO DIAGNOSTIC LT RETURNEE	MG	ACRdart,IDC	3
+PULMONARY PERFU SION	CT, NM, nan	IDC,TCIA,MIDRC	3
+PET LUNG	nan	TCIA	3
+CAP IV OP	CT	MIDRC	3
+LUMBAR SACRAL SPINE 2 OR 3 VIEWS (ROUTINE)	CR	MIDRC	3
+CAP_WO(Adult)	CT	MIDRC	3
+CARDIAC CORONARY CTA	CT, nan	IDC,TCIA,MIDRC	3
+LEFT MAMMO DIGITAL TOMOSYNTHESIS DIAGNOSTIC	MG	ACRdart,IDC	3
+L-SPINE	MR, nan	IDC,TCIA,MIDRC	3
+KIDNEY PROTOCOL(Adult)	CT	MIDRC	3
+JOINY CT CHEST LUNG SCREEN	CT	MIDRC	3
+JOIEN CT C/A/P	CT	MIDRC	3
+Physics^EFJ NCI	nan	TCIA	3
+Abdomen^GH_AbdomenPlain (Adult)	CT	MIDRC	3
+XR SPINE LUMBAR (AP+LAT, SUPINE+UPRIGHT)	CR, DX	MIDRC	3
+CT ER Chest w IV Contrast	CT	MIDRC	3
+CT Abd/Pelvis W/ IV + Oral Contrast	CT	MIDRC	3
+CT CAP W DYE	nan	TCIA	3
+CT CHEST NO IVCON	CT	MIDRC	3
+CT CHEST, ABDOMEN & PELVIS W CONTRAST	CT	MIDRC	3
+CT CHEST ILD	CT	MIDRC	3
+CT CHEST(SEE AB/PEL) W IV CON	CT, nan	IDC,TCIA,MIDRC	3
+CT CHEST DYNAMIC AIRWAY	CT	AIMI	3
+CT CHEST ANGIOGRAPHY W IV CONTRAST PULMONARY EMBOLISM	CT	MIDRC	3
+CT CARDIAC CHEST W/ (ROBOTIC & CORONARY)	CT	MIDRC	3
+CT Chest/Abd/Pelvis W/Contrast	CT	MIDRC	3
+CT CHEST ABDOMEN AND PELVIS W CONTRAST	CT	MIDRC	3
+CT CHEST WO CONT	CT	MIDRC	3
+CT CHEST WO AND W CONTRAST	CT	MIDRC	3
+CT CHEST WITH AND WITHOUT CONTRAST (S)	CT	MIDRC	3
+CT ANGIOGRAM HEART CORONARY ARTERIES WITH CONTRAST	CT	MIDRC	3
+6V2E-2	SR, nan	IDC,TCIA	2
+PET/CT LUNG CA STAGING FD	SEG, nan	IDC,TCIA	2
+_t8of8EXTERNAL IMAGES	MR, nan	IDC,TCIA	2
+7V6A-2	SR, nan	IDC,TCIA	2
+7V6A-1	SR, nan	IDC,TCIA	2
+7V5F-2	SR, nan	IDC,TCIA	2
+7V5E-2	SR, nan	IDC,TCIA	2
+7V5E-1	SR, nan	IDC,TCIA	2
+_t8of8  MRI IAMS post Gad	MR, nan	IDC,TCIA	2
+_t8of8  MRI IAMS	MR, nan	IDC,TCIA	2
+PET/CT Lung Nodu	SEG, nan	IDC,TCIA	2
+7V5D-2	SR, nan	IDC,TCIA	2
+7V5D-1	SR, nan	IDC,TCIA	2
+7V5C-2	SR, nan	IDC,TCIA	2
+7V5C-1	SR, nan	IDC,TCIA	2
+PET/CT RAD TX	SEG, nan	IDC,TCIA	2
+7V5B-2	SR, nan	IDC,TCIA	2
+7V6B-1	SR, nan	IDC,TCIA	2
+7V6B-2	SR, nan	IDC,TCIA	2
+7V6E-1	SR, nan	IDC,TCIA	2
+S.KOZAK	CT, nan	IDC,TCIA	2
+1V4A-2	SR, nan	IDC,TCIA	2
+PET-CT STUDY for Shelly Wallace	PT, nan	IDC,TCIA	2
+PET-CT WATROBA	CT, nan	IDC,TCIA	2
+PET-CT WB ST	CT, nan	IDC,TCIA	2
+_t8of8MRI Head	MR, nan	IDC,TCIA	2
+PET-TK ONKOLOGIC	PT, nan	IDC,TCIA	2
+SBRT PELVIS	CT, nan	IDC,TCIA	2
+7V6D-1	SR, nan	IDC,TCIA	2
+PET/CT ATTN ONLY NCAP	SEG, nan	IDC,TCIA	2
+7V6C-2	SR, nan	IDC,TCIA	2
+7V6C-1	SR, nan	IDC,TCIA	2
+PET/CT DELAY	SEG, nan	IDC,TCIA	2
+PET/CT Head Neck Reference Only	SEG, nan	IDC,TCIA	2
+PET/CT Imaging - Skull Base to Mid-Thigh=W	PT, nan	IDC,TCIA	2
+PET/CT LUNG	SEG, nan	IDC,TCIA	2
+7V5B-1	SR, nan	IDC,TCIA	2
+1V4B-1	SR, nan	IDC,TCIA	2
+1V4B-2	SR, nan	IDC,TCIA	2
+7V5A-2	SR, nan	IDC,TCIA	2
+7V4B-2	SR, nan	IDC,TCIA	2
+1V4C-1	SR, nan	IDC,TCIA	2
+PETCT CONTRASTED SUBSQ TX 78815	SEG, nan	IDC,TCIA	2
+7V4B-1	SR, nan	IDC,TCIA	2
+7V4A-2	SR, nan	IDC,TCIA	2
+7V4A-1	SR, nan	IDC,TCIA	2
+7V3F-2	SR, nan	IDC,TCIA	2
+PETCT LIMITED WHOLE BODY VERTEX TO MID THIGH (S)	PT	MIDRC	2
+PETCT LUNG CA	SEG, nan	IDC,TCIA	2
+7V3E-2	SR, nan	IDC,TCIA	2
+PETCT LUNG NODULE	SEG, nan	IDC,TCIA	2
+7V3E-1	SR, nan	IDC,TCIA	2
+7V3D-2	SR, nan	IDC,TCIA	2
+7V3D-1	SR, nan	IDC,TCIA	2
+7V3C-2	SR, nan	IDC,TCIA	2
+6V2B-1	SR, nan	IDC,TCIA	2
+PETCT COLON CA	SEG, nan	IDC,TCIA	2
+7V4C-1	SR, nan	IDC,TCIA	2
+PET/CT W/CON LUNG SPN	SEG, nan	IDC,TCIA	2
+Rtg Klatki Piersiowej	CT, nan	IDC,TCIA	2
+7V5A-1	SR, nan	IDC,TCIA	2
+PET/CT Skull Base to M	SEG, nan	IDC,TCIA	2
+7V4F-2	SR, nan	IDC,TCIA	2
+6V2A-1	SR, nan	IDC,TCIA	2
+PET/CT Uncovered Diagn	SEG, nan	IDC,TCIA	2
+7V4E-2	SR, nan	IDC,TCIA	2
+7V4C-2	SR, nan	IDC,TCIA	2
+7V4E-1	SR, nan	IDC,TCIA	2
+PET/CT with added MR	MR, nan	IDC,TCIA	2
+7V4D-2	SR, nan	IDC,TCIA	2
+7V4D-1	SR, nan	IDC,TCIA	2
+PET1A	CT, nan	IDC,TCIA	2
+6V2A-2	SR, nan	IDC,TCIA	2
+7V6D-2	SR, nan	IDC,TCIA	2
+PET WB OR REG RESTAG HEAD+NECK	SEG, nan	IDC,TCIA	2
+_t5of9MRI IAMS post Gad	MR, nan	IDC,TCIA	2
+PET CT TUMOR IMG SKULL THIGH	CT, nan	IDC,TCIA	2
+abd/pelvis	SEG, nan	IDC,TCIA	2
+PET CT TUMOR WHOLE BO	nan	TCIA	2
+AB PEL/	CT, nan	IDC,TCIA	2
+AABD/PELVIS	SEG, nan	IDC,TCIA	2
+PET CT WHOLE BODY NON REGISTRY INITIAL STAGING	PT, nan	IDC,TCIA	2
+AABD (ADRENAL)	CT, nan	IDC,TCIA	2
+ab/5589	MR, nan	IDC,TCIA	2
+AA/P LIVER	SEG, nan	IDC,TCIA	2
+PET DEDICATED RUBIDIUM REST/STRESS MYOCARDIAL PERFUSION	CT, PT	MIDRC	2
+A/P-PRE/POST	CT, nan	IDC,TCIA	2
+1V3D-1	SR, nan	IDC,TCIA	2
+1V3D-2	SR, nan	IDC,TCIA	2
+A/P-LIVER	SEG, nan	IDC,TCIA	2
+1V3E-1	SR, nan	IDC,TCIA	2
+A/P WO	CT, nan	IDC,TCIA	2
+SCAN ABDOMINO-PELVIEN C+ -ABD	CT, nan	IDC,TCIA	2
+PET CT Skull To Mid Th	SEG, nan	IDC,TCIA	2
+7V6E-2	SR, nan	IDC,TCIA	2
+PET CT Sarcoma Initial	SEG, nan	IDC,TCIA	2
+1V3A-1	SR, nan	IDC,TCIA	2
+PET CT IMAGING SKULL BASE TO THIGH	CT, nan	IDC,TCIA	2
+1V3A-2	SR, nan	IDC,TCIA	2
+1V3B-1	SR, nan	IDC,TCIA	2
+PET CT LIMITED AREA	CT, nan	IDC,TCIA	2
+1V3B-2	SR, nan	IDC,TCIA	2
+ABD	CT, nan	IDC,TCIA	2
+PET CT SCAN ONCOLOGY DIAGNOSTIC	CT, nan	IDC,TCIA	2
+PET CT SCAN ONCOLOGY INITIAL STAGING	CT, nan	IDC,TCIA	2
+1V3C-1	SR, nan	IDC,TCIA	2
+1V3C-2	SR, nan	IDC,TCIA	2
+AB/6514	MR, nan	IDC,TCIA	2
+AB+C	SEG, nan	IDC,TCIA	2
+PET CT SKULL TO MID-TH	SEG, nan	IDC,TCIA	2
+PET CT SKULL TO MID-THIGH	PT, nan	IDC,TCIA	2
+PET IMAGE W/CT, LMTD	SEG, nan	IDC,TCIA	2
+A/P WITH	CT, nan	IDC,TCIA	2
+PET Imaging Outside Consultation With Formal Dictation	CT, nan	IDC,TCIA	2
+1V3E-2	SR, nan	IDC,TCIA	2
+PET OVARIAN CANCER	SEG, nan	IDC,TCIA	2
+A/P - LIVER	SEG, nan	IDC,TCIA	2
+_t8of9MRI Head	MR, nan	IDC,TCIA	2
+A-P W/WO	CT, nan	IDC,TCIA	2
+_t8of8_MRI IAMS WITH CONTRAST	MR, nan	IDC,TCIA	2
+A-P W	CT, nan	IDC,TCIA	2
+1V3F-2	SR, nan	IDC,TCIA	2
+PET TUM SKULL/MID-THIGH-CT	SEG, nan	IDC,TCIA	2
+PET TUM SKULL/MID-THIGH-CT ANA	SEG, nan	IDC,TCIA	2
+1V4A-1	SR, nan	IDC,TCIA	2
+88.011 TK jamy brzuszn	CT, nan	IDC,TCIA	2
+PET TUMOR IMAGING	PT, nan	IDC,TCIA	2
+PET TUMOR IMAGING WITH DOTATATE	PT,CT	MIDRC	2
+PET TUMOR METAB	SEG, nan	IDC,TCIA	2
+7V6F-2	SR, nan	IDC,TCIA	2
+A/P -CLONOGRAPHY	CT, nan	IDC,TCIA	2
+A/P -LIVER	SEG, nan	IDC,TCIA	2
+A/P -UROGRAM	CT, nan	IDC,TCIA	2
+PET Lung	SEG, nan	IDC,TCIA	2
+A/P W/W/O	CT, nan	IDC,TCIA	2
+A/P W WO	CT, nan	IDC,TCIA	2
+PET LYMPHOMA HODGKINS	PT,CT	MIDRC	2
+A/P RENAL W/WO	SEG, nan	IDC,TCIA	2
+A/P RENAL PRT W/WO	SEG, nan	IDC,TCIA	2
+A/P RENAL	SEG, nan	IDC,TCIA	2
+PET Lung Cancer Initial I	SEG, nan	IDC,TCIA	2
+_t9of17  External Images for PACS	MR, nan	IDC,TCIA	2
+PET Lung Cancer Restag	SEG, nan	IDC,TCIA	2
+A/P LIVER W/WO	SEG, nan	IDC,TCIA	2
+A/P LIVER PRT W/WO	SEG, nan	IDC,TCIA	2
+A/P LIVER PROTOCOL	SEG, nan	IDC,TCIA	2
+PET NCAP ATTN ONLY	RTSTRUCT, nan	IDC,TCIA	2
+PET NON-SMALL CELL LUN	SEG, nan	IDC,TCIA	2
+7V3C-1	SR, nan	IDC,TCIA	2
+7V3B-2	SR, nan	IDC,TCIA	2
+PETCT_NCAP	PT, nan	IDC,TCIA	2
+6V4D-2	SR, nan	IDC,TCIA	2
+Post Treatment- Specials 1PETCT_WholeBody	SEG, nan	IDC,TCIA	2
+Post treatment- Abdomen 2_CHEST-ABD-PEL	CT, nan	IDC,TCIA	2
+6V4D-1	SR, nan	IDC,TCIA	2
+6V4C-2	SR, nan	IDC,TCIA	2
+Private^WBHPELVIS (Adult)	CT, nan	IDC,TCIA	2
+_t6of10MRI IAMS	MR, nan	IDC,TCIA	2
+Prostate CA PET	PT, nan	IDC,TCIA	2
+QIN-PET-Phantom-UI	nan	TCIA	2
+6V2C-2	SR, nan	IDC,TCIA	2
+QIN-PET-Phantom-UW	nan	TCIA	2
+6V4C-1	SR, nan	IDC,TCIA	2
+RAD Chest 2 V Pa and Lat 71020	CR, nan	IDC,TCIA	2
+6V4B-2	SR, nan	IDC,TCIA	2
+RCC S/P PARTIAL RT NEP	CT, nan	IDC,TCIA	2
+RECALL FOR ADDITIONAL IMAGING	MR	ACRdart	2
+1V4D-2	SR, nan	IDC,TCIA	2
+Renal	US	ACRdart	2
+7V3B-1	SR, nan	IDC,TCIA	2
+Port Chest	CR, nan	IDC,TCIA	2
+Pelvis	MR, nan	IDC,TCIA	2
+Pelvis^01_Pelvis_Routine (Adult)	CT, nan	IDC,TCIA	2
+6V5A-2	SR, nan	IDC,TCIA	2
+Pelvis^MIEDNICA (Adult)	CT, nan	IDC,TCIA	2
+1V4D-1	SR, nan	IDC,TCIA	2
+6V5A-1	SR, nan	IDC,TCIA	2
+Pelvis^PELVIS_SUPINE (Adult)	CT, nan	IDC,TCIA	2
+Pelvis^PELVIS_TRAUMA_Customized (Adult)	CT	MIDRC	2
+6V4F-2	SR, nan	IDC,TCIA	2
+Pet CUPS Acrin	SEG, nan	IDC,TCIA	2
+Pet/Ct WB	SEG, nan	IDC,TCIA	2
+_t6of11MRI Stereo Gamma Knife gad	MR, nan	IDC,TCIA	2
+PinSourceImg	CT, nan	IDC,TCIA	2
+6V4E-2	SR, nan	IDC,TCIA	2
+6V4E-1	SR, nan	IDC,TCIA	2
+6V2D-1	SR, nan	IDC,TCIA	2
+6V4B-1	SR, nan	IDC,TCIA	2
+RECTUM/ANUS	CT, nan	IDC,TCIA	2
+RENAL// C A P	SEG, nan	IDC,TCIA	2
+6V3C-2	SR, nan	IDC,TCIA	2
+6V3C-1	SR, nan	IDC,TCIA	2
+6V3B-2	SR, nan	IDC,TCIA	2
+RM PELVE - EXT	MR, nan	IDC,TCIA	2
+ROUTINE BRAIN	MR, nan	IDC,TCIA	2
+6V3B-1	SR, nan	IDC,TCIA	2
+6V3A-2	SR, nan	IDC,TCIA	2
+6V3A-1	SR, nan	IDC,TCIA	2
+6V2F-2	SR, nan	IDC,TCIA	2
+RT BREAST/GAD	MR, nan	IDC,TCIA	2
+RT Breast Study	MR, nan	IDC,TCIA	2
+RT HIP & L3 SBRT	CT, nan	IDC,TCIA	2
+RT LUNG	RTSTRUCT, CT	IDC	2
+RT LUNG BX	CT, nan	IDC,TCIA	2
+RT-BREAST	MR, nan	IDC,TCIA	2
+RIGHT THIGH C+	RTSTRUCT, nan	IDC,TCIA	2
+RIGHT MAMMO DIGITAL TOMOSYNTHESIS DIAGNOSTIC	MG	ACRdart	2
+1V4E-2	SR, nan	IDC,TCIA	2
+6V2D-2	SR, nan	IDC,TCIA	2
+RESEARCH BREAST	MR, nan	IDC,TCIA	2
+6V4A-2	SR, nan	IDC,TCIA	2
+6V4A-1	SR, nan	IDC,TCIA	2
+RESEARCH-ACRIN6667	MR, nan	IDC,TCIA	2
+6V3F-2	SR, nan	IDC,TCIA	2
+6V3E-2	SR, nan	IDC,TCIA	2
+RESSONANCIA MAGNETICA ABDOME INFERIOR	MR, nan	IDC,TCIA	2
+RIGHT LUNG	RTSTRUCT, CT	IDC	2
+6V3E-1	SR, nan	IDC,TCIA	2
+6V3D-2	SR, nan	IDC,TCIA	2
+1V4E-1	SR, nan	IDC,TCIA	2
+RIBS - UNILATERAL NO CHEST-CS	DX	MIDRC	2
+6V2E-1	SR, nan	IDC,TCIA	2
+6V3D-1	SR, nan	IDC,TCIA	2
+6V5B-1	SR, nan	IDC,TCIA	2
+6V5B-2	SR, nan	IDC,TCIA	2
+6V5C-1	SR, nan	IDC,TCIA	2
+7V1A-1	SR, nan	IDC,TCIA	2
+7V1F-2	SR, nan	IDC,TCIA	2
+7V1E-2	SR, nan	IDC,TCIA	2
+PET^1PETCT_LUNG_RTP (Adult)	SEG, nan	IDC,TCIA	2
+7V1E-1	SR, nan	IDC,TCIA	2
+7V1D-2	SR, nan	IDC,TCIA	2
+PET^1_PETCT_cerv_WB_CAUDCRAN (Adult)	PT, nan	IDC,TCIA	2
+6V2C-1	SR, nan	IDC,TCIA	2
+7V1D-1	SR, nan	IDC,TCIA	2
+7V1C-2	SR, nan	IDC,TCIA	2
+1V4C-2	SR, nan	IDC,TCIA	2
+7V1C-1	SR, nan	IDC,TCIA	2
+7V1B-2	SR, nan	IDC,TCIA	2
+7V1B-1	SR, nan	IDC,TCIA	2
+7V1A-2	SR, nan	IDC,TCIA	2
+PET^PETCT_AC_WB_VEN_LHR (Adult)	CT, nan	IDC,TCIA	2
+7V2A-1	SR, nan	IDC,TCIA	2
+7V2A-2	SR, nan	IDC,TCIA	2
+7V2B-1	SR, nan	IDC,TCIA	2
+ABD LIVER PROTOCOL	SEG, nan	IDC,TCIA	2
+7V3A-2	SR, nan	IDC,TCIA	2
+6V2B-2	SR, nan	IDC,TCIA	2
+_t7of7External Images for PACS	MR, nan	IDC,TCIA	2
+7V3A-1	SR, nan	IDC,TCIA	2
+7V2F-2	SR, nan	IDC,TCIA	2
+7V2E-2	SR, nan	IDC,TCIA	2
+7V2E-1	SR, nan	IDC,TCIA	2
+7V2B-2	SR, nan	IDC,TCIA	2
+7V2D-2	SR, nan	IDC,TCIA	2
+_t7of7 MRI IAMS	MR, nan	IDC,TCIA	2
+7V2D-1	SR, nan	IDC,TCIA	2
+_t7of7  MRI Stereo Gamma Knife	MR, nan	IDC,TCIA	2
+7V2C-2	SR, nan	IDC,TCIA	2
+7V2C-1	SR, nan	IDC,TCIA	2
+PET^PETCT_WholeBody (Adult)	SEG, nan	IDC,TCIA	2
+74160 CT ABDOMEN W	CT, nan	IDC,TCIA	2
+Pancreas/Liver DIBH 2mm	CT, nan	IDC,TCIA	2
+6V6F-2	SR, nan	IDC,TCIA	2
+PROSTATE FOSSA	CT, nan	IDC,TCIA	2
+PROSTATE RE-SIM	CT, nan	IDC,TCIA	2
+PROSTATE W/URETHRO	CT, nan	IDC,TCIA	2
+6V6A-2	SR, nan	IDC,TCIA	2
+PROSTATE/PELVIS	CT, nan	IDC,TCIA	2
+6V6A-1	SR, nan	IDC,TCIA	2
+6V5F-2	SR, nan	IDC,TCIA	2
+6V5E-2	SR, nan	IDC,TCIA	2
+6V5E-1	SR, nan	IDC,TCIA	2
+6V5D-2	SR, nan	IDC,TCIA	2
+_t6of6_MRI HEAD	MR, nan	IDC,TCIA	2
+PYELOGRAM, IV W/TOMO	DX, nan	IDC,TCIA	2
+_t6of6MRI IAMS	MR, nan	IDC,TCIA	2
+6V5D-1	SR, nan	IDC,TCIA	2
+6V5C-2	SR, nan	IDC,TCIA	2
+6V6B-1	SR, nan	IDC,TCIA	2
+6V6B-2	SR, nan	IDC,TCIA	2
+6V6C-1	SR, nan	IDC,TCIA	2
+PP CT CHEST WITH CONTR	CT, nan	IDC,TCIA	2
+_t7of7  External Images for PACS	MR, nan	IDC,TCIA	2
+PORTABLE CHEST 1 VIEW	DX	MIDRC	2
+PORTABLE CXR PICC PLMT	CR	MIDRC	2
+6V6E-2	SR, nan	IDC,TCIA	2
+6V6E-1	SR, nan	IDC,TCIA	2
+PP CT CHEST ABDOMEN W	CT, nan	IDC,TCIA	2
+6V6D-2	SR, nan	IDC,TCIA	2
+6V6C-2	SR, nan	IDC,TCIA	2
+PRE CHEST	SEG, nan	IDC,TCIA	2
+_t6of6_MRI IAMS	MR, nan	IDC,TCIA	2
+_t6of6_MRI HEAD WITH CONTRAST	MR, nan	IDC,TCIA	2
+6V6D-1	SR, nan	IDC,TCIA	2
+PRONE	SEG, nan	IDC,TCIA	2
+PRONE ANUS	CT, nan	IDC,TCIA	2
+ascities	CT, nan	IDC,TCIA	2
+ABD PEL NO IV	CT, nan	IDC,TCIA	2
+brain	MR, nan	IDC,TCIA	2
+MRI LT LEG +C	MR, nan	IDC,TCIA	2
+MRI LIVER ELASTOGRAPHY W/O	MR, nan	IDC,TCIA	2
+MRI LOWER EXTREMITY NOT JOINT WITH CONTRAST LEFT	MR, nan	IDC,TCIA	2
+hot spheres with water	PT, nan	IDC,TCIA	2
+MRI LOWER EXTREMITY NOT JOINT WITH CONTRAST RIGHT	MR, nan	IDC,TCIA	2
+Abdomen^03_7_Kidney_Biphase_Post_Nephrectomy (Adult)	CT, nan	IDC,TCIA	2
+MRI LOWER EXTREMITY W/WO CONT	MR, nan	IDC,TCIA	2
+MRI LT BREAST	MR, nan	IDC,TCIA	2
+Abdomen^03_7_Kidney_Biphase (Adult)	CT, nan	IDC,TCIA	2
+PET CT	RTSTRUCT, nan	IDC,TCIA	2
+hernia	CT, nan	IDC,TCIA	2
+head^general	MR, nan	IDC,TCIA	2
+he/37280	MR, nan	IDC,TCIA	2
+CT CHEST  NO IV	SEG, nan	IDC,TCIA	2
+MRI OF BLADDER	MR, nan	IDC,TCIA	2
+Abdomen^02_0_Abdomen_Pelvis (Adult)	CT, nan	IDC,TCIA	2
+1V1E-1	SR, nan	IDC,TCIA	2
+Abdomen^03_LARGE_ABD_PELVIS (Adult)	CT, nan	IDC,TCIA	2
+kidney ca	CT, nan	IDC,TCIA	2
+lt hemorrahagic cyst	CT, nan	IDC,TCIA	2
+Abdomen^06CTAAbdomenPostEVT (Adult)	CT, nan	IDC,TCIA	2
+Abdomen^12_9_Liver_HCC (Adult)	SEG, nan	IDC,TCIA	2
+Abdomen^12_5_Liver_Post_Ablation (Adult)	CT, nan	IDC,TCIA	2
+1V1C-2	SR, nan	IDC,TCIA	2
+Abdomen^10_LOW_DOSE_STONE_STUDY (Adult)	CT	MIDRC	2
+MRI ELBOW W/O CONTRAST-RIGHT	MR	MIDRC	2
+1V1D-1	SR, nan	IDC,TCIA	2
+lung+C	CT, nan	IDC,TCIA	2
+lung bx	CT, nan	IDC,TCIA	2
+MRI EXTREMITIES WITHOU AND WITH CONTRAST - LEFT	RTSTRUCT, nan	IDC,TCIA	2
+lung biopsy	CT, nan	IDC,TCIA	2
+Abdomen^08_Kidney_MultiPhase (Adult)	SEG, nan	IDC,TCIA	2
+Abdomen^08_3_Type_I_Dose_Saving (Adult)	CT, nan	IDC,TCIA	2
+1V1D-2	SR, nan	IDC,TCIA	2
+Abdomen^08_3_Type_I_CTU_Dose_Saving (Adult)	CT, nan	IDC,TCIA	2
+lt. renal mass,? bleed	CT, nan	IDC,TCIA	2
+MRI PELVIS C- C	RTSTRUCT, nan	IDC,TCIA	2
+MRI PELVIS SOFT TISSUE WO/W CONTRAST	MR	MIDRC	2
+e-1 PET/CT CHEST	SEG, nan	IDC,TCIA	2
+e+1 PET IMAGE W/CT, SKULL-	SEG, nan	IDC,TCIA	2
+e+1 MRI BREAST BILAT W-WO-RH	SEG, nan	IDC,TCIA	2
+MRI Pelvis w/ + w/o Contrast	MR	ACRdart	2
+e+1 MRI BREAST ABBREVIATED BILATERAL W/WO CONTRAST	MR	ACRdart,IDC	2
+Abdomen^004 Chest-Abd-Pelvis	CT, nan	IDC,TCIA	2
+Abdomen^0 ABDOMEN	CT, nan	IDC,TCIA	2
+Abdomen/Pelvis W/WO	CT, nan	IDC,TCIA	2
+MRI Prostate w+wo	MR	ACRdart	2
+MRI RENAL W/WO CONTRAST	MR, nan	IDC,TCIA	2
+Abdomen 3 phase	RTSTRUCT, nan	IDC,TCIA	2
+MRI RT THIGH	RTSTRUCT, nan	IDC,TCIA	2
+MRI RT THIGH +C	MR, nan	IDC,TCIA	2
+ANONYMIZED	CT, nan	IDC,TCIA	2
+ANKLE RIGHT MIN 3 VIEWS	CR, DX	MIDRC	2
+e+1 MRI 3D REFORMATION NON INDEPENDENT WORKSTATION	SEG, nan	IDC,TCIA	2
+ANKLE RIGHT 3 VIEWS (WEIGHT BEARING)	CR	MIDRC	2
+Abdomen^01AP_Routine (Adult)	CT, nan	IDC,TCIA	2
+MRI PROSTATE WO CONTRAST	SEG	IDC	2
+MRI PELVIS W&W/O CONTR	MR, nan	IDC,TCIA	2
+MRI PROSTATE WITHOUT CONTRAST	MR, nan	IDC,TCIA	2
+Abdomen^02 Chest-Abd-Pelvis 1	CT, nan	IDC,TCIA	2
+e-1	PT, nan	IDC,TCIA	2
+MRI PELVIS WO CONT	MR, nan	IDC,TCIA	2
+MRI PELVIS WO/W	MR, nan	IDC,TCIA	2
+Abdomen^02 Chest-Abd 1	CT, nan	IDC,TCIA	2
+MRI PELVIS WW CON	SEG	IDC	2
+e+1 lung biopsy	CT, nan	IDC,TCIA	2
+e+1 lung	SEG, nan	IDC,TCIA	2
+Abdomen^01_LARGE_WB_PETCT	SEG, nan	IDC,TCIA	2
+e+1 PET/CT LUNG NODULE	CT, nan	IDC,TCIA	2
+MRI PERIANAL FISTULA WO/W CONTRAST	MR	MIDRC	2
+Abdomen^01_Abdomen_Pelvis (Adult)	CT, nan	IDC,TCIA	2
+Abdomen^01_AbdNative_and_Contrast (Adult)	SEG, nan	IDC,TCIA	2
+MRI PROSTATE WITH + WITHOUT IV CONTRAST	MR	ACRdart	2
+Abdomen^01_ABDOMENBIOPSY (Adult)	CT, nan	IDC,TCIA	2
+lung+ccc	SEG, nan	IDC,TCIA	2
+1V1C-1	SR, nan	IDC,TCIA	2
+Abdomen^12_9_Liver_HCC_Triphase (Adult)	SEG, nan	IDC,TCIA	2
+*CT CHEST	CT, nan	IDC,TCIA	2
+Abdomen^CTA_ILLIOFEMORAL_RUN_OFF (Adult)	CT	MIDRC	2
+Abdomen^CTA_ABD_PELVIS_ (Adult)	CT	MIDRC	2
+Abdomen^BRZUCH_MIEDNICA (Adult)	RTSTRUCT, nan	IDC,TCIA	2
+Abdomen^BRZUCH_BOLUS_FAZA_TRZUSTKA (Adult)	RTSTRUCT, nan	IDC,TCIA	2
+Abdomen^BRZUCH_BOLUS (Adult)	RTSTRUCT, nan	IDC,TCIA	2
+MRI BREAST BILATERAL W & W/O	SEG, nan	IDC,TCIA	2
+MRI BREAST BILATERAL W & WO	MR, nan	IDC,TCIA	2
+Abdomen^AVERAGE_ABD_PELVIS_WITHOUT_IV_CONTRAST (Adult)	nan	TCIA	2
+Abdomen^ACRIN_COLON_12 (Adult)	CT, nan	IDC,TCIA	2
+testCTACw75ccContrast	CT, nan	IDC,TCIA	2
+MRI BREAST BILATERAL W/ & WO	SEG, nan	IDC,TCIA	2
+Abdomen^ACRIN COLON (Adult)	CT, nan	IDC,TCIA	2
+Abdomen^ABD_WO_W (Adult)	SEG, nan	IDC,TCIA	2
+testCTACw35ccContrast	PT, nan	IDC,TCIA	2
+Abdomen^ABD_TRIPHASIC_KIDNEYS (Adult)	CT, nan	IDC,TCIA	2
+MRI BREAST BILAT W-WO	SEG, nan	IDC,TCIA	2
+MRI BREAST BILAT PRE&POMR	MR	IDC	2
+MRI BREAST BIOPSY UNILATERAL WITH CONTRAST	MR, nan	IDC,TCIA	2
+two_phase__chest_abdomen	SEG, nan	IDC,TCIA	2
+Abdomen^ENTEROGRAPHY_GR (Adult)	CT	MIDRC	2
+Abdomen^ENTEROGRAPHY (Adult)	CT	MIDRC	2
+MRI BR BI W/INJ/MBBI	MR	IDC	2
+Abdomen^DUAL_PHASE_PANC (Adult)	RTSTRUCT, nan	IDC,TCIA	2
+MRI BR UNILAT W&WO CONT LEFT	MR, SEG	IDC	2
+MRI BRAIN	MR, nan	IDC,TCIA	2
+two_phase__chest_abdomen_pelvis	SEG, nan	IDC,TCIA	2
+Abdomen^Chest-Abd-Pelvis 1	CT, nan	IDC,TCIA	2
+MRI BRAIN, MRA BRAIN, MRA NECK - WITHOUT AND WITH CONTRAST	MR	MIDRC	2
+Abdomen^CYSTOGRAM (Adult)	CT	MIDRC	2
+Abdomen^CT_MARKS_CAILLAT_AP (Adult)	CT	MIDRC	2
+Abdomen^CT_CHST_ABD_PELVIS_WO_W_IVCON (Adult)	SEG, nan	IDC,TCIA	2
+MRI BREAST BIL ABBREVIATED W WO CONTRAST WO CAD	MR	IDC	2
+MRI BREAST BIL WO W CONTRAST	MR, nan	IDC,TCIA	2
+MRI BREAST BIL WO/W CON	MR, nan	IDC,TCIA	2
+MRI BREAST BIOPSY RIGHT  1ST LESION	MR	ACRdart,IDC	2
+MRI BREAST BIOPSY UNILATERAL WITH WITHOUT CONTRAST	MR, nan	IDC,TCIA	2
+Abdomen^12_DE_ABD_N_CE_(Adult)	CT, nan	IDC,TCIA	2
+MRI BREAST, BILATERAL WITHOUT CONTRAST	MR, nan	IDC,TCIA	2
+pe/6516	MR, nan	IDC,TCIA	2
+MRI BREAST, UNILATERAL, WITH WITHOUT CONTRAST	MR	IDC	2
+1V1A-1	SR, nan	IDC,TCIA	2
+1V1A-2	SR, nan	IDC,TCIA	2
+Abdomen^1VIRT_COLON_SUPINE (Adult)	CT, nan	IDC,TCIA	2
+Abdomen^1VIRT_COLON (Adult)	CT, nan	IDC,TCIA	2
+MRI Brain	MR, nan	IDC,TCIA	2
+MRI Breast Bilat W WO IV Contrast	MR	ACRdart	2
+MRI Breast Bilateral	SEG, nan	IDC,TCIA	2
+Abdomen^1CA_AP_WC (Adult)	CT, nan	IDC,TCIA	2
+MRI Breast Bilateral without Contrast	MR, nan	IDC,TCIA	2
+1V1B-1	SR, nan	IDC,TCIA	2
+MRI Breast Biopsy	MR, nan	IDC,TCIA	2
+1V1B-2	SR, nan	IDC,TCIA	2
+MRI Breast w  wo Contrast Bilateral	MR	ACRdart,IDC	2
+pelvis^Pelvis (Y)	MR, nan	IDC,TCIA	2
+Abdomen^1_ABDOMEN_PELVIS_WITH (Adult)	CT, nan	IDC,TCIA	2
+MRI BREAST BX VAC CLIP 2 LSN RT WPPM SI	MR, nan	IDC,TCIA	2
+Abdomen^1_ABD_BMI_UNDER_30 (Adult)	RTSTRUCT, nan	IDC,TCIA	2
+MRI BREAST CORE BIOPSY	MR, nan	IDC,TCIA	2
+test CTAC radial trunc	PT, nan	IDC,TCIA	2
+Abdomen^ABDOME_4_FASES (Adult)	CT, nan	IDC,TCIA	2
+Abdomen^ABDOMEN_PELVIS_WO_WC (Adult)	CT, nan	IDC,TCIA	2
+Abdomen^ABDOMEN_4D (Adult)	CT, nan	IDC,TCIA	2
+post	PT, nan	IDC,TCIA	2
+06.Chest, Abdomen contrast	SEG, nan	IDC,TCIA	2
+Abdomen^23 COLON PRONE	CT, nan	IDC,TCIA	2
+MRI BREAST UNILA	MR, nan	IDC,TCIA	2
+MRI BREAST UNILATERAL W/WO	SEG, nan	IDC,TCIA	2
+MRI BREAST UNILATERAL WITH WITHOUT CONTRAST	nan	TCIA	2
+penqct	CT, nan	IDC,TCIA	2
+Abdomen^1_RENAL_WITH_IV (Adult)	CT, nan	IDC,TCIA	2
+pelvis_0001^MALYI TAZ	MR, nan	IDC,TCIA	2
+MRI BREAST W/WO + SUB + RECON	MR, nan	IDC,TCIA	2
+MRI SPINAL CANAL, LUMBAR WITHOUT CONTRAST	MR, nan	IDC,TCIA	2
+e+1 MR BREAST BILAT W AND W/O CONT-DR	SEG, nan	IDC,TCIA	2
+e+1 LEFT BREAST	MR, nan	IDC,TCIA	2
+OSF CT CHEST	CT, nan	IDC,TCIA	2
+OSI CT CHEST	SEG, nan	IDC,TCIA	2
+1V2C-2	SR, nan	IDC,TCIA	2
+ch.3d ao.cta	SEG, nan	IDC,TCIA	2
+ABDOMEN   PELVIS WITH CONTRAST	CT, nan	IDC,TCIA	2
+ABDOMEN   PELVIS W/O CONTRAST	CT, nan	IDC,TCIA	2
+OUTSIDE FILM CONSULTATION MAM	CR, nan	IDC,TCIA	2
+OVARIAN CA RESTAGING	CT, nan	IDC,TCIA	2
+OVARY CA,FATIGUE ?MASS	CT, nan	IDC,TCIA	2
+ABDOMEN   PELVIS W/CON	CT, nan	IDC,TCIA	2
+ABD/RENAL	SEG, nan	IDC,TCIA	2
+ch.3d	CT, nan	IDC,TCIA	2
+1V2D-1	SR, nan	IDC,TCIA	2
+Outside Read or Comparison BREAST MRI	MR, nan	IDC,TCIA	2
+ABD/PELVIS/ RENAL	SEG, nan	IDC,TCIA	2
+ABD/PELVIS/  LIVER	SEG, nan	IDC,TCIA	2
+OSI CT BRAIN	SEG, nan	IDC,TCIA	2
+OSF CT C/A/P	CT, nan	IDC,TCIA	2
+1V2E-1	SR, nan	IDC,TCIA	2
+chest.3d	CT, nan	IDC,TCIA	2
+NSCLC INIT STG	SEG, nan	IDC,TCIA	2
+NSCLC LUNG RESTAGING	SEG, nan	IDC,TCIA	2
+NSCLC RESTAGING	SEG, nan	IDC,TCIA	2
+chest_abdomen_pelvis__w_and_wo	SEG, nan	IDC,TCIA	2
+NSCLC RESTG	SEG, nan	IDC,TCIA	2
+1V2B-2	SR, nan	IDC,TCIA	2
+NUC MED LUNG VENTILATION + PERFUSION	NM	MIDRC	2
+Needle Loc Mammo Guidance 1st Right PRIM	MG	ACRdart,IDC	2
+No study description	SEG, nan	IDC,TCIA	2
+1V2C-1	SR, nan	IDC,TCIA	2
+ORTHO CHUS^OS LONGS	MR, nan	IDC,TCIA	2
+ORTHO THORAX	MR, nan	IDC,TCIA	2
+chest/abd with	CT, nan	IDC,TCIA	2
+ABDOMEN +/-CONT	MR, nan	IDC,TCIA	2
+ABDOMEN (CT)-BODY	SEG, nan	IDC,TCIA	2
+1V2D-2	SR, nan	IDC,TCIA	2
+P/P A/P	SEG, nan	IDC,TCIA	2
+ABDOMEN KIDNEY CHEST PELVIS WITH(Adult)	CT	MIDRC	2
+PELVIS SBRT	CT, nan	IDC,TCIA	2
+PELVIS W/O CONTRAST	CT, nan	IDC,TCIA	2
+PELVIS.1:PELVIS:Private^WBHPELVIS (Adult)	CT, nan	IDC,TCIA	2
+ABD. AND PELVIS	CT, nan	IDC,TCIA	2
+breast^lesion evaluation	SEG, nan	IDC,TCIA	2
+PENGQIANG	CT, nan	IDC,TCIA	2
+ABD RENAL W/WO	SEG, nan	IDC,TCIA	2
+1V2F-2	SR, nan	IDC,TCIA	2
+PET / CT F-18 FDG TUMOR SKULL BASE TO MID-THIGH	SEG, nan	IDC,TCIA	2
+breast research	MR, nan	IDC,TCIA	2
+ABD RENAL STONE	CT, nan	IDC,TCIA	2
+PET BREAST CANCER (W/L	PT,CT	MIDRC	2
+6V1F-2	SR, nan	IDC,TCIA	2
+ABD PEL LIVER	SEG, nan	IDC,TCIA	2
+PET COLON OR RECTAL CA	PT,CT	MIDRC	2
+PET COLON OR RECTAL CANCER (W/LOW DOSE CT)	PT,CT	MIDRC	2
+1V2E-2	SR, nan	IDC,TCIA	2
+PELVIS RECTUM	CT, nan	IDC,TCIA	2
+P/P A/P W/RENAL PROTO.	SEG, nan	IDC,TCIA	2
+PELVIS FULLL	CT, nan	IDC,TCIA	2
+c+c	SEG, nan	IDC,TCIA	2
+P/P A/P, W/RENAL PROTO	SEG, nan	IDC,TCIA	2
+P/P C/A	SEG, nan	IDC,TCIA	2
+P/P C/A/P W/LIVER PRO	SEG, nan	IDC,TCIA	2
+P/P C/A/P,LIVER PROTO.	SEG, nan	IDC,TCIA	2
+ABD/PELVIS W/W/O	CT, nan	IDC,TCIA	2
+PC TX AS	CT, nan	IDC,TCIA	2
+ABD/PELVIS ANGIO/VENO	CT, nan	IDC,TCIA	2
+PE CHEST WITH	SEG, nan	IDC,TCIA	2
+c t ap	CT, nan	IDC,TCIA	2
+PELVE	MR, nan	IDC,TCIA	2
+ABD/PEL W/C	SEG, nan	IDC,TCIA	2
+ABD/PEL LIVER PROTOCOL	SEG, nan	IDC,TCIA	2
+ABD/PEL  LIVER	CT, nan	IDC,TCIA	2
+PELVIS FULL BLADDER	CT, nan	IDC,TCIA	2
+NSCLC	PT, nan	IDC,TCIA	2
+NSC LUNG RESTG	SEG, nan	IDC,TCIA	2
+ANKLE LEFT 3 VIEWS (WEIGHT BEARING)	CR, DX	MIDRC	2
+ACWOWC ANGIO CHEST WO/WC	CT	MIDRC	2
+e+1 FDG 6AFOV TORSO	SEG, nan	IDC,TCIA	2
+ACRIN6667 CONTRA-LAT.	MR, nan	IDC,TCIA	2
+MRI_L_Shoulder	MR, nan	IDC,TCIA	2
+ACRIN CT COLONGRAPHY	CT, nan	IDC,TCIA	2
+ACRIN COLON	CT, nan	IDC,TCIA	2
+e+1 F/U	CT, nan	IDC,TCIA	2
+e+1 CT LUNG SCREEN	CT, nan	IDC,TCIA	2
+e+1 CT Chest W/ Non Ionic	CT, nan	IDC,TCIA	2
+e+1 CT CHEST WO CONTRAST	CT	MIDRC	2
+MRM  6667	MR, nan	IDC,TCIA	2
+e+1 BREAST W/WO	MR, nan	IDC,TCIA	2
+ACRIN 6668 PET	SEG, nan	IDC,TCIA	2
+e+1 BILAT/ATTN LEFT	MR, nan	IDC,TCIA	2
+1V1E-2	SR, nan	IDC,TCIA	2
+ACRIN 6667 CONTRA. BRE	MR, nan	IDC,TCIA	2
+ACRIN6667CONTRALAT. BR	MR, nan	IDC,TCIA	2
+MRI-UNLISTED AREA	MR, nan	IDC,TCIA	2
+MRM/DYN	MR, nan	IDC,TCIA	2
+MRI-RT THIGH	RTSTRUCT, nan	IDC,TCIA	2
+MRI THIGH C+ LEFT	MR, nan	IDC,TCIA	2
+MRI THIGH C+ RIGHT	RTSTRUCT, nan	IDC,TCIA	2
+e+1 HANCHE GAUCHE C+	RTSTRUCT, nan	IDC,TCIA	2
+MRI THORACIC W/WO CONTRAST	MR, nan	IDC,TCIA	2
+MRI W/O CONT UNIBR	MR, nan	IDC,TCIA	2
+MRI W/WO CONT BI	MR, nan	IDC,TCIA	2
+MRI, BRAIN W&W/O CONTR	MR, nan	IDC,TCIA	2
+MRI, BRAIN W&W/O CONTRAST	MR, nan	IDC,TCIA	2
+MRI,BRAIN W&W/O	MR, nan	IDC,TCIA	2
+MRI-EXTREMITIES	MR, nan	IDC,TCIA	2
+MRI-LT LEG	MR, nan	IDC,TCIA	2
+ANGIO - CHEST (PE STUDY)	CT	MIDRC	2
+MRI-Pelvis	MR, nan	IDC,TCIA	2
+MRI-RT BUTTOCK	MR, nan	IDC,TCIA	2
+MRI-RT LEG	RTSTRUCT, nan	IDC,TCIA	2
+e+1 A/P	CT, nan	IDC,TCIA	2
+MR_BREAST-LT STUDY PT	MR, nan	IDC,TCIA	2
+ABDOMEN LIVER PROTOCOL	SEG, nan	IDC,TCIA	2
+ABDOMEN^1 ACRIN PRONE COLONOGRAPHY	CT, nan	IDC,TCIA	2
+ABDOMEN/PELVIS CT	CT, nan	IDC,TCIA	2
+1V2A-1	SR, nan	IDC,TCIA	2
+NM Chest	DX, nan	IDC,TCIA	2
+ct a/p w/wo	SEG, nan	IDC,TCIA	2
+ABDOMEN, AP (KUB)	CR, nan	IDC,TCIA	2
+NM PET 18 FDG  SKULL T	PT, nan	IDC,TCIA	2
+ABDOMEN+C	RTSTRUCT, nan	IDC,TCIA	2
+contrabreast (LEFT)	MR, nan	IDC,TCIA	2
+NM PET STOT LUNG CA RESTG	SEG, nan	IDC,TCIA	2
+NM PETCT 18FDG BASE OF SKULL TO THIGHS	CT, nan	IDC,TCIA	2
+ABDOMEN SERIES INCL CHEST-CS	CR	MIDRC	2
+1V2A-2	SR, nan	IDC,TCIA	2
+NM_Bone_WB	NM, nan	IDC,TCIA	2
+NM_Chest	NM, nan	IDC,TCIA	2
+1V2B-1	SR, nan	IDC,TCIA	2
+1V1F-2	SR, nan	IDC,TCIA	2
+Multiple Line Source Background	PT, nan	IDC,TCIA	2
+ABDPEL C	CT, nan	IDC,TCIA	2
+ct chest with contrast,	CT, nan	IDC,TCIA	2
+MR_BREAST-lT	MR, nan	IDC,TCIA	2
+MR_CSpine	MR, nan	IDC,TCIA	2
+MR_LT BR	MR, nan	IDC,TCIA	2
+MR_LT BREAST-STUDY PT	MR, nan	IDC,TCIA	2
+MR_RT BREAST	MR, nan	IDC,TCIA	2
+MS4183/GAD   Abdomen w & w/o	MR, nan	IDC,TCIA	2
+MSKT organov grudnoy k	CT, nan	IDC,TCIA	2
+e+1	CT, nan	IDC,TCIA	2
+MSK^HIP	RTSTRUCT, nan	IDC,TCIA	2
+ct thorax with contrast	CT, nan	IDC,TCIA	2
+MW CT ,ABD W CONT, 74160	SEG, nan	IDC,TCIA	2
+ABDOMINAL CT W/ + W/O CONTRAST	CT, nan	IDC,TCIA	2
+ABDOMEN^UPPER	RTSTRUCT, nan	IDC,TCIA	2
+ABDOMEN^METRO MRI	SEG, nan	IDC,TCIA	2
+ct head w/wo contrast	CT, nan	IDC,TCIA	2
+SCAN THORAX C+ -THO	SEG, nan	IDC,TCIA	2
+6V1D-2	SR, nan	IDC,TCIA	2
+_t5of9MRI IAMS	MR, nan	IDC,TCIA	2
+3V4A-1	SR, nan	IDC,TCIA	2
+US_Biopsy_Liver	XA, nan	IDC,TCIA	2
+US_CT_Abdomen	CT, nan	IDC,TCIA	2
+US_Chest	US, nan	IDC,TCIA	2
+US_biopsyliver	US, nan	IDC,TCIA	2
+2V1A-2	SR, nan	IDC,TCIA	2
+3V4A-2	SR, nan	IDC,TCIA	2
+_t1of9MRI Head	MR, nan	IDC,TCIA	2
+3V3F-2	SR, nan	IDC,TCIA	2
+3V2C-1	SR, nan	IDC,TCIA	2
+Unspecified CT ABDOMEN	CT, nan	IDC,TCIA	2
+3V3E-2	SR, nan	IDC,TCIA	2
+Unspecified MG BREAST	MG	ACRdart	2
+3V3E-1	SR, nan	IDC,TCIA	2
+3V3D-2	SR, nan	IDC,TCIA	2
+VIRTUAL  RECTUM	CT, nan	IDC,TCIA	2
+2V1B-1	SR, nan	IDC,TCIA	2
+3V4B-1	SR, nan	IDC,TCIA	2
+3V4B-2	SR, nan	IDC,TCIA	2
+US UPPER EXTREMITY VENOUS DUPLEX LTD - RIGHT	US	MIDRC	2
+2V1A-1	SR, nan	IDC,TCIA	2
+US Abdomen Complete	US, nan	IDC,TCIA	2
+US BREAST CORE BX	US	ACRdart	2
+US Biopsy Axilla	US, nan	IDC,TCIA	2
+3V4E-1	SR, nan	IDC,TCIA	2
+US Biopsy LymphNode	US, nan	IDC,TCIA	2
+US Breast Bilateral	US	ACRdart	2
+US Breast Right	US	ACRdart	2
+US DOPPLER LOWER EXTREMITY VENOUS, BILATERAL (S)	US	MIDRC	2
+US Echocardiogram	US, nan	IDC,TCIA	2
+3V4D-2	SR, nan	IDC,TCIA	2
+US KIDNEY TRANSPLANT	US	MIDRC	2
+3V4D-1	SR, nan	IDC,TCIA	2
+2AFOV PELVIS POST CATH	PT, nan	IDC,TCIA	2
+3V4C-2	SR, nan	IDC,TCIA	2
+3V4C-1	SR, nan	IDC,TCIA	2
+VIRTUAL ABDOMEN/PELVIS	CT, nan	IDC,TCIA	2
+_t1of8_MRI External Films	MR, nan	IDC,TCIA	2
+VIRTUAL GYN PELVIS FULL BLADDER	CT, nan	IDC,TCIA	2
+3V3A-1	SR, nan	IDC,TCIA	2
+Vascular^FL_CTPA (Adult)	CT	MIDRC	2
+Vascular^GATED_CHEST_CTA (Adult)	CT, nan	IDC,TCIA	2
+3V2E-2	SR, nan	IDC,TCIA	2
+Vascular^PEAngio(Adiult) (Adult)	CT, nan	IDC,TCIA	2
+3V2E-1	SR, nan	IDC,TCIA	2
+_t1of7External Images for PACS	MR, nan	IDC,TCIA	2
+Vascular^PULMONARY_VEIN_STUDY (Adult)	CT	MIDRC	2
+_t1of7  MRI Head	MR, nan	IDC,TCIA	2
+2V1C-2	SR, nan	IDC,TCIA	2
+Vascular^RUNOFF_CTA (Adult)	CT	MIDRC	2
+Vascular^THORACIC_ANEURYSM_CTA (Adult)	CT	MIDRC	2
+3V2D-2	SR, nan	IDC,TCIA	2
+WB	SEG, nan	IDC,TCIA	2
+3V2D-1	SR, nan	IDC,TCIA	2
+WB PET & LUNG DELAYS	SEG, nan	IDC,TCIA	2
+3V2F-2	SR, nan	IDC,TCIA	2
+3V3A-2	SR, nan	IDC,TCIA	2
+VIRTUAL PELVIS	CT, nan	IDC,TCIA	2
+_t1of7_MRI External Films	MR, nan	IDC,TCIA	2
+VIRTUAL PELVIS  FULL BLADDER	CT, nan	IDC,TCIA	2
+VIRTUAL PELVIS FULL BLADDER	CT, nan	IDC,TCIA	2
+Vascular^01_0_Abdominal_Aorta_CTA_Pre_Post_Stent (Adult)	CT, nan	IDC,TCIA	2
+3V3D-1	SR, nan	IDC,TCIA	2
+Vascular^06CTA_Abd_(Post-stent) (Adult)	CT, nan	IDC,TCIA	2
+3V3C-2	SR, nan	IDC,TCIA	2
+Vascular^CH03A_CHST_W_PE (Adult)	CT	MIDRC	2
+3V3C-1	SR, nan	IDC,TCIA	2
+_t1of8_MR IAMs	nan	TCIA	2
+_t1of8_MR IAM's	MR	IDC	2
+3V3B-2	SR, nan	IDC,TCIA	2
+Vascular^CTA_MESSENTERIC (Adult)	CT	MIDRC	2
+2V1B-2	SR, nan	IDC,TCIA	2
+2V1C-1	SR, nan	IDC,TCIA	2
+3V3B-1	SR, nan	IDC,TCIA	2
+_t2of3  MRI HEAD	MR, nan	IDC,TCIA	2
+US ABDOMEN COMPLETE=AB	US, nan	IDC,TCIA	2
+3V4E-2	SR, nan	IDC,TCIA	2
+Thorax^PE_ROUTINE (Adult)	CT, nan	IDC,TCIA	2
+1V6E-2	SR, nan	IDC,TCIA	2
+Thorax^ROUTINE_CHEST_5MM (Adult)	CT, nan	IDC,TCIA	2
+4V1C-1	SR, nan	IDC,TCIA	2
+_t2of3MRI IAMS post Gad	MR, nan	IDC,TCIA	2
+4V1B-2	SR, nan	IDC,TCIA	2
+4V1B-1	SR, nan	IDC,TCIA	2
+4V1A-2	SR, nan	IDC,TCIA	2
+4V1A-1	SR, nan	IDC,TCIA	2
+4D CT THORAX	RTSTRUCT, CT	IDC	2
+Thorax^RoutineChest (Adult)	CT, nan	IDC,TCIA	2
+_t2of3MRI Head	MR, nan	IDC,TCIA	2
+Thorax^THORACIC_DISSECTION (Adult)	CT	MIDRC	2
+Thorax^TRAUMA_CHEST_ABD_PEL (Adult)	CT	MIDRC	2
+1V6F-2	SR, nan	IDC,TCIA	2
+3V6F-2	SR, nan	IDC,TCIA	2
+4V1C-2	SR, nan	IDC,TCIA	2
+Thorax^PE_CHEST (Adult)	CT, nan	IDC,TCIA	2
+Thorax^VERAN_MEDIUM (Adult)	CT	MIDRC	2
+4V1D-1	SR, nan	IDC,TCIA	2
+4V2C-2	SR, nan	IDC,TCIA	2
+Thorax^LOW_DOSE_NON_CONCHEST (Adult)	CT, nan	IDC,TCIA	2
+4V2C-1	SR, nan	IDC,TCIA	2
+4V2B-2	SR, nan	IDC,TCIA	2
+4V2B-1	SR, nan	IDC,TCIA	2
+4V2A-2	SR, nan	IDC,TCIA	2
+4V2A-1	SR, nan	IDC,TCIA	2
+_t2of7  MRI IAMS	MR, nan	IDC,TCIA	2
+_t2of5  External Images for PACS	MR, nan	IDC,TCIA	2
+4V1F-2	SR, nan	IDC,TCIA	2
+4V1E-2	SR, nan	IDC,TCIA	2
+4V1E-1	SR, nan	IDC,TCIA	2
+4V1D-2	SR, nan	IDC,TCIA	2
+_t2of4External Images for PACS	MR, nan	IDC,TCIA	2
+1V6E-1	SR, nan	IDC,TCIA	2
+3V6E-2	SR, nan	IDC,TCIA	2
+3V6E-1	SR, nan	IDC,TCIA	2
+UROGRAPHY STUDY	CT, nan	IDC,TCIA	2
+Tomografia komputerowa jamy brzusznej z kontrastem	RTSTRUCT, nan	IDC,TCIA	2
+3V5D-1	SR, nan	IDC,TCIA	2
+Tomoscintigrafia PET total body TOMOSCINTIGRAFIA TOTAL BODY-Tomo	SEG, nan	IDC,TCIA	2
+3V5C-2	SR, nan	IDC,TCIA	2
+Trio RoutineImage Guidance	RTSTRUCT, nan	IDC,TCIA	2
+3V5C-1	SR, nan	IDC,TCIA	2
+3V5B-2	SR, nan	IDC,TCIA	2
+2-FOV uniform.test	PT, nan	IDC,TCIA	2
+ULTRASOUND/ASPIRATION EXAM	US	ACRdart	2
+3V5B-1	SR, nan	IDC,TCIA	2
+UNILAT BREAST US	US	ACRdart	2
+3V5A-2	SR, nan	IDC,TCIA	2
+3V5A-1	SR, nan	IDC,TCIA	2
+UROGRAM	SEG, nan	IDC,TCIA	2
+UROGRAM CT	CT, nan	IDC,TCIA	2
+3V4F-2	SR, nan	IDC,TCIA	2
+3V5D-2	SR, nan	IDC,TCIA	2
+Tomografia klatki piersiowej - inne	CT, nan	IDC,TCIA	2
+_t2of3 MRI IAMS	MR, nan	IDC,TCIA	2
+3V5E-1	SR, nan	IDC,TCIA	2
+Thorax^XL_CAP_WITH_Customized (Adult)	CT	MIDRC	2
+3V6D-2	SR, nan	IDC,TCIA	2
+3V6D-1	SR, nan	IDC,TCIA	2
+3V6C-2	SR, nan	IDC,TCIA	2
+3V6C-1	SR, nan	IDC,TCIA	2
+_t2of3  MRI IAMS post Gad	MR, nan	IDC,TCIA	2
+3V6B-2	SR, nan	IDC,TCIA	2
+1_PETCT_cerv_WB_CAUDCRAN (Adult)	PT, nan	IDC,TCIA	2
+3V6B-1	SR, nan	IDC,TCIA	2
+Thorax^chest abd	CT, nan	IDC,TCIA	2
+3V6A-2	SR, nan	IDC,TCIA	2
+3V6A-1	SR, nan	IDC,TCIA	2
+3V5F-2	SR, nan	IDC,TCIA	2
+TomoHD Unilateral Left	MG	ACRdart,IDC	2
+3V5E-2	SR, nan	IDC,TCIA	2
+3V2C-2	SR, nan	IDC,TCIA	2
+3V2B-2	SR, nan	IDC,TCIA	2
+4V2D-2	SR, nan	IDC,TCIA	2
+2V2E-2	SR, nan	IDC,TCIA	2
+2V2E-1	SR, nan	IDC,TCIA	2
+2V5E-1	SR, nan	IDC,TCIA	2
+XT CHEST W/CONT	SEG, nan	IDC,TCIA	2
+XR LUMBAR SPINE AND BEND 4+ VIEWS	DX	MIDRC	2
+2V5D-2	SR, nan	IDC,TCIA	2
+XR LUMBAR SPINE FLEXION AND EXTENSION ONLY	DX	MIDRC	2
+2V5D-1	SR, nan	IDC,TCIA	2
+XR_ThoracicSpine	DX, nan	IDC,TCIA	2
+WB PET/CT W/DELAYS	SEG, nan	IDC,TCIA	2
+XR PORT ABDOMEN 1V LINE PLCMNT - NO CHARGE	CR	MIDRC	2
+XR PORT ABDOMEN SINGLE VIEW AP	CR	MIDRC	2
+2V5C-2	SR, nan	IDC,TCIA	2
+XR_RF AbdPelvis	DX, nan	IDC,TCIA	2
+XR_LSpine	XA, nan	IDC,TCIA	2
+2V5C-1	SR, nan	IDC,TCIA	2
+2V5B-2	SR, nan	IDC,TCIA	2
+2V5E-2	SR, nan	IDC,TCIA	2
+XR LEFT TOES 2 VIEWS	CR, DX	MIDRC	2
+XR LEFT TIBIA FIBULA 3+ VIEWS	DX	MIDRC	2
+^THIGH	RTSTRUCT, nan	IDC,TCIA	2
+2V6E-2	SR, nan	IDC,TCIA	2
+2V6E-1	SR, nan	IDC,TCIA	2
+2V2D-1	SR, nan	IDC,TCIA	2
+2V6D-2	SR, nan	IDC,TCIA	2
+XR LEFT HIP 1 VIEW	CR	MIDRC	2
+2V6D-1	SR, nan	IDC,TCIA	2
+2V6C-2	SR, nan	IDC,TCIA	2
+2V6C-1	SR, nan	IDC,TCIA	2
+2V6B-2	SR, nan	IDC,TCIA	2
+2V2D-2	SR, nan	IDC,TCIA	2
+2V6B-1	SR, nan	IDC,TCIA	2
+2V6A-2	SR, nan	IDC,TCIA	2
+_t10of10MRI IAMS	MR, nan	IDC,TCIA	2
+2V6A-1	SR, nan	IDC,TCIA	2
+2V5F-2	SR, nan	IDC,TCIA	2
+2V5B-1	SR, nan	IDC,TCIA	2
+2V5A-2	SR, nan	IDC,TCIA	2
+2V5A-1	SR, nan	IDC,TCIA	2
+2V3B-1	SR, nan	IDC,TCIA	2
+2V3E-2	SR, nan	IDC,TCIA	2
+2V3E-1	SR, nan	IDC,TCIA	2
+XR RIGHT SHOULDER 1 VIEW	DX	MIDRC	2
+2V3D-2	SR, nan	IDC,TCIA	2
+2V3D-1	SR, nan	IDC,TCIA	2
+2V3C-2	SR, nan	IDC,TCIA	2
+2V3C-1	SR, nan	IDC,TCIA	2
+XR SACROILIAC JOINTS 1-2 VIEWS	CR, DX	MIDRC	2
+XR SACRUM AND COCCYX	DX	MIDRC	2
+XR STERNUM PA AND LATERAL	DX	MIDRC	2
+XR SHOULDER 2 OR MORE VIEW	DX	MIDRC	2
+XR SHOULDER RT 1 VIEW	DX	MIDRC	2
+XR SHOULDER RT 2 OR MORE VIEWS	DX	MIDRC	2
+XR SPINE THORACIC (AP+LAT)	DX	MIDRC	2
+XR SPINE LUMBAR (AP, LAT, FLEX/EX)	DX	MIDRC	2
+2V3F-2	SR, nan	IDC,TCIA	2
+2V4A-1	SR, nan	IDC,TCIA	2
+2V4F-2	SR, nan	IDC,TCIA	2
+2V4A-2	SR, nan	IDC,TCIA	2
+XR RIGHT CALCANEUS 2 VIEWS	CR	MIDRC	2
+2V4E-2	SR, nan	IDC,TCIA	2
+2V2F-2	SR, nan	IDC,TCIA	2
+XR RIGHT ELBOW 4+ VIEWS	DX	MIDRC	2
+2V4E-1	SR, nan	IDC,TCIA	2
+2V4D-2	SR, nan	IDC,TCIA	2
+2V4D-1	SR, nan	IDC,TCIA	2
+2V4C-2	SR, nan	IDC,TCIA	2
+2V3A-1	SR, nan	IDC,TCIA	2
+XR WRIST RIGHT (ROUTINE: AP,LAT,OBL)	CR, DX	MIDRC	2
+2V4C-1	SR, nan	IDC,TCIA	2
+2V4B-2	SR, nan	IDC,TCIA	2
+2V3A-2	SR, nan	IDC,TCIA	2
+2V4B-1	SR, nan	IDC,TCIA	2
+XR THORACIC SPINE AP AND LATERAL	DX	MIDRC	2
+2V6F-2	SR, nan	IDC,TCIA	2
+_t17of17_MRI IAMS	MR, nan	IDC,TCIA	2
+XR LEFT FEMUR MIN 2 VIEWS	DX	MIDRC	2
+3V1B-2	SR, nan	IDC,TCIA	2
+_t1of5External Images for PACS	MR, nan	IDC,TCIA	2
+3V1B-1	SR, nan	IDC,TCIA	2
+X-RAY CLAVICLE COMPLETE - RIGHT	CR, DX	MIDRC	2
+2V1D-2	SR, nan	IDC,TCIA	2
+X-RAY ELBOW COMPLETE MIN 3 VWS - LEFT	CR, DX	MIDRC	2
+_t1of4 MRI IAMS	MR, nan	IDC,TCIA	2
+2V1E-1	SR, nan	IDC,TCIA	2
+3V1A-2	SR, nan	IDC,TCIA	2
+2V1E-2	SR, nan	IDC,TCIA	2
+3V1A-1	SR, nan	IDC,TCIA	2
+3PHASE, DUAL E	CT, nan	IDC,TCIA	2
+3MM	nan	TCIA	2
+2V1F-2	SR, nan	IDC,TCIA	2
+3D decay linearity	CT, nan	IDC,TCIA	2
+X-RAY GI UPPER DOUBLE CONTRAST W/KUB	DX	MIDRC	2
+X-RAY CHEST OUTSIDE IMAGE	CR, DX	MIDRC	2
+3V1C-1	SR, nan	IDC,TCIA	2
+3D MULTIPLANAR/C-A-P	SEG, nan	IDC,TCIA	2
+3V1C-2	SR, nan	IDC,TCIA	2
+3V2B-1	SR, nan	IDC,TCIA	2
+WHOLE BODY	PT, nan	IDC,TCIA	2
+3V2A-2	SR, nan	IDC,TCIA	2
+_t1of6 MRI IAMS	MR, nan	IDC,TCIA	2
+WRIST COMPLETE RIGHT 3 VIEWS MIN	CR, DX	MIDRC	2
+3V2A-1	SR, nan	IDC,TCIA	2
+3V1F-2	SR, nan	IDC,TCIA	2
+_t1of6 External Images for PACS	MR, nan	IDC,TCIA	2
+3V1E-2	SR, nan	IDC,TCIA	2
+3V1E-1	SR, nan	IDC,TCIA	2
+3V1D-2	SR, nan	IDC,TCIA	2
+_t1of6  MRI IAMS	MR, nan	IDC,TCIA	2
+3V1D-1	SR, nan	IDC,TCIA	2
+X-RAY CALCANEUS MINIMUM 2 VIEWS - RIGHT	DX	MIDRC	2
+2V1D-1	SR, nan	IDC,TCIA	2
+2V2A-1	SR, nan	IDC,TCIA	2
+3615 MR RIGHT BREAST WO/W CONT	MR, nan	IDC,TCIA	2
+2V2C-2	SR, nan	IDC,TCIA	2
+XR CERVICAL SPINE 2-3 VIEWS WITH FLEXION EXTENSION	DX	MIDRC	2
+XR FOOT 3+ VIEWS	CR	MIDRC	2
+2V2B-2	SR, nan	IDC,TCIA	2
+XR HAND LEFT (ROUTINE: AP,LAT,OBL)	CR, DX	MIDRC	2
+_t1of17  External Images for PACS	MR, nan	IDC,TCIA	2
+XR HAND RIGHT (ROUTINE: AP,LAT,OBL)	CR, DX	MIDRC	2
+_t1of11_MRI RNTNE historical imaging	MR, nan	IDC,TCIA	2
+XR HIP LEFT 2-3 VIEWS WWO PELVIS	CR	MIDRC	2
+XR HIP RIGHT 1 VIEW	DX	MIDRC	2
+2V2C-1	SR, nan	IDC,TCIA	2
+XR KNEE LT 4 OR MORE VIEWS	CR	MIDRC	2
+XR KNEE RT 1 OR 2 VIEWS	DX	MIDRC	2
+XR KNEE RT 3 VIEWS	DX	MIDRC	2
+XR KNEES ANTEROPOSTERIOR STANDING BILATERAL	DX	MIDRC	2
+_t1of10External Images for PACS	MR, nan	IDC,TCIA	2
+XR KUB UPRIGHT, ABDOMEN 1 VIEW	DX	MIDRC	2
+_t1of2  MRI Head	MR, nan	IDC,TCIA	2
+XR CAP	DX, nan	IDC,TCIA	2
+3615 - MR BREAST WO/W CONT #6667	MR, nan	IDC,TCIA	2
+XR ANKLE RIGHT (ROUTINE: AP,LAT,OBL)	CR, DX	MIDRC	2
+3615 - 6667 LIMITED MR RT BREAST WO/W CONT	MR, nan	IDC,TCIA	2
+2V2A-2	SR, nan	IDC,TCIA	2
+X-RAY HIPS BILATERAL WITH PELVIS 3 OR 4 VIEWS	DX	MIDRC	2
+X-RAY HIPS BILATERAL WITH PELVIS MINIMUM 5 VIEWS	DX	MIDRC	2
+_t1of3  MRI IAMS post Gad	MR, nan	IDC,TCIA	2
+3607 MR LT BREAST WO/W CONT	MR, SEG	IDC	2
+X-RAY SCAPULA COMPLETE - RIGHT	DX	MIDRC	2
+_t1of3  MRI IAMS	MR, nan	IDC,TCIA	2
+X-RAY TIBIA & FIBULA 2 VIEWS - RIGHT	CR, DX	MIDRC	2
+_t1of3  MRI Head	MR, nan	IDC,TCIA	2
+2V2B-1	SR, nan	IDC,TCIA	2
+XA_Biopsy	XA, nan	IDC,TCIA	2
+XA_Pelvis	XA, nan	IDC,TCIA	2
+3607 MR BREAST WO OR W BILAT	MR, SEG	IDC	2
+XR ABDOMEN 2 VIEWS	DX	MIDRC	2
+4V2D-1	SR, nan	IDC,TCIA	2
+4V2E-1	SR, nan	IDC,TCIA	2
+6V1E-2	SR, nan	IDC,TCIA	2
+5V4B-1	SR, nan	IDC,TCIA	2
+5V4B-2	SR, nan	IDC,TCIA	2
+T/A/P W/C LIVER	SEG, nan	IDC,TCIA	2
+1V5C-1	SR, nan	IDC,TCIA	2
+T1 - US	US	ACRdart	2
+T11-L1/RT CLAVICLE	SEG, nan	IDC,TCIA	2
+T3	SEG, nan	IDC,TCIA	2
+TAP LIVER W/C	SEG, nan	IDC,TCIA	2
+5V4A-2	SR, nan	IDC,TCIA	2
+5V3B-1	SR, nan	IDC,TCIA	2
+TB TOTAL BODY	NM, nan	IDC,TCIA	2
+THOR.ABD.PEL.BED.	CT, nan	IDC,TCIA	2
+1V5C-2	SR, nan	IDC,TCIA	2
+THORACIC SPINE 3 VIEWS	CR, DX	MIDRC	2
+THORAX	RTSTRUCT, CT	IDC	2
+THORAX (Adult)	CT, nan	IDC,TCIA	2
+5V4A-1	SR, nan	IDC,TCIA	2
+T/A/P LIVER W/C	SEG, nan	IDC,TCIA	2
+T SPINERIB & PELVIS	SEG, nan	IDC,TCIA	2
+5V4C-1	SR, nan	IDC,TCIA	2
+T L S SPINE	CT, nan	IDC,TCIA	2
+5V5B-2	SR, nan	IDC,TCIA	2
+5V5B-1	SR, nan	IDC,TCIA	2
+5V5A-2	SR, nan	IDC,TCIA	2
+Specials^ADRENAL_ABD_WO_W (Adult)	CT, nan	IDC,TCIA	2
+Specials^RCCTPET_THORAX_8F (Adult)	RTSTRUCT, CT	IDC	2
+Spine^CRANIOSPINAL_SUPINE (Adult)	SEG, nan	IDC,TCIA	2
+5V5A-1	SR, nan	IDC,TCIA	2
+Spine^SPINE_BONE_SBRT_4D (Adult)	SEG, nan	IDC,TCIA	2
+5V4F-2	SR, nan	IDC,TCIA	2
+Standard Diagnostic- TomoHD	MG, nan	IDC,TCIA	2
+5V4E-2	SR, nan	IDC,TCIA	2
+5V4E-1	SR, nan	IDC,TCIA	2
+5V4D-2	SR, nan	IDC,TCIA	2
+5V4D-1	SR, nan	IDC,TCIA	2
+5V4C-2	SR, nan	IDC,TCIA	2
+1V5D-1	SR, nan	IDC,TCIA	2
+5V3F-2	SR, nan	IDC,TCIA	2
+_t4of6  MRI IAMS post Gad	MR, nan	IDC,TCIA	2
+5V3D-1	SR, nan	IDC,TCIA	2
+TK jamy brzusznej lub miednicy mniejszej bez wzmoc.kontr. i co n	RTSTRUCT, nan	IDC,TCIA	2
+TK jamy brzusznej z ko	RTSTRUCT, nan	IDC,TCIA	2
+TK jamy brzusznej z kontrastem	RTSTRUCT, nan	IDC,TCIA	2
+TK klatki piersiowej	RTSTRUCT, nan	IDC,TCIA	2
+TK klatki piersiowej bez i ze wzmocnieniem kontrastowym	CT, nan	IDC,TCIA	2
+TK klatki piersiowej bez i ze wzmocnieniem kontrastowym - VISIPA	CT, nan	IDC,TCIA	2
+1V5E-1	SR, nan	IDC,TCIA	2
+TK klatki piersiowej bez kontrastu i z kontrastem	CT, nan	IDC,TCIA	2
+MRI Abdomen W, W/O Contrast	SEG, nan	IDC,TCIA	2
+5V3C-2	SR, nan	IDC,TCIA	2
+TOMO DIAGNOSTIC MAMM RIGHT	MG	ACRdart,IDC	2
+TOMOGRAFIA COMPUTADORI	CT, nan	IDC,TCIA	2
+TOMOGRAFIA JAMY BRZUSZNEJ Z KONTRASTEM	RTSTRUCT, nan	IDC,TCIA	2
+5V3C-1	SR, nan	IDC,TCIA	2
+5V3B-2	SR, nan	IDC,TCIA	2
+TK jamy brzusznej lub miednicy malej bez kontrastu i z kontraste	RTSTRUCT, nan	IDC,TCIA	2
+TK j.brzusznej/mied malej BK i min 2 fazy ZK	RTSTRUCT, nan	IDC,TCIA	2
+1V5D-2	SR, nan	IDC,TCIA	2
+TK SPECJ. JAMY BRZUSZN	SEG, nan	IDC,TCIA	2
+5V3E-2	SR, nan	IDC,TCIA	2
+THORAX WITH	SEG, nan	IDC,TCIA	2
+5V3E-1	SR, nan	IDC,TCIA	2
+TK - BRZUCHA Z K	RTSTRUCT, nan	IDC,TCIA	2
+TK - KLP	CT, nan	IDC,TCIA	2
+TK - j. brzusznej	RTSTRUCT, nan	IDC,TCIA	2
+TK - jama brzuszna z kontrastem	RTSTRUCT, nan	IDC,TCIA	2
+TK Angiografia tt. i zyl plucnych	CT, nan	IDC,TCIA	2
+TK J BRZUSZNEJ	RTSTRUCT, nan	IDC,TCIA	2
+_t4of5  MRI Head	MR, nan	IDC,TCIA	2
+TK J. BRZ. I M.M	RTSTRUCT, nan	IDC,TCIA	2
+TK JAMA BRZUSZNA I MIE	RTSTRUCT, nan	IDC,TCIA	2
+5V3D-2	SR, nan	IDC,TCIA	2
+TK JAMY BRZUSZNEJ I MIEDNICY MNIEJSZEJ	RTSTRUCT, nan	IDC,TCIA	2
+TK Klatki piersiowej bez kontrastu	CT, nan	IDC,TCIA	2
+Specials^01_Biopsy_1 (Adult)	CT, nan	IDC,TCIA	2
+Specials 1PETCT_Wholebody	SEG, nan	IDC,TCIA	2
+5V5C-1	SR, nan	IDC,TCIA	2
+SUPINE RECTUM	CT, nan	IDC,TCIA	2
+6667 acrin	MR, nan	IDC,TCIA	2
+6667 LT BREAST/GAD	MR, nan	IDC,TCIA	2
+6667 CONTRALATERAL	MR, nan	IDC,TCIA	2
+_t5of8MRI IAMS post Gad	MR, nan	IDC,TCIA	2
+1V5A-1	SR, nan	IDC,TCIA	2
+6667 CONTRA BREAST	MR, nan	IDC,TCIA	2
+1V5A-2	SR, nan	IDC,TCIA	2
+_t5of7  MRI IAMS	MR, nan	IDC,TCIA	2
+6667 BREAST WO/W CONT	MR, nan	IDC,TCIA	2
+6026   ABD CT W/C	CT, nan	IDC,TCIA	2
+5mm chest	CT, nan	IDC,TCIA	2
+5V6F-2	SR, nan	IDC,TCIA	2
+5V6E-2	SR, nan	IDC,TCIA	2
+_t5of6  MRI IAMS	MR, nan	IDC,TCIA	2
+5V6E-1	SR, nan	IDC,TCIA	2
+1V4F-2	SR, nan	IDC,TCIA	2
+STUDY RT BREAST	MR, nan	IDC,TCIA	2
+5V6D-1	SR, nan	IDC,TCIA	2
+STANDARD Abdomen	RTSTRUCT, nan	IDC,TCIA	2
+6V1E-1	SR, nan	IDC,TCIA	2
+2V3B-2	SR, nan	IDC,TCIA	2
+6V1D-1	SR, nan	IDC,TCIA	2
+6V1C-2	SR, nan	IDC,TCIA	2
+6V1C-1	SR, nan	IDC,TCIA	2
+6V1B-2	SR, nan	IDC,TCIA	2
+6V1B-1	SR, nan	IDC,TCIA	2
+6V1A-2	SR, nan	IDC,TCIA	2
+6V1A-1	SR, nan	IDC,TCIA	2
+SPINE	SEG, nan	IDC,TCIA	2
+_t5of9MRI Head	MR, nan	IDC,TCIA	2
+SPINE^C-SPINE	MR	MIDRC	2
+6667CONDRLATERAL BREAS	MR, nan	IDC,TCIA	2
+6667/sodium	MR, nan	IDC,TCIA	2
+_t5of9  MRI IAMS	MR, nan	IDC,TCIA	2
+5V6D-2	SR, nan	IDC,TCIA	2
+_t5of5_MRI IAMS	MR, nan	IDC,TCIA	2
+5V5C-2	SR, nan	IDC,TCIA	2
+_t5of5EXTERNAL IMAGES	MR, nan	IDC,TCIA	2
+Scanner-Philips_Exp-50_Pitch-1.2_SlCol-16x0.75	CT, nan	IDC,TCIA	2
+Scanner-Philips_Exp-50_Pitch-1.2_SlCol-16x1.5	CT, nan	IDC,TCIA	2
+1V5B-1	SR, nan	IDC,TCIA	2
+Scanner-SIEMENS_Exp-100_Pitch-0.9_SlCol-64x0.6mm	CT, nan	IDC,TCIA	2
+_t5of5  MRI Head	MR, nan	IDC,TCIA	2
+Scanner-SIEMENS_Exp-100_Pitch-1.2_SlCol-64x0.6mm	CT, nan	IDC,TCIA	2
+Scanner-SIEMENS_Exp-200_Pitch-0.9_SlCol-64x0.6mm	CT, nan	IDC,TCIA	2
+Scanner-SIEMENS_Exp-200_Pitch-1.2_SlCol-64x0.6mm	CT, nan	IDC,TCIA	2
+_t4of8MRI IAMS	MR, nan	IDC,TCIA	2
+Scanner-SIEMENS_Exp-25_Pitch-0.9_SlCol-64x0.6mm	CT, nan	IDC,TCIA	2
+Scanner-SIEMENS_Exp-25_Pitch-1.2_SlCol-64x0.6mm	CT, nan	IDC,TCIA	2
+1V5B-2	SR, nan	IDC,TCIA	2
+5V5D-2	SR, nan	IDC,TCIA	2
+5V5D-1	SR, nan	IDC,TCIA	2
+Screening-Bilateral Mammography	MG, nan	IDC,TCIA	2
+Scanner-Philips_Exp-50_Pitch-0.9_SlCol-16x1.5	CT, nan	IDC,TCIA	2
+Scanner-Philips_Exp-50_Pitch-0.9_SlCol-16x0.75	CT, nan	IDC,TCIA	2
+5V6C-2	SR, nan	IDC,TCIA	2
+5V5E-1	SR, nan	IDC,TCIA	2
+5V6C-1	SR, nan	IDC,TCIA	2
+_t5of5MRI IAMS post Gad	MR, nan	IDC,TCIA	2
+_t5of5MRI IAMS	MR, nan	IDC,TCIA	2
+5V6B-2	SR, nan	IDC,TCIA	2
+Scanner-Philips_Exp-20_Pitch-1.2_SlCol-16x0.75	CT, nan	IDC,TCIA	2
+Scanner-Philips_Exp-20_Pitch-1.2_SlCol-16x0.75mm	CT, nan	IDC,TCIA	2
+Scanner-Philips_Exp-20_Pitch-1.2_SlCol-16x1.5	CT, nan	IDC,TCIA	2
+Scanner-Philips_Exp-20_Pitch-1.2_SlCol-16x1.5mm	CT, nan	IDC,TCIA	2
+5V6B-1	SR, nan	IDC,TCIA	2
+5V6A-2	SR, nan	IDC,TCIA	2
+5V6A-1	SR, nan	IDC,TCIA	2
+5V5F-2	SR, nan	IDC,TCIA	2
+Scanner-Philips_Exp-25_Pitch-1.2_SlCol-16x0.75	CT, nan	IDC,TCIA	2
+5V5E-2	SR, nan	IDC,TCIA	2
+Scanner-Philips_Exp-25_Pitch-1.2_SlCol-16x1.5	CT, nan	IDC,TCIA	2
+_t4of4_MRI IAMS WITH CONTRAST	MR, nan	IDC,TCIA	2
+_t4of4MRI Head	MR, nan	IDC,TCIA	2
+Thorax^LOW_DOSE_CHEST_SCREENING (Adult)	CT, nan	IDC,TCIA	2
+_t3of3_MR IAM's	MR	IDC	2
+_t3of4  MRI IAMS	MR, nan	IDC,TCIA	2
+_t3of4  External Images for PACS	MR, nan	IDC,TCIA	2
+4V5C-1	SR, nan	IDC,TCIA	2
+Thorax^CTA_CAP_Customized (Adult)	CT	MIDRC	2
+_t3of3_MRI RNTNE historical imaging	MR, nan	IDC,TCIA	2
+4V5B-2	SR, nan	IDC,TCIA	2
+_t3of3_MR IAMs	nan	TCIA	2
+_t3of3_MR Head	MR, nan	IDC,TCIA	2
+5V3A-2	SR, nan	IDC,TCIA	2
+4V5B-1	SR, nan	IDC,TCIA	2
+1V6A-2	SR, nan	IDC,TCIA	2
+4V5A-2	SR, nan	IDC,TCIA	2
+4V5A-1	SR, nan	IDC,TCIA	2
+4V4F-2	SR, nan	IDC,TCIA	2
+4V4E-2	SR, nan	IDC,TCIA	2
+Thorax^CT_CHEST_LOW_DOSE_NODULE_WO (Adult)	CT	MIDRC	2
+4V5C-2	SR, nan	IDC,TCIA	2
+4V5D-1	SR, nan	IDC,TCIA	2
+4V5D-2	SR, nan	IDC,TCIA	2
+Thorax^CHEST_WO_IRIS (Adult)	CT	MIDRC	2
+4V6E-2	SR, nan	IDC,TCIA	2
+Thorax^CHEST_ABD_WITH (Adult)	CT, nan	IDC,TCIA	2
+4V6E-1	SR, nan	IDC,TCIA	2
+4V6D-2	SR, nan	IDC,TCIA	2
+4V6D-1	SR, nan	IDC,TCIA	2
+Thorax^CHEST_NON_CONTRAST (Adult)	CT, nan	IDC,TCIA	2
+4V6C-2	SR, nan	IDC,TCIA	2
+4V6C-1	SR, nan	IDC,TCIA	2
+4V6B-2	SR, nan	IDC,TCIA	2
+4V6B-1	SR, nan	IDC,TCIA	2
+4V6A-2	SR, nan	IDC,TCIA	2
+4V6A-1	SR, nan	IDC,TCIA	2
+4V5F-2	SR, nan	IDC,TCIA	2
+4V5E-2	SR, nan	IDC,TCIA	2
+4V5E-1	SR, nan	IDC,TCIA	2
+4V4E-1	SR, nan	IDC,TCIA	2
+4V4D-2	SR, nan	IDC,TCIA	2
+Thorax^CT_CHEST_WO_AND_HI_RES_CUTS (Adult)	CT	MIDRC	2
+4V3C-1	SR, nan	IDC,TCIA	2
+Thorax^GH_ThoraxHR (Adult)	CT	MIDRC	2
+4V3B-1	SR, nan	IDC,TCIA	2
+4V3A-2	SR, nan	IDC,TCIA	2
+_t3of3MRI IAMS	MR, nan	IDC,TCIA	2
+1V6B-2	SR, nan	IDC,TCIA	2
+4V3A-1	SR, nan	IDC,TCIA	2
+Thorax^KLATKA_PIERSIOWA_kontrast (Adult)	CT, nan	IDC,TCIA	2
+Thorax^KlatkaPiersiowa (Adult)	RTSTRUCT, nan	IDC,TCIA	2
+1V6C-1	SR, nan	IDC,TCIA	2
+1V6C-2	SR, nan	IDC,TCIA	2
+4V2F-2	SR, nan	IDC,TCIA	2
+1V6D-1	SR, nan	IDC,TCIA	2
+4V2E-2	SR, nan	IDC,TCIA	2
+Thorax^LOW_DOSE_CHEST_CT_NON_CON (Adult)	CT, nan	IDC,TCIA	2
+1V6D-2	SR, nan	IDC,TCIA	2
+4V3B-2	SR, nan	IDC,TCIA	2
+4V3C-2	SR, nan	IDC,TCIA	2
+Thorax^CT_CHST_ABD_PELVIS_WO_W_IVCON (Adult)	SEG, nan	IDC,TCIA	2
+4V3D-1	SR, nan	IDC,TCIA	2
+4V4D-1	SR, nan	IDC,TCIA	2
+4V4C-2	SR, nan	IDC,TCIA	2
+Thorax^C_A_P_WITH _XXL (Adult)	CT	MIDRC	2
+4V4C-1	SR, nan	IDC,TCIA	2
+4V4B-2	SR, nan	IDC,TCIA	2
+Thorax^Chest (Adult)	CT, nan	IDC,TCIA	2
+4V4B-1	SR, nan	IDC,TCIA	2
+4V4A-2	SR, nan	IDC,TCIA	2
+4V4A-1	SR, nan	IDC,TCIA	2
+Thorax^DE_TRAUMA_CAP_WITH_FEET_FIRST__INFUSION_AUTO_Customized (	CT	MIDRC	2
+1V6B-1	SR, nan	IDC,TCIA	2
+4V3F-2	SR, nan	IDC,TCIA	2
+4V3E-2	SR, nan	IDC,TCIA	2
+4V3E-1	SR, nan	IDC,TCIA	2
+4V3D-2	SR, nan	IDC,TCIA	2
+4V6F-2	SR, nan	IDC,TCIA	2
+_t3of4MRI Head	MR, nan	IDC,TCIA	2
+57MRI BREAST BILAT WO/W CONTRAST	MR	ACRdart,IDC	2
+Thorax^01_ThoraxRoutine (Adult)	CT, nan	IDC,TCIA	2
+5V2B-2	SR, nan	IDC,TCIA	2
+Thorax^02_0_Chest_Routine (Adult)	SEG, nan	IDC,TCIA	2
+5V2B-1	SR, nan	IDC,TCIA	2
+Thorax^03_THORAX_ROUTINE (Adult)	CT, nan	IDC,TCIA	2
+Thorax^04Chest_Biphase _Liver_Panc (Adult)	SEG, nan	IDC,TCIA	2
+5V2A-2	SR, nan	IDC,TCIA	2
+_t4of4  External Images for PACS	MR, nan	IDC,TCIA	2
+Thorax^04_Chest_Biphase_Liver_Panc (Adult)	SEG, nan	IDC,TCIA	2
+Thorax^04_PE (Adult)	CT, nan	IDC,TCIA	2
+Thorax^08 PE ROUTINE	CT, nan	IDC,TCIA	2
+5V2A-1	SR, nan	IDC,TCIA	2
+Thorax^1 CHEST BIPHASE LIVER	SEG, nan	IDC,TCIA	2
+5V1F-2	SR, nan	IDC,TCIA	2
+_t3of7  External Images for PACS	MR, nan	IDC,TCIA	2
+Thorax^11WBPETCT	SEG, nan	IDC,TCIA	2
+Thorax^02CAPRoutine (Adult)	CT, nan	IDC,TCIA	2
+Thorax^01_ThoraxNative (Adult)	CT, nan	IDC,TCIA	2
+5V1E-2	SR, nan	IDC,TCIA	2
+5V2C-1	SR, nan	IDC,TCIA	2
+5V3A-1	SR, nan	IDC,TCIA	2
+_t4of4  MRI IAMS	MR, nan	IDC,TCIA	2
+TUMOR PET RES	PT, nan	IDC,TCIA	2
+5V2F-2	SR, nan	IDC,TCIA	2
+5V2E-2	SR, nan	IDC,TCIA	2
+Thorax 01_PE (Adult)	CT, nan	IDC,TCIA	2
+5V2E-1	SR, nan	IDC,TCIA	2
+Thorax^01 Chest 1mm Collimator	CT, nan	IDC,TCIA	2
+5V2D-2	SR, nan	IDC,TCIA	2
+5V2D-1	SR, nan	IDC,TCIA	2
+Thorax^01_CHEST (Adult)	CT, nan	IDC,TCIA	2
+5V2C-2	SR, nan	IDC,TCIA	2
+Thorax^01_CHEST_ROUTINE (Adult)	CT, nan	IDC,TCIA	2
+Thorax^01_CHEST_ROUTINE_WITH (Adult)	CT	MIDRC	2
+Thorax^01_Chest_Routine (Adult)	CT, nan	IDC,TCIA	2
+Thorax^11_Chest_BX_Startup_NObreathing (Adult)	CT	MIDRC	2
+5V1E-1	SR, nan	IDC,TCIA	2
+5AFOV LUNG	PT, nan	IDC,TCIA	2
+5V1B-1	SR, nan	IDC,TCIA	2
+1V5F-2	SR, nan	IDC,TCIA	2
+Thorax^AVERAGE_CHEST_WITH_IV_CONTRAST (Adult)	nan	TCIA	2
+_t3of5External Images for PACS	MR, nan	IDC,TCIA	2
+Thorax^CAP (Adult)	SEG, nan	IDC,TCIA	2
+_t3of5  MRI IAMS post Gad	MR, nan	IDC,TCIA	2
+1V6A-1	SR, nan	IDC,TCIA	2
+Thorax^CAP_ARTERIAL_PORTVENOUS (Adult)	SEG, nan	IDC,TCIA	2
+Thorax^CAP_WITH (Adult)	CT	MIDRC	2
+5V1A-2	SR, nan	IDC,TCIA	2
+5V1A-1	SR, nan	IDC,TCIA	2
+Thorax^CAP_WO (Adult)	CT	MIDRC	2
+Thorax^CHEST (Adult)	CT, nan	IDC,TCIA	2
+Thorax^CHESTABDPELVIS.WCONTRAST	CT, nan	IDC,TCIA	2
+5AFOV TORSO	PT, nan	IDC,TCIA	2
+_t3of4MRI IAMS	MR, nan	IDC,TCIA	2
+Thorax^AVERAGE_CHEST_LOW_DOSE (Adult)	nan	TCIA	2
+Thorax^3_CHEST_ABD_PELV_BMI_SM (Adult)	RTSTRUCT, nan	IDC,TCIA	2
+5V1D-2	SR, nan	IDC,TCIA	2
+Thorax^31_ThorAbd_N_CE (Adult)	CT, nan	IDC,TCIA	2
+_t3of6  MRI IAMS post Gad	MR, nan	IDC,TCIA	2
+Thorax^1MM_CHEST_ROUTINE (Adult)	CT, nan	IDC,TCIA	2
+5V1D-1	SR, nan	IDC,TCIA	2
+5V1C-2	SR, nan	IDC,TCIA	2
+1V5E-2	SR, nan	IDC,TCIA	2
+Thorax^1_CAP_W_WO (Adult)	SEG, nan	IDC,TCIA	2
+Thorax^1_CHEST_ROUTINE_3MM	CT, nan	IDC,TCIA	2
+5V1C-1	SR, nan	IDC,TCIA	2
+Thorax^1_CHEST_WO (Adult)	CT, nan	IDC,TCIA	2
+Thorax^1_CHEST_WO_IRIS (Adult)	CT	MIDRC	2
+Thorax^1_PULMONARY_EMBOLIS (Adult)	CT, nan	IDC,TCIA	2
+Thorax^1_ROUTINE_CHEST_LARGE (Adult)	CT, nan	IDC,TCIA	2
+Thorax^1_Routine_Chest (Adult)	CT, nan	IDC,TCIA	2
+5V1B-2	SR, nan	IDC,TCIA	2
+Thorax^3 PE PROTOCOL + LEGS	CT, nan	IDC,TCIA	2
+TK- j. brzuszna z kontr.	RTSTRUCT, nan	IDC,TCIA	2
+CT CHE/ABD/PEL	SEG, nan	IDC,TCIA	2
+MRI Abd wo+w	MR, nan	IDC,TCIA	2
+CT A/P  LIVER	SEG, nan	IDC,TCIA	2
+CT A/P LIVER PR.	SEG, nan	IDC,TCIA	2
+CT_R_Hip	CT, nan	IDC,TCIA	2
+CT_SkullMidThigh	CT, nan	IDC,TCIA	2
+CT_T_Spine	CT, nan	IDC,TCIA	2
+CT_WholeBody	CT, nan	IDC,TCIA	2
+CT_biopstbonemarrow	CT, nan	IDC,TCIA	2
+CT A/P LIVER	SEG, nan	IDC,TCIA	2
+CT A/P IV PO	CT, nan	IDC,TCIA	2
+CT A/P (LIVER) W/WO	SEG, nan	IDC,TCIA	2
+CT_pelvisbonebiopsy	CT, nan	IDC,TCIA	2
+CVA12	CT, nan	IDC,TCIA	2
+CXR	DX	MIDRC	2
+CXR  COUGHX 3 MONTHS	CT, nan	IDC,TCIA	2
+Cardiac^02_0_Constrictive_Pericarditis (Adult)	CT, nan	IDC,TCIA	2
+Cardiac^CORONARY_RETROSPECTIVE_MORE_PAD (Adult)	CT	MIDRC	2
+CT A/P RENAL	SEG, nan	IDC,TCIA	2
+CT A/P W/W/O	CT, nan	IDC,TCIA	2
+CT_Lung	CT, nan	IDC,TCIA	2
+CT_Biopsy_Liver	CT, nan	IDC,TCIA	2
+CTAPWO	CT, nan	IDC,TCIA	2
+CT ABD LIV PRO	SEG, nan	IDC,TCIA	2
+CTCAP/CT6   CT CHE/BODY(SCH	CT, nan	IDC,TCIA	2
+CT ABD AND/OR PEL - CD	CT, nan	IDC,TCIA	2
+CTTHOR2 CT THORAX W/WO CONTR	CT, nan	IDC,TCIA	2
+CT ABD & PELVIS W/O CONTRAST	nan	TCIA	2
+CT ABD & PELV W/CONTRAST	nan	TCIA	2
+CT_L_Hip	CT, nan	IDC,TCIA	2
+CT_Brain	nan	TCIA	2
+CT AB/PEL W & W/O CONTRAST	CT, nan	IDC,TCIA	2
+CT_CHEST	CT, nan	IDC,TCIA	2
+CT AB WITH	CT, nan	IDC,TCIA	2
+CT_ChestAbd	CT, nan	IDC,TCIA	2
+CT A/P-RENAL	SEG, nan	IDC,TCIA	2
+Cardiac^FLASH_PILOT_LAMODEL (Adult)	CT	MIDRC	2
+CT A-P LIVER	SEG, nan	IDC,TCIA	2
+CT URETERS W/O	CT, nan	IDC,TCIA	2
+CT A	RTSTRUCT, nan	IDC,TCIA	2
+ComboHD Unilateral Left	MG, nan	IDC,TCIA	2
+Cryomacrotome anatomic images	XC	IDC	2
+DELAYS	CT, nan	IDC,TCIA	2
+CRANE 3MM	CT	IDC	2
+DG RIBS BILAT 3V	DX	MIDRC	2
+DIG CB DX TOMO MAM	MG	IDC	2
+DIG DX TOMO MAMMO BIL	MG	ACRdart,IDC	2
+DIG MAM DIAGNOSTIC UNI LT	MG	ACRdart,IDC	2
+DIG MAM SCRN>UNI DX SAME DAY	MG	ACRdart	2
+CORONARY_AFIB (Adult)	CT	AIMI	2
+DIGITAL BILAT SCREENING MAMMO	MG, nan	IDC,TCIA	2
+DIGITAL DX MAMMO UNILAT (NO CAD)	MG	ACRdart	2
+DIGITAL MAMMOGRAM UNILATERAL	nan	TCIA	2
+CONTRABREAST -LT	MR, nan	IDC,TCIA	2
+CONTRABREAST  (LEFT)	MR, nan	IDC,TCIA	2
+Combo Unilateral Right	MG	ACRdart,IDC	2
+Chest Single View Frontal	CR	MIDRC	2
+CST ABD WITH	CT, nan	IDC,TCIA	2
+Chest 3	CT, nan	IDC,TCIA	2
+CT ,CHEST ABD PEL W/, CONTRAST	SEG, nan	IDC,TCIA	2
+Chest +C(T)	SEG, nan	IDC,TCIA	2
+Chest 1 View	CR	MIDRC	2
+CT  F/U CA STAGING	CT, nan	IDC,TCIA	2
+CT  C/A/P  W/O CONT	SEG, nan	IDC,TCIA	2
+CT  C/A/P  UROGRAM	CT, nan	IDC,TCIA	2
+CT  C/A/P	CT, nan	IDC,TCIA	2
+CT  ABD/PEL	SEG, nan	IDC,TCIA	2
+Chest CT Enhanced	CT, nan	IDC,TCIA	2
+CT  Abd/Pelvis	CT, nan	IDC,TCIA	2
+CT  ABDOMEN W CONTRAST	CT, nan	IDC,TCIA	2
+CT  ABD/PELVIS   W	CT, nan	IDC,TCIA	2
+Chest Inspiration & Expiration	CR, nan	IDC,TCIA	2
+CT  ABD/PEL  LIVER	SEG, nan	IDC,TCIA	2
+CTAPW	CT, nan	IDC,TCIA	2
+CTABDPELWX	RTSTRUCT, nan	IDC,TCIA	2
+CT ABD LIVER PR.	SEG, nan	IDC,TCIA	2
+CT ABD PANCRERAS	SEG, nan	IDC,TCIA	2
+CT,ABD (LIVER)	CT, nan	IDC,TCIA	2
+CT,ABD/PEL LIVER W/C	SEG, nan	IDC,TCIA	2
+CT,ABD/PEL(RENAL) WO/W	SEG, nan	IDC,TCIA	2
+CT,C/A/P RENAL W/C	SEG, nan	IDC,TCIA	2
+CT,CHEST ROUTINE W/O	CT, nan	IDC,TCIA	2
+CT,CHEST/ABD/PEL RENAL	SEG, nan	IDC,TCIA	2
+CT-A/P  LIVER PROTOCOL	CT, nan	IDC,TCIA	2
+CT-A/P LIVER PROTOCOL	SEG, nan	IDC,TCIA	2
+CT-ABD W/WO CON (LIVER	SEG, nan	IDC,TCIA	2
+CT-ABD-PEL	CT, nan	IDC,TCIA	2
+CT-Abdomen/Pelvis enha	CT, nan	IDC,TCIA	2
+CT-C-A-P  (PA)	SEG, nan	IDC,TCIA	2
+CT-C/A/P W/WO CON	SEG, nan	IDC,TCIA	2
+CT-CH/A/P LIVER	SEG, nan	IDC,TCIA	2
+CT-UROGRAM	CT, nan	IDC,TCIA	2
+CT, LUNG,MED, PLEURAL W/CONTRAST	CT, nan	IDC,TCIA	2
+CT ABD/PEL W/WO LIVER	SEG, nan	IDC,TCIA	2
+CT, CAP	SEG, nan	IDC,TCIA	2
+CT Urography	RTSTRUCT, nan	IDC,TCIA	2
+CT ABD/PELVIS WO/W	SEG, nan	IDC,TCIA	2
+CT ABD/PELVIS WITH CONTRAST	CT, nan	IDC,TCIA	2
+CT Urogram	CT, nan	IDC,TCIA	2
+CT ABD/PELVIS WITH	CT, nan	IDC,TCIA	2
+CT ABD/PELVIS W AND WO CONTRAST	CT, nan	IDC,TCIA	2
+CT Urogram with 3D	CR, nan	IDC,TCIA	2
+CT V ABD/PEL	RTSTRUCT, nan	IDC,TCIA	2
+CT ABD/PELV W/O	CT, nan	IDC,TCIA	2
+CT VIRTUAL COLONOSCOPY	CT, nan	IDC,TCIA	2
+CT ABD/PELVIS LIVER PR	SEG, nan	IDC,TCIA	2
+CT ABD/PELV(STONE)	CT, nan	IDC,TCIA	2
+CT head+c	CT, nan	IDC,TCIA	2
+CT jamy brzusznej z kontrastem	RTSTRUCT, nan	IDC,TCIA	2
+CT, ABD/PEL W/C	SEG, nan	IDC,TCIA	2
+CT/C-A-P/ LIVER	SEG, nan	IDC,TCIA	2
+CT/CC Brain, Unenhanc	CT, nan	IDC,TCIA	2
+CT/CC Chest	CT, nan	IDC,TCIA	2
+CT ABD WO THEN ABD/PEL WITH CONTRAST	CT, nan	IDC,TCIA	2
+CT ABD/PEL  LIVER	SEG, nan	IDC,TCIA	2
+CT ABD/CHEST W CONTRAST	CT, nan	IDC,TCIA	2
+CT ABD./PELVIS	CT, nan	IDC,TCIA	2
+CT ABD-PEL WO/W CM	CT	MIDRC	2
+CTA CHEST R/O	CT, nan	IDC,TCIA	2
+CTA CHEST W WO CONTRAST	CT	MIDRC	2
+CT ABD W/WO AND PELVIS W CONTRAST	SEG, nan	IDC,TCIA	2
+CTA CHEST ANGIO	CT	MIDRC	2
+CT ABD W/O/W  PELVIS W	CT, nan	IDC,TCIA	2
+CT ABD W/O(RENAL STONE	CT, nan	IDC,TCIA	2
+CT ABD UN + EN	CT, nan	IDC,TCIA	2
+CTA HEAD NECK(Adult)	CT	MIDRC	2
+CT ABD PELBIS	CT, nan	IDC,TCIA	2
+CT ABD PEL WITH	CT, nan	IDC,TCIA	2
+CT ABD/PEL  W/WO RENAL	SEG, nan	IDC,TCIA	2
+CT ABD/PEL (LIVER PRO)	SEG, nan	IDC,TCIA	2
+CT004   CT CHEST W/O CO	CT, nan	IDC,TCIA	2
+CTA ABDOMEN WWO CONTRAST (AORTA)	CT	MIDRC	2
+CT ABD/PEL W+WO CONT	CT, nan	IDC,TCIA	2
+CT009   CT ABDOMEN W&WO	CT, nan	IDC,TCIA	2
+CT: Chest w/contrast	CT	MIDRC	2
+CTA ABD AND PELV (ENTIRE AORTA)	CT	MIDRC	2
+CTA ABDM PELVIS RENAL	CT, nan	IDC,TCIA	2
+CTA ABDOMEN PELVIS AND BILATERAL EXTREMITY	CT	MIDRC	2
+CTA Abdomen WO and W contrast	SEG, nan	IDC,TCIA	2
+CT ABD/PEL (LIVER)	SEG, nan	IDC,TCIA	2
+CTA CARDIAC MORPHOLOGY	CT	MIDRC	2
+CT ABD/PEL W CONT	SEG, nan	IDC,TCIA	2
+CT ABD/PEL RENAL	SEG, nan	IDC,TCIA	2
+CT ABD/PEL LIV	SEG, nan	IDC,TCIA	2
+CT ABD/PEL (RENAL PRO)	SEG, nan	IDC,TCIA	2
+CTA CHEST ABDOMEN PELVIS W/O & W IV CON	CT	MIDRC	2
+DR Chest PORTABLE	CR, DX	MIDRC	2
+DRO QIN	MR, nan	IDC,TCIA	2
+CONTRA RIGHT BREAST	MR, nan	IDC,TCIA	2
+GBM DSC DRO b0 3T CA pre quarter bolus Full  - TR 1sec	MR, nan	IDC,TCIA	2
+CHEST POST	SEG, nan	IDC,TCIA	2
+CHEST PE ER	CT	MIDRC	2
+Head^CT_MAXILLOFACIAL_WO (Adult)	CT	MIDRC	2
+Head^DE_CTA_HEAD (Adult)	CT	MIDRC	2
+Head^DE_CTA_NECK (Adult)	CT	MIDRC	2
+Head^HEAD_FAST (Adult)	CT	MIDRC	2
+CHEST DELAYS	SEG, nan	IDC,TCIA	2
+CHEST DECUB RGHT/LFT/BIL (RAD)-CS	CR, DX	MIDRC	2
+CHEST CT [CE,3D]	SC, nan	IDC,TCIA	2
+Head^MAXILLOFACIAL (Adult)	CT	MIDRC	2
+CHEST CT WITH CONTRAST	CT	MIDRC	2
+CHEST CT W/CONTRAST	CT, nan	IDC,TCIA	2
+Head^STEALTH_Sinuses (Adult)	CT	MIDRC	2
+CHEST CT W CONTRAST	SEG, nan	IDC,TCIA	2
+Head^head_woandwith_GR (Adult)	CT	MIDRC	2
+Head^BHeadSeq6MM (Adult)	CT, nan	IDC,TCIA	2
+Head^BHead6MM (Adult)	CT, nan	IDC,TCIA	2
+HOT SPHERES TEST	PT, nan	IDC,TCIA	2
+CHEST WITH(Adult)	CT	MIDRC	2
+GBM DSC DRO b0 3T CA pre quarter bolus three-quarter - TR 1.5sec	MR, nan	IDC,TCIA	2
+GBM DSC DRO b0 3T CA pre quarter bolus three-quarter - TR 1sec	MR, nan	IDC,TCIA	2
+GBM DSC DRO b0 3T CA pre quarter bolus three-quarter - TR 2sec	MR, nan	IDC,TCIA	2
+GI	RTSTRUCT, nan	IDC,TCIA	2
+GROIN/PELVIS	CT, nan	IDC,TCIA	2
+Group-487 Cells and 425	MR, nan	IDC,TCIA	2
+HCT CHEST ANGIO W/O & W/	CT, nan	IDC,TCIA	2
+CHEST S	CT, nan	IDC,TCIA	2
+HCT CHEST W/ CONTRAST	CT, nan	IDC,TCIA	2
+HDR PROSTATE	CT, nan	IDC,TCIA	2
+HEAD	MR, nan	IDC,TCIA	2
+CHEST W CONTRAST CT	CT	MIDRC	2
+CHEST TWO VIEWS PA AND LATERAL	CR, nan	IDC,TCIA	2
+HEPATOCELLULAR CA	CT, nan	IDC,TCIA	2
+Hip R	CR	MIDRC	2
+CHEST CT  W/O CONTRAST	CT, nan	IDC,TCIA	2
+IC CT ABD PELV W CONT	CT, nan	IDC,TCIA	2
+JB	RTSTRUCT, nan	IDC,TCIA	2
+Info Sheet	CT, nan	IDC,TCIA	2
+J.B+MM	RTSTRUCT, nan	IDC,TCIA	2
+J.BRZUSZ.	CT, nan	IDC,TCIA	2
+J.BRZUSZNA	RTSTRUCT, nan	IDC,TCIA	2
+JAMA BRZUSZNA	RTSTRUCT, nan	IDC,TCIA	2
+JAMBE^Reso-Concorde	RTSTRUCT, nan	IDC,TCIA	2
+JCCI CT CHEST HRCT	CT	MIDRC	2
+CHEST 2V PA + LAT	CR, nan	IDC,TCIA	2
+JCCI CT CHEST PE	CT	MIDRC	2
+CHEST (THORAX) WITH CONTRAST-CT	CT, nan	IDC,TCIA	2
+CH/ABD/PEL-RENAL 3D	SEG, nan	IDC,TCIA	2
+CH/ABD/PEL-RENAL	SEG, nan	IDC,TCIA	2
+CH-AB W/WO	SEG, nan	IDC,TCIA	2
+CH W CAT THORAX W/C 71260	CT, nan	IDC,TCIA	2
+Implant Screening - Conventional	MG, nan	IDC,TCIA	2
+CHEST ABD LIVER PROTOC	CT, nan	IDC,TCIA	2
+IC MRI ABD WO+W CON	MR, nan	IDC,TCIA	2
+IRM EXTRU+00C9MITU+00C9S SANS & AVEC INFUSION	MR, nan	IDC,TCIA	2
+CHEST C 65ML OPTIRAY64	CT, nan	IDC,TCIA	2
+IR BIOPSY LIVER	US, nan	IDC,TCIA	2
+IR BIOPSY LIVER NON FOCAL	US	MIDRC	2
+CHEST AP AM SERVICE ICU	DX	MIDRC	2
+IRM - CUISSE GAUCHE	MR, nan	IDC,TCIA	2
+IRM BRAS GAUCHE C-C+	MR, nan	IDC,TCIA	2
+IRM Extremites Gauche Epaule	RTSTRUCT, nan	IDC,TCIA	2
+CHEST ABDOMEN	CT, nan	IDC,TCIA	2
+IRM FEMUR GAUCHE C-/C+	RTSTRUCT, nan	IDC,TCIA	2
+IRM FEMUR/CUISSE GAUCHE C+	MR, nan	IDC,TCIA	2
+IRM FEMUR/CUISSE GAUCHE C- C+	RTSTRUCT, nan	IDC,TCIA	2
+IRM HANCHE DROITE C+	MR, nan	IDC,TCIA	2
+IRM HANCHE DROITE C- C+	MR, nan	IDC,TCIA	2
+IRM extremite gauche sans et avec contraste	MR, nan	IDC,TCIA	2
+GBM DSC DRO b0 3T CA pre quarter bolus Full  - TR 2sec	MR, nan	IDC,TCIA	2
+GBM DSC DRO b0 3T CA pre quarter bolus Full  - TR 1.5sec	MR, nan	IDC,TCIA	2
+DX Read Outside Film(s)	SEG, nan	IDC,TCIA	2
+GBM DSC DRO b0 3T CA pre none bolus full - TR 2sec	MR, nan	IDC,TCIA	2
+CHEST172	CT, nan	IDC,TCIA	2
+FDG 5AFOV Lung	PT, nan	IDC,TCIA	2
+FDG 5AFOV SWEEP	PT, nan	IDC,TCIA	2
+FDG 5AFOV TORSO BU	PT, nan	IDC,TCIA	2
+FDG 5AFOV UPPER LUNG	PT, nan	IDC,TCIA	2
+FDG 5FOV TORSO	SEG, nan	IDC,TCIA	2
+FDG 6AFOV TORSO	SEG, nan	IDC,TCIA	2
+FDG 7 AFOV TORSO	SEG, nan	IDC,TCIA	2
+FDG BRIAIN	CT, nan	IDC,TCIA	2
+FDG/F18 PET/CT BONE SCAN	SEG, nan	IDC,TCIA	2
+CHEST/ABDOMEN	SEG, nan	IDC,TCIA	2
+CHEST/ABD/PEL (LIVER)	SEG, nan	IDC,TCIA	2
+CHEST/ABD-PEL W/WO IP	CT	MIDRC	2
+CHEST/ABD-PEL IV IP	CT	MIDRC	2
+FOOT LEFT 3 VIEWS (WEIGHT BEARING)	CR	MIDRC	2
+FDG 5AFOV CHEST	PT, nan	IDC,TCIA	2
+FDG 2AFOV PELVIS W/CAT	CT, nan	IDC,TCIA	2
+FDG 10 AFOV WB	PT, nan	IDC,TCIA	2
+CNHDWO	CT	MIDRC	2
+CONTRA HIGH RISK	MR, nan	IDC,TCIA	2
+CONTRA BREAST(LEFT)	MR, nan	IDC,TCIA	2
+COLONOGRAPHY	CT, nan	IDC,TCIA	2
+Digital Left Mammogram Diagnostic	MG, nan	IDC,TCIA	2
+Digital Spot Compression: 9286464	MG, nan	IDC,TCIA	2
+Dual Energy^DE_PE_SIEMENS (Adult)	SEG, nan	IDC,TCIA	2
+ECAT PET Study	PT, nan	IDC,TCIA	2
+CHST2	CR, nan	IDC,TCIA	2
+CLINICAL^BODY	MR, nan	IDC,TCIA	2
+ECT008   CT ABDOMEN W CO	CT, nan	IDC,TCIA	2
+ECT008/IV   CT ABDOMEN W CO	CT, nan	IDC,TCIA	2
+EVT	CT, nan	IDC,TCIA	2
+Echocardiogram 2D Complete	US	MIDRC	2
+CL	CT, nan	IDC,TCIA	2
+CHEST/ABD W/C	SEG, nan	IDC,TCIA	2
+CHEST/ABD	SEG, nan	IDC,TCIA	2
+FOREARM RIGHT 2 VIEWS	CR, DX	MIDRC	2
+GBM DSC DRO b0 3T CA pre Full bolus Full  - TR 1.5sec	MR, nan	IDC,TCIA	2
+GBM DSC DRO b0 1.5T CA pre quarter bolus Full  - TR 1.5sec	MR, nan	IDC,TCIA	2
+GBM DSC DRO b0 1.5T CA pre quarter bolus Full  - TR 1sec	MR, nan	IDC,TCIA	2
+GBM DSC DRO b0 1.5T CA pre quarter bolus Full  - TR 2sec	MR, nan	IDC,TCIA	2
+GBM DSC DRO b0 1.5T CA pre quarter bolus three-quarter - TR 1.5s	MR, nan	IDC,TCIA	2
+GBM DSC DRO b0 1.5T CA pre quarter bolus three-quarter - TR 1sec	MR, nan	IDC,TCIA	2
+GBM DSC DRO b0 1.5T CA pre quarter bolus three-quarter - TR 2sec	MR, nan	IDC,TCIA	2
+GBM DSC DRO b0 3T CA pre Full bolus Full  - TR 1sec	MR, nan	IDC,TCIA	2
+GBM DSC DRO b0 1.5T CA pre none bolus full - TR 1sec	MR, nan	IDC,TCIA	2
+GBM DSC DRO b0 3T CA pre Full bolus Full  - TR 2sec	MR, nan	IDC,TCIA	2
+GBM DSC DRO b0 3T CA pre half bolus half - TR 1.5sec	MR, nan	IDC,TCIA	2
+GBM DSC DRO b0 3T CA pre half bolus half - TR 1sec	MR, nan	IDC,TCIA	2
+GBM DSC DRO b0 3T CA pre half bolus half - TR 2sec	MR, nan	IDC,TCIA	2
+GBM DSC DRO b0 3T CA pre none bolus full - TR 1.5sec	MR, nan	IDC,TCIA	2
+GBM DSC DRO b0 3T CA pre none bolus full - TR 1sec	MR, nan	IDC,TCIA	2
+GBM DSC DRO b0 1.5T CA pre none bolus full - TR 2sec	MR, nan	IDC,TCIA	2
+GBM DSC DRO b0 1.5T CA pre none bolus full - TR 1.5sec	MR, nan	IDC,TCIA	2
+FOREARM^ROUTINE	MR, nan	IDC,TCIA	2
+FORFILE MR ABDO AND/OR PEL - CD	MR, nan	IDC,TCIA	2
+CHEST,ABDOMEN,  PELVIS W CONT	CT, nan	IDC,TCIA	2
+FOREIGN CT CH/ABD/PELV - CD	CT, nan	IDC,TCIA	2
+FOREIGN CT CH/ABD/PELV - FILM	CT, nan	IDC,TCIA	2
+CHEST, TWO VIEWS	CR	MIDRC	2
+CHEST, CHEST PA	CR, nan	IDC,TCIA	2
+FORFILE CT CH/AB/PEL - CD for 8155012288	CT, nan	IDC,TCIA	2
+FORFILE MR ABDOMEN	MR, nan	IDC,TCIA	2
+GBM DSC DRO b0 1.5T CA pre half bolus half - TR 2sec	MR, nan	IDC,TCIA	2
+FR PERMANENT FILE COPY=	RTSTRUCT, nan	IDC,TCIA	2
+GBM DSC DRO b0 1.5T CA pre Full bolus Full  - TR 1.5sec	MR, nan	IDC,TCIA	2
+GBM DSC DRO b0 1.5T CA pre Full bolus Full  - TR 1sec	MR, nan	IDC,TCIA	2
+GBM DSC DRO b0 1.5T CA pre Full bolus Full  - TR 2sec	MR, nan	IDC,TCIA	2
+GBM DSC DRO b0 1.5T CA pre half bolus half - TR 1.5sec	MR, nan	IDC,TCIA	2
+GBM DSC DRO b0 1.5T CA pre half bolus half - TR 1sec	MR, nan	IDC,TCIA	2
+CT ABD/PELVIS(LIVER)	SEG, nan	IDC,TCIA	2
+CT UPPER ABD W+WO CONT	SEG, nan	IDC,TCIA	2
+CH CH.3D	CT, nan	IDC,TCIA	2
+CT Abdomen Nonenh & Enhanced-BODY	SEG, nan	IDC,TCIA	2
+CT Abdomen/Pelvis With	CT, nan	IDC,TCIA	2
+CT CHEST WO CONTRAST IP	CT	MIDRC	2
+CT CHEST WO CONTRAST OP	CT	MIDRC	2
+CT Abdomen wwo	CT, nan	IDC,TCIA	2
+CT Abdomen wo+w + Pelvis wo+w	CT, nan	IDC,TCIA	2
+CT CHEST WO IV CONTRAST LUNG CANCER SCREENING	CT	AIMI	2
+CT Abdomen without con	CT, nan	IDC,TCIA	2
+CT Abdomen with contrast	CT, nan	IDC,TCIA	2
+CT Abdomen w/o	CT, nan	IDC,TCIA	2
+CT Abdomen and Pelvis Without Contrast	RTSTRUCT, nan	IDC,TCIA	2
+CT Abdomen and Pelvis W/O Contrast	CT	MIDRC	2
+CT Abdomen W/Contrast	CT, nan	IDC,TCIA	2
+CT Abdomen Pelvis W/ Contrast	CT, nan	IDC,TCIA	2
+CT CHEST+ABD+PELVIS AUGMENT=CH	RTSTRUCT, nan	IDC,TCIA	2
+CT CHEST+ABDOMEN+PELVIS W CONTRAST	CT, nan	IDC,TCIA	2
+CT Abdomen/Pelvis w/o & w contrast	CT, nan	IDC,TCIA	2
+CT Adrenal Mass	RTSTRUCT, nan	IDC,TCIA	2
+CT CHEST WITHOUT CONTRAST (PETCT)	CT	MIDRC	2
+CT CHEST W/WO CONTRAST	CT, nan	IDC,TCIA	2
+CT CHEST W/O CONT	SEG, nan	IDC,TCIA	2
+CT Biopsy Bone Marrow	CT, nan	IDC,TCIA	2
+CT BRAIN W CONT	CT, nan	IDC,TCIA	2
+CT CHEST W/O- LOW DOSE (LUNG CANCER SCREENING)	CT	MIDRC	2
+CT CHEST W/OUT	SEG, nan	IDC,TCIA	2
+CT CHEST W/WO	CT, nan	IDC,TCIA	2
+CT BODY OUTSIDE IMAGE	CT	MIDRC	2
+CT Aspiration	CT, nan	IDC,TCIA	2
+CT CHEST WITH :	CT, nan	IDC,TCIA	2
+CT BIOPSY ST MASS	CT, nan	IDC,TCIA	2
+CT BIOPSY MUSCLE	CT, nan	IDC,TCIA	2
+CT BIOPSY LIVER	CT, nan	IDC,TCIA	2
+CT CHEST WITH CONTRAST - PE PROTOCOL	CT	MIDRC	2
+CT BIOPSY BONE DEEP/NE	CT, nan	IDC,TCIA	2
+CT CHEST, ENHANCED-CHEST	CT, nan	IDC,TCIA	2
+CT CHEST/ ABDOMEN GE	CT, nan	IDC,TCIA	2
+CT UPPER ABD W CONT	CT, nan	IDC,TCIA	2
+CT CHEST/AB/PEL (LIVER	SEG, nan	IDC,TCIA	2
+CT Abd and Pelvis wo cont	CT, nan	IDC,TCIA	2
+CT AP W/WO CONTRAST	SEG, nan	IDC,TCIA	2
+CT AP UROGRAM	CT, nan	IDC,TCIA	2
+CT AP RENAL	SEG, nan	IDC,TCIA	2
+CT AP	CT, nan	IDC,TCIA	2
+CT ANGIOGRAPHY, CHEST	SEG, nan	IDC,TCIA	2
+CT ANGIOGRAPHY PELVIS W/WO CON	CT, nan	IDC,TCIA	2
+CT CT-ANGIOGRAPHY CHEST W/WO	CT	MIDRC	2
+CT ANGIOGRAPHY CHEST WITH CONTRAST	CT	MIDRC	2
+CT CT-Thorax (W/O Contrast)	CT	MIDRC	2
+CT ANGIOGRAPHY CHEST W/WO CON	CT, nan	IDC,TCIA	2
+CT CTA CHEST W CONTRAST	CT	MIDRC	2
+CT ANGIOGRAM PULMONARY ABDOMEN AND PELVIS W CONTRAST	CT	MIDRC	2
+CT Chest +C	CT, nan	IDC,TCIA	2
+CT Chest Abd Pelvis Reference Only	SEG, nan	IDC,TCIA	2
+CT COLONGRAGHY	CT, nan	IDC,TCIA	2
+CT COLON OGRAPHY	CT, nan	IDC,TCIA	2
+CT COLOLNOGRAPHY	CT, nan	IDC,TCIA	2
+CT Abd/Pelvis w/o Cont	RTSTRUCT, nan	IDC,TCIA	2
+CT Abdomen & Pelvis	CT, nan	IDC,TCIA	2
+CT CHEST/ABD/PEL EXTERNAL IMAGING	RTSTRUCT, nan	IDC,TCIA	2
+CT Abdo UnEnhan	CT, nan	IDC,TCIA	2
+CT CHEST/ABD/PEL RENAL	SEG, nan	IDC,TCIA	2
+CT Abdo Enhan	CT, nan	IDC,TCIA	2
+CT CHEST/ABD/PELV WO CONTRAST	CT	MIDRC	2
+CT CHEST/ABD/PELVIS W/O CONTRAST	CT, nan	IDC,TCIA	2
+CT Abd/PELVIS	CT, nan	IDC,TCIA	2
+CT CHEST/ABD/[PEL W/	SEG, nan	IDC,TCIA	2
+CT CHEST/ABDOMEN	CT, nan	IDC,TCIA	2
+CT CHEST/ABDOMEN W/	CT, nan	IDC,TCIA	2
+CT Abd/Pelvis w/ Contrast	SEG, nan	IDC,TCIA	2
+CT CHEST/ABDOMEN/PELVI	CT, nan	IDC,TCIA	2
+CT CHEST/RENAL MASS	SEG, nan	IDC,TCIA	2
+CT Biopsy Liver	CT, nan	IDC,TCIA	2
+CT CHEST W/O CM	CT	MIDRC	2
+CT Biopsy Lung Procedu	SEG, nan	IDC,TCIA	2
+CT Body Outside Consultation With Formal Dictation	CT, nan	IDC,TCIA	2
+CT CH/AB W/ CONTRAST	SEG, nan	IDC,TCIA	2
+CT CH/AB W & W/O CONTRAST	CT, nan	IDC,TCIA	2
+CT CHEST ABDOMEN PELVIS W/O IV CONTRAST	RTSTRUCT, nan	IDC,TCIA	2
+CT CH-ABD-PEL (LIVER)	SEG, nan	IDC,TCIA	2
+CT CBD/PEL LIV	SEG, nan	IDC,TCIA	2
+CT CARDIAC W	CT	MIDRC	2
+CT CARDIAC CTA CORONAR	CT, nan	IDC,TCIA	2
+CT CHEST AND ABDOMEN AND PELVIS WWO CONTRAST	CT	MIDRC	2
+CT CARDIAC CONGENTIAL	CT, nan	IDC,TCIA	2
+CT CARD W/CON CORONARY ARTRY/VEIN CTA	CT	MIDRC	2
+CT CAPW	RTSTRUCT, nan	IDC,TCIA	2
+CT CAP WO/W	SEG, nan	IDC,TCIA	2
+CT CAP WITH	RTSTRUCT, nan	IDC,TCIA	2
+CT CHEST C+	CT, nan	IDC,TCIA	2
+CT CAP W/IV	CT, nan	IDC,TCIA	2
+CT CH/AB/PEL W/O	SEG, nan	IDC,TCIA	2
+CT CHEST ABDOMEN PELVIS W CONTRAST (S)	CT	MIDRC	2
+CT CH/AB/PEL-LIVER	SEG, nan	IDC,TCIA	2
+CT CH/ABD/PELVIS	SEG, nan	IDC,TCIA	2
+CT CHEST  W CON	CT, nan	IDC,TCIA	2
+CT CHEST & ABDOMEN W/C	CT, nan	IDC,TCIA	2
+CT CHE/ABD	CT, nan	IDC,TCIA	2
+CT CHE./ABD/PEL-LIVER	SEG, nan	IDC,TCIA	2
+CT CHEST ABD PEL. LIVE	SEG, nan	IDC,TCIA	2
+CT CHEST ABD PELVIS REFERENCE ONLY	CT	AIMI	2
+CT CH/ABD/PELV	CT, nan	IDC,TCIA	2
+CT CH/ABD  LIVER	SEG, nan	IDC,TCIA	2
+CT CHEST ABD W/ CONTRAST	CT, nan	IDC,TCIA	2
+CT CH/ABD/PEL  LIVER	SEG, nan	IDC,TCIA	2
+CT CHEST ABDOMEN ANGIOGRAM WITH IV CONTRAST	CT	MIDRC	2
+CT CH/ABD/PEL   LIVER	SEG, nan	IDC,TCIA	2
+CT CH/ABD/PEL	CT, nan	IDC,TCIA	2
+CT CH/ABD LIVER PROTO	SEG, nan	IDC,TCIA	2
+CT CHEST HIGH RESOLUTION WITHOUT CONTRAST	CT	MIDRC	2
+CT CAP W/CONTRAST	SEG, nan	IDC,TCIA	2
+CT CHEST N/C	CT, nan	IDC,TCIA	2
+CT C/A/ P W/O WITH	SEG, nan	IDC,TCIA	2
+CT C/A/P PRE/POST	CT, nan	IDC,TCIA	2
+CT CHEST W IV CONTRAST PULMONARY EMBOLUS	CT	MIDRC	2
+CT C/A/P LIVER PR	SEG, nan	IDC,TCIA	2
+CT C/A/P LIVER	SEG, nan	IDC,TCIA	2
+CT C/A/P  RENAL	SEG, nan	IDC,TCIA	2
+CT CHEST W+WO CONT	CT, nan	IDC,TCIA	2
+CT C/A LIVER PROT	CT, nan	IDC,TCIA	2
+CT C/A/P W-WO PE	CT, nan	IDC,TCIA	2
+CT C-A-P RENAL-3D	SEG, nan	IDC,TCIA	2
+CT CHEST W/ CON.	CT, nan	IDC,TCIA	2
+CT C Spine	CT, nan	IDC,TCIA	2
+CT Bone Marrow	CT, nan	IDC,TCIA	2
+CT CHEST W/ CONTRAST:	CT, nan	IDC,TCIA	2
+CT CHEST W/C-DESCENDAN	SEG, nan	IDC,TCIA	2
+CT CHEST W CONTRAST IP	CT	MIDRC	2
+CT C/A/P(LIVER)	SEG, nan	IDC,TCIA	2
+CT CAP W/ CONTRAST	SEG, nan	IDC,TCIA	2
+CT CAP LIVER PROT.	SEG, nan	IDC,TCIA	2
+CT CAP W/	CT, nan	IDC,TCIA	2
+CT CAP RENAL	SEG, nan	IDC,TCIA	2
+CT CHEST PE STUDY	CT	MIDRC	2
+CT CAP NO IV	CT, nan	IDC,TCIA	2
+CT CAP LYMPH	CT, nan	IDC,TCIA	2
+CT CHEST PULMONARY ANGIOGRAM	CT	MIDRC	2
+CT CAP LIVER PROT	SEG, nan	IDC,TCIA	2
+CT CHEST W ABDOMEN W/WO	CT, nan	IDC,TCIA	2
+CT CAP LIVER PR.	SEG, nan	IDC,TCIA	2
+CT CAP LIV PRO	SEG, nan	IDC,TCIA	2
+CT CHEST PULMONARY EMBOLUS PE ABDOMEN PELVIS W	CT, nan	IDC,TCIA	2
+CT CHEST R/O P	CT, nan	IDC,TCIA	2
+CT CAP LI VER	SEG, nan	IDC,TCIA	2
+CT CHEST W & ABDOMEN W	SEG, nan	IDC,TCIA	2
+CT Chest Abdomen and P	SEG, nan	IDC,TCIA	2
+CT ANGIOGRAM HEAD NECK W CONTRAST	CT	MIDRC	2
+CT Chest Thorax W Cont 71260	CT, nan	IDC,TCIA	2
+CT NECK W/ CONTRAST, CT CHEST W/ CONTRAST	CT, nan	IDC,TCIA	2
+CT ABDOMEN W CNTRST	CT, nan	IDC,TCIA	2
+CT Pelvis With Contrast	CT, nan	IDC,TCIA	2
+CT ABDOMEN W AND W/O IV CONTRAST	RTSTRUCT, nan	IDC,TCIA	2
+CT ABDOMEN W AND W/O AND CHEST/PELVIS W IV CONTRAST	RTSTRUCT, nan	IDC,TCIA	2
+CT Pelvis with contrast	CT, nan	IDC,TCIA	2
+CT RAD THERAPY EXAM ONLY	CT, nan	IDC,TCIA	2
+CT RENAL MASS W/Pelvis	CT, nan	IDC,TCIA	2
+CT RENAL MASS-CT ABDOM	RTSTRUCT, nan	IDC,TCIA	2
+CT ABDOMEN W  PELVIS W CONT	SEG, nan	IDC,TCIA	2
+CT RT UPPER EXTREMITY W/O CONTRAST	CT	MIDRC	2
+CT SINUSES WITHOUT CONTRAST	CT	MIDRC	2
+CT ST THIGH BIOPSY	CT, nan	IDC,TCIA	2
+CT Specials	CT, nan	IDC,TCIA	2
+CT Spine	CT, nan	IDC,TCIA	2
+CT T-SPINE W/O IV CONTRAST	CT	MIDRC	2
+CT PULMONARY ANGIOGRAM	CT, nan	IDC,TCIA	2
+CT PLAN	CT, nan	IDC,TCIA	2
+CT ABDOMEN W CONTRAST (PANCREAS)	CT	MIDRC	2
+CT PELVIS W CONT	CT, nan	IDC,TCIA	2
+CT ABDOMEN WITH AND WITHOUT CONTRAST	CT, nan	IDC,TCIA	2
+CT ABDOMEN WITH	CT, nan	IDC,TCIA	2
+CT Outside Images Reference only	CT, nan	IDC,TCIA	2
+CT ABDOMEN W/O (RENAL	CT, nan	IDC,TCIA	2
+CT PANCREATIC MASS CT	RTSTRUCT, nan	IDC,TCIA	2
+CT ABDOMEN W/CONTRAST	CT, nan	IDC,TCIA	2
+CT ABDOMEN W/ & W/O CONTRAST	CT, nan	IDC,TCIA	2
+CT PELVIS wo	CT, nan	IDC,TCIA	2
+CT PELVIS W IV CONTRAST	RTSTRUCT, nan	IDC,TCIA	2
+CT PELVIS W/ CONTRAST	CT, nan	IDC,TCIA	2
+CT PELVIS WITH CONTRAST	CT	MIDRC	2
+CT PELVIS WITH IV CONT	CT, nan	IDC,TCIA	2
+CT ABDOMEN W WO CONTRAST	CT, nan	IDC,TCIA	2
+CT ABDOMEN W PELVIS W	CT, nan	IDC,TCIA	2
+CT THORACIC AND LUMBAR SPINE WITHOUT IV CONTRAST	CT	MIDRC	2
+CT ABDOMEN PELVIS W/WO CONTRAST	CT, nan	IDC,TCIA	2
+CT ABDOMEN PELVIS W/O AND W	SEG, nan	IDC,TCIA	2
+CT ABDOMEN & PELVIS-BODY	CT, nan	IDC,TCIA	2
+CT THORAX/ABDOMENW/	CT, nan	IDC,TCIA	2
+CT TRAUMA CHEST ABDOMEN PELVIS W IV CONTRAST	RTSTRUCT, nan	IDC,TCIA	2
+CT ABDOMEN (LIVER)	CT, nan	IDC,TCIA	2
+CT TREATMENT P	CT, nan	IDC,TCIA	2
+CT TRUNK	CT, nan	IDC,TCIA	2
+CT ABDOMEN & PELVIS=AB	RTSTRUCT, nan	IDC,TCIA	2
+CT Thorax W/Contrast	CT, nan	IDC,TCIA	2
+CT ABDOMEN AND PELVIS W CONT	CT	MIDRC	2
+CT ABDOMEN & PELVIS W&WO IV CONTRAST	CT, nan	IDC,TCIA	2
+CT ABDOMEN & PELVIS NONENH & ENHANCED=AB	RTSTRUCT, nan	IDC,TCIA	2
+CT ABDOMEN & PELVIS NONENH & ENHANCED-BODY	SEG, nan	IDC,TCIA	2
+CT Thorax with Contras	SEG, nan	IDC,TCIA	2
+CT ABDO  FILMS	CT, nan	IDC,TCIA	2
+CT ABD/PELVIS-W	SEG, nan	IDC,TCIA	2
+CT THORAX, W	CT, nan	IDC,TCIA	2
+CT ABDOMEN AND PELVIS WO/W CONTRAST	CT	MIDRC	2
+CT THORAX  WITH CONTRAST	RTSTRUCT, nan	IDC,TCIA	2
+CT THORAX W CON	CT, nan	IDC,TCIA	2
+CT ABDOMEN PELVIS W/CO	CT, nan	IDC,TCIA	2
+CT THORAX ENHANCE	CT, nan	IDC,TCIA	2
+CT ABDOMEN PELVIS W WO IV CONTRAST	RTSTRUCT, nan	IDC,TCIA	2
+CT THORAX UNENHAN	CT, nan	IDC,TCIA	2
+CT THORAX UNENHANCED	CT, nan	IDC,TCIA	2
+CT THORAX W	CT, nan	IDC,TCIA	2
+CT ABDOMEN PELVIS W CON	CT, nan	IDC,TCIA	2
+CT ABDOMEN ENHANC	CT, nan	IDC,TCIA	2
+CT ABDOMEN PELVIS W CO	CT	MIDRC	2
+CT THORAX W/	CT, nan	IDC,TCIA	2
+CT ABDOMEN NO IV CONTRAST	CT, nan	IDC,TCIA	2
+CT ABDOMEN IV CONTRAST	CT, nan	IDC,TCIA	2
+CT ABDOMEN EXTERNAL IMAGING	RTSTRUCT, nan	IDC,TCIA	2
+CT ABDOMEN ENHANCED	CT, nan	IDC,TCIA	2
+CT ABDOMEN WITH CONTRAST	CT, nan	IDC,TCIA	2
+CT NECK W/ CONTRAST	CT, nan	IDC,TCIA	2
+CT Chest W/CST	CT, nan	IDC,TCIA	2
+CT NECK SOFT TISSUE CO	CT, nan	IDC,TCIA	2
+CT Drain	CT, nan	IDC,TCIA	2
+CT ANGIO ABD/PELVIS W RUNOFFS	SEG, nan	IDC,TCIA	2
+CT ENTEROGRAPHY	CT, nan	IDC,TCIA	2
+CT ENTEROGRAPHY WITH CONTRAST	CT	MIDRC	2
+CT ANGIO AB W/WO AND CH/PEL W/	CT, nan	IDC,TCIA	2
+CT Extremity	CT, nan	IDC,TCIA	2
+CT Extremity (R Foot)	CT, nan	IDC,TCIA	2
+CT FACE/SINUSES + NECK (H AND N CANCER) W CONTRAST*	CT	MIDRC	2
+CT FNA RT + LT LUNG	SEG, nan	IDC,TCIA	2
+CT FOREIGN IMAGES	CT, nan	IDC,TCIA	2
+CT ABDOMEN/PELVIS WITHOUT CONTRAST (PETCT)	CT	MIDRC	2
+CT GUIDED BIOPSY:  LUNG	CT, nan	IDC,TCIA	2
+CT GUIDED BIOPSY:PANCREAS	RTSTRUCT, nan	IDC,TCIA	2
+CT GUIDED NEEDLE INJ,B	CT, nan	IDC,TCIA	2
+CT GUIDED NEEDLE PLACEMENT	CT, nan	IDC,TCIA	2
+CT D.E. 3 PHASE, & CH	CT, nan	IDC,TCIA	2
+CT Colonography Screen	CT	IDC	2
+CT ChestAbd	CT, nan	IDC,TCIA	2
+CT ANGIO KIDNEY ONLY	CT, nan	IDC,TCIA	2
+CT ANGIOGRAM CHEST FOR PULMONARY HYPE	CT	MIDRC	2
+CT ANGIO THORAX	CT, nan	IDC,TCIA	2
+CT ANGIO LIVER WITH CH	SEG, nan	IDC,TCIA	2
+CT Chest w/ Contrast	SEG, nan	IDC,TCIA	2
+CT Chest w/ contrast	CT, nan	IDC,TCIA	2
+CT Chest w/o	CT, nan	IDC,TCIA	2
+CT Chest withBH	CT, nan	IDC,TCIA	2
+CT Chest/Neck	CT, nan	IDC,TCIA	2
+CT Chest without Contrast - Routine	CT	MIDRC	2
+CT ANGIO CHEST/ABDOMEN/PELVIS-BODY	CT, nan	IDC,TCIA	2
+CT ANGIO CHEST WITH AND WITHOUT CONTRAST	CT	MIDRC	2
+CT Chest-w/wo Contrast	CT, nan	IDC,TCIA	2
+CT Chest/Abdomen W/ Co	CT, nan	IDC,TCIA	2
+CT ANGIO BRAIN/NECK FOR STROKE (INC 3D POST-PROCESSING AND PERF)	CT	MIDRC	2
+CT HEAD (BRAIN LAB) WO CONTRAST POST OP	CT	MIDRC	2
+CT ABDOMEN/PELVIS WITH AND WITHOUT CONTRAST (S)	CT	MIDRC	2
+CT HEAD W CON	CT, nan	IDC,TCIA	2
+CT LOWER EXTREMITY WITH CONTRAST RIGHT	CT, nan	IDC,TCIA	2
+CT LIMITED OR LOCALIZE	SEG, nan	IDC,TCIA	2
+CT LIMITED OR LOCALIZED F/U	CT, nan	IDC,TCIA	2
+CT LIVER CAP	SEG, nan	IDC,TCIA	2
+CT LOCALIZATION WITH BIOPSY	CT, nan	IDC,TCIA	2
+CT LOW-DOSE LUNG CANCER SCREEN	CT	MIDRC	2
+CT LOWER EXTREMITY WITH CONTRAST LEFT	CT, nan	IDC,TCIA	2
+CT LT LOWER EXTREMITY WITH IV CONTRAST	CT	MIDRC	2
+CT LEVEL 1-2 SPINE THORACIC LUMBAR REFORMATS W ED TRAUMA	CT	MIDRC	2
+CT LUMBAR SPINE NERVE BLOCK MULTI LEVEL	CT	MIDRC	2
+CT LUMBAR SPINE WO IV CONTRAST	CT	MIDRC	2
+CT ABDOMEN WO+W CONTRAST	RTSTRUCT, nan	IDC,TCIA	2
+CT ABDOMEN WO CONTR	CT, nan	IDC,TCIA	2
+CT MAXILLOFACIAL WITHOUT CONTRAST	CT	MIDRC	2
+CT NECK ,THORAX	CT, nan	IDC,TCIA	2
+CT ABDOMEN WWO CONTRAST (ADRENALS)	CT	MIDRC	2
+CT LEVEL 1-2 HEAD WO ED TRAUMA	CT	MIDRC	2
+CT ABDOMEN/PELVIS WITH AND WITHOUT CONTRAST	CT	MIDRC	2
+CT HEART W CONTRAST- LEFT ATRIUM AND PULMONARY VEINS	CT	MIDRC	2
+CT ABDOMEN/PELVIS WC	CT, nan	IDC,TCIA	2
+CT HEAD WITH I	CT, nan	IDC,TCIA	2
+CT ABDOMEN/PELVIS W IV AND ORAL CONTRAST	RTSTRUCT, nan	IDC,TCIA	2
+CT ABDOMEN/PELVIS	CT, nan	IDC,TCIA	2
+CT ABDOMEN-PELVIS WITH CONTRAST	CT, nan	IDC,TCIA	2
+CT HEART W CONTRAST 3D CONGENITAL HEART DISEASE	CT	MIDRC	2
+CT ABDOMEN, W	CT, nan	IDC,TCIA	2
+CT LEVEL 1-2 CERVICAL SPINE WO ED TRAUMA	CT	MIDRC	2
+CT ABDOMEN+PELVIS WO+W CONTRAST	RTSTRUCT, nan	IDC,TCIA	2
+CT Head	CT, nan	IDC,TCIA	2
+CT ABDOMEN+PELVIS W CONTRAST	RTSTRUCT, nan	IDC,TCIA	2
+CT ABDOMEN wo Lmtd	CT, nan	IDC,TCIA	2
+CT L-SPINE W/O IV CONTRAST	CT	MIDRC	2
+CT LEFT FEMUR WITH	CT, nan	IDC,TCIA	2
+JHN CHEST PE OP	CT	MIDRC	2
+FDG5AFOV TORSO	SEG, nan	IDC,TCIA	2
+MR BREAST BIL W AND WO GAD	MR	ACRdart,IDC	2
+LT.  BREAST	MR, nan	IDC,TCIA	2
+LUNF	SEG, nan	IDC,TCIA	2
+MR PEDIATRIC RAPID BRAIN WITHOUT CONTRAST	MR	MIDRC	2
+MG Tomo Mammo Digital Screening Bilat	MG	ACRdart,IDC	2
+B CT NON-INFUSED CHEST	SEG, nan	IDC,TCIA	2
+CAP/LIVER	CT, nan	IDC,TCIA	2
+B  MRI THIGH C- LEFT	MR, nan	IDC,TCIA	2
+LT. BREAST	MR, nan	IDC,TCIA	2
+All Other Initial Soli	SEG, nan	IDC,TCIA	2
+BREST/PRONE	SEG, nan	IDC,TCIA	2
+AgilityN Treatme:Tx Plan	CT, nan	IDC,TCIA	2
+MR PELVIS WITH CONTRAST	RTSTRUCT, nan	IDC,TCIA	2
+MR PELVIS WITH INTRACAVITY COIL WITHOUT CONTRAST	MR, nan	IDC,TCIA	2
+BREAST^lesion evaluation	SEG, nan	IDC,TCIA	2
+Abdomen^UROGRAM (Adult)	CT, nan	IDC,TCIA	2
+MR Prostate	MR, nan	IDC,TCIA	2
+LT LUNG	CT	IDC	2
+LUNG BX	CT, nan	IDC,TCIA	2
+MG Screen Bilat w/Tomo/CAD Stnd Protocol	MG	ACRdart	2
+MR jamy brzusznej	RTSTRUCT, nan	IDC,TCIA	2
+MR BREAST WO/W CONT #6657	MR, SEG	IDC	2
+LUNG RESTG	SEG, nan	IDC,TCIA	2
+MBUI	MR	IDC	2
+LUNG RESTAG	SEG, nan	IDC,TCIA	2
+BRST UNI RT SCREENING MAMMO W/ TOMO	MG	ACRdart	2
+MR LT BREAST 6667	MR, nan	IDC,TCIA	2
+B MRI-LT THIGH	RTSTRUCT, nan	IDC,TCIA	2
+CAP W/CON	SEG, nan	IDC,TCIA	2
+B MRI-LT KNEE	RTSTRUCT, nan	IDC,TCIA	2
+B KNEE RT	MR, nan	IDC,TCIA	2
+MR LT BREAST WO/W CONT/6667	MR, nan	IDC,TCIA	2
+MR LUMBAR SPINE WITH AND WITHOUT CONTRAST	MR	MIDRC	2
+CAP W/WO CON	CT, nan	IDC,TCIA	2
+B MRI THIGH C+- LEFT	MR, nan	IDC,TCIA	2
+CAP WITH CONTRAST	SEG, nan	IDC,TCIA	2
+MR LUMBAR SPINE WITHOUT CONTRAST (S)	MR	MIDRC	2
+LUNG CA  ACRIN	PT, nan	IDC,TCIA	2
+LT FLANK PAIN	CT, nan	IDC,TCIA	2
+LT BRST STUDY	MR, nan	IDC,TCIA	2
+MG-POST PROCEDURE MAMMO	MG	ACRdart,IDC	2
+Abdomen^STONES (Adult)	CT, nan	IDC,TCIA	2
+LEFT   BREAST	MR, nan	IDC,TCIA	2
+BREAST^CE BREAST	MR, nan	IDC,TCIA	2
+MR - JB I PRZ. Z	RTSTRUCT, nan	IDC,TCIA	2
+L5	CT, nan	IDC,TCIA	2
+L4	CT, nan	IDC,TCIA	2
+L2	SEG, nan	IDC,TCIA	2
+L1	CT, nan	IDC,TCIA	2
+MR 6667 BREAST W/WO CONTRAST	MR, nan	IDC,TCIA	2
+LSSPINE	SEG, nan	IDC,TCIA	2
+L-SPINE^ROUTINE	MR	MIDRC	2
+BREAST^BIOPSY BREAST	MR, nan	IDC,TCIA	2
+MR SHOULDER RIGHT WO CONTRAST	MR	MIDRC	2
+MR AB ANGIO	MR, nan	IDC,TCIA	2
+CARDIAC TRIPLE RULE OUT OP	CT	MIDRC	2
+KT miednicy mniejszej - bad z kontrastem	RTSTRUCT, nan	IDC,TCIA	2
+MR TOTAL SPINE WITHOUT CONTRAST	MR	MIDRC	2
+MM US LT BREAST	US	ACRdart	2
+MR RT BREAST WO/W CONT/6667	MR, nan	IDC,TCIA	2
+BREAST^RESEARCH	MR	ACRdart	2
+MR RT BREAST WO/W CONT 6667	MR, nan	IDC,TCIA	2
+LIVER/PELVIS	SEG, nan	IDC,TCIA	2
+LIVER/C AP	SEG, nan	IDC,TCIA	2
+LIVER/C A P	SEG, nan	IDC,TCIA	2
+LIVER/C A  P	SEG, nan	IDC,TCIA	2
+LIVER//CHEST	SEG, nan	IDC,TCIA	2
+MR RECTUM (SCH)	SEG, nan	IDC,TCIA	2
+LIVER// C A P	SEG, nan	IDC,TCIA	2
+MR RENAL PROTOCOL W/O CONTRAST	MR, nan	IDC,TCIA	2
+MR RT BREAST BOLD	MR, nan	IDC,TCIA	2
+LIMITED EOVIST MRI HCC	MR	MIDRC	2
+MM Mammogram Diagnostic DDI Bilat	MG	ACRdart,IDC	2
+MR RT BREAST WO/W CONT	MR, nan	IDC,TCIA	2
+LEFT MAMMO DIGITAL DIAGNOSTIC	MG	ACRdart,IDC	2
+LEFT LUNG	RTSTRUCT, CT	IDC	2
+LEFT KNEE/FEMUR	MR, nan	IDC,TCIA	2
+LUNG SCAN QUANT PERFUSION	NM, nan	IDC,TCIA	2
+BRZUCH TRZUSTKA	RTSTRUCT, nan	IDC,TCIA	2
+MR LOWER EXTREMITY ANY JOINT WITH AND WITHOUT CONTRAST RIGHT	MR, nan	IDC,TCIA	2
+BILAT BREAT	MR, nan	IDC,TCIA	2
+MAMMO TOMOGRAM DIAGNOSTIC  RIGHT	MG	ACRdart	2
+BILAT BRST	MR, nan	IDC,TCIA	2
+MAMMO DIAGNOSTIC BREAST TOMOSYNTHESIS LEFT	MG, nan	IDC,TCIA	2
+MAMMO TOMOGRAPHY DIAGNOSTIC  RIGHT	MG	ACRdart,IDC	2
+MR Breast Bilat Implant WWO Contrast	MR	ACRdart	2
+MR CholangoPancreagram with without Contrast	RTSTRUCT, nan	IDC,TCIA	2
+MAMMO US GUIDED BREAST BX LT	MG	ACRdart,IDC	2
+MAMMO US GUIDED BREAST BX RT	MG	ACRdart,IDC	2
+MAMMAE	MR, nan	IDC,TCIA	2
+CALCIUM SCORING HI HR(Adult)	CT	MIDRC	2
+Breast Ultrasound	US	ACRdart	2
+Breast Bil tumor ax	MR, nan	IDC,TCIA	2
+MAMMO diagnostic digital left	MG, nan	IDC,TCIA	2
+Brain Tumor	MR, nan	IDC,TCIA	2
+Biopsy_Lung	DX, nan	IDC,TCIA	2
+CAMRIS^PELVIS RESEARCH	MR	ACRdart	2
+MR CERVICAL SPINE WITHOUT CONTRAST (S)	MR	MIDRC	2
+C/A/P W/WO  RENAL	SEG, nan	IDC,TCIA	2
+C/A/P POST	SEG, nan	IDC,TCIA	2
+BILAT/ATTN LEFT BREAST	MR, nan	IDC,TCIA	2
+C.3D	CT, nan	IDC,TCIA	2
+C/A/P	SEG, nan	IDC,TCIA	2
+C-SP Chest	CT, nan	IDC,TCIA	2
+MAMMO SCREENING BILATERAL	MG	ACRdart,IDC	2
+BLADDER EMPTY	CT, nan	IDC,TCIA	2
+C/A/P LIVER PROTOCOL	SEG, nan	IDC,TCIA	2
+C-J	CT, nan	IDC,TCIA	2
+BILATERAL BREAST	MR, nan	IDC,TCIA	2
+C-A-P/ LIVER PROTOCOL	SEG, nan	IDC,TCIA	2
+C-A-P NO IV CONTRAST	CT, nan	IDC,TCIA	2
+C-A-P	SEG, nan	IDC,TCIA	2
+C SPINE AND T SPINE	SEG, nan	IDC,TCIA	2
+BLADDER FULL	CT, nan	IDC,TCIA	2
+MAMMO DIAGNOSTIC W OR WO CAD RT	MG	ACRdart,IDC	2
+MAMMO DIAGNOSTIC DIGITAL RIGHT	MG, nan	IDC,TCIA	2
+MAMMO - SELF REFERRAL SCREENING TOMO	MG	ACRdart,IDC	2
+CAP -LIVER	SEG, nan	IDC,TCIA	2
+LUNGCTA	CT, nan	IDC,TCIA	2
+MR LEFT BREAST WO/W CONT 6667	MR, nan	IDC,TCIA	2
+MR JAMY BRZUSZNEJ Z KONTRASTEM	RTSTRUCT, nan	IDC,TCIA	2
+CAP LYM PRE/POST	SEG, nan	IDC,TCIA	2
+MR JB	RTSTRUCT, nan	IDC,TCIA	2
+MR KNEE LEFT WO CONTRAST	MR	MIDRC	2
+MA BREAST NEDDLE LOCALIZATION	MG, nan	IDC,TCIA	2
+Lung Ventilation Scan	NM, nan	IDC,TCIA	2
+CAP OP	CT	MIDRC	2
+CAP RENAL PRT W/WO	SEG, nan	IDC,TCIA	2
+BODY/ BREAST STUDY	SEG	IDC	2
+Lung Ca	SEG, nan	IDC,TCIA	2
+BWH CT ABDOMEN PELVIS OUTSIDE STUDY OICTAP	CT, nan	IDC,TCIA	2
+MR BREAST WO/W CONT 6667	MR, nan	IDC,TCIA	2
+Lung CA	SEG, nan	IDC,TCIA	2
+MR BREAST WO/W CONT (6667 - LT BREAST)	MR, nan	IDC,TCIA	2
+Liver CT Enhanced	CT, nan	IDC,TCIA	2
+MR BREAST WO/W CONT #6667	MR, nan	IDC,TCIA	2
+CAP LIVER W/WO	SEG, nan	IDC,TCIA	2
+MR HEART WITHOUT CONTRAST	MR	MIDRC	2
+MR HEART WITH AND WITHOUT CONTRAST	MR	MIDRC	2
+MR HEART HCM WITH AND WITHOUT CONTRAST	MR	MIDRC	2
+MAMMOGRAM RAD SCREENING TO DIAGNOSTIC UNILATERAL CONVERSION	MG	ACRdart	2
+Bilateral Screening Mammogram CAD+TOMO	MG	ACRdart	2
+Bilateral Diagnostic With Tomo	MG	ACRdart,IDC	2
+BODY/BREAST STUDY LEFT	MR, SEG	IDC	2
+MAMMOGRAM UNI/LEFT DIGITAL	MG	ACRdart,IDC	2
+MAM MAMMOGRAPHY SCREENING	MG	ACRdart,IDC	2
+MAM MAMMOGRAPHY DIAGNOSTIC WITH TOMOSYNTHESIS LEFT	MG	ACRdart,IDC	2
+MAM MAMMOGRAPHY DIAGNOSTIC WITH TOMOSYNTHESIS	MG	ACRdart,IDC	2
+BI-LATERAL BREASTS	MR, nan	IDC,TCIA	2
+BI BREAST DIAGNOSTIC LEFT WITH TOMOSYNTHESIS	MG	ACRdart,IDC	2
+BCT CHEST	CT, nan	IDC,TCIA	2
+BC009   CT ABDOMEN W&WO	CT, nan	IDC,TCIA	2
+BAR CT ABDOMEN WITH CO	CT, nan	IDC,TCIA	2
+B RT THIGH	MR, nan	IDC,TCIA	2
+B MRI-PELVIS	MR, nan	IDC,TCIA	2
+MR UPPER EXTREMITY NOT JOINT WITHOUT CONTRAST RIGHT	MR, nan	IDC,TCIA	2
+LIVER	RTSTRUCT, nan	IDC,TCIA	2
+KT KLP BEZ+CE	CT, nan	IDC,TCIA	2
+BREAST MRI BIL W WO CON	MR, nan	IDC,TCIA	2
+MR BODY RESEARC	MR, nan	IDC,TCIA	2
+KNEE	MR	MIDRC	2
+BREAST RT	MR, nan	IDC,TCIA	2
+MRI ABDOMEN EXTERNAL IMAGING	RTSTRUCT, nan	IDC,TCIA	2
+JHN OP CHEST WO	CT	MIDRC	2
+MRI ABDOMEN W/WO CONTR	MR, nan	IDC,TCIA	2
+MR BR SC HR	MR, nan	IDC,TCIA	2
+MRI ABDOMEN LIVER WWO CONTRAST	MR, nan	IDC,TCIA	2
+KNEE 2 VIEWS LEFT	CR, DX	MIDRC	2
+MR BREAST #6667 WO/W CONT	MR, nan	IDC,TCIA	2
+MR BREAST UNI E	MR	IDC	2
+KNEE 3 VIEWS LEFT	CR, DX	MIDRC	2
+MRI ABDOMEN W&W/O CONTRAST	MR, nan	IDC,TCIA	2
+MRI ABDOMEN WITH AND WITHOUT CONTRAST	RTSTRUCT, nan	IDC,TCIA	2
+BREAST WO/W CONT	MR, nan	IDC,TCIA	2
+MR BRAIN WITH AND WITHOUT CONTRAST (O)	MR	MIDRC	2
+MRI ,ABD W&W/O, CONT 74183	SEG, nan	IDC,TCIA	2
+BRAIN/SPINE	MR, nan	IDC,TCIA	2
+MRI  RT. BREAST	MR, nan	IDC,TCIA	2
+MR ABDOMEN NO CONTRAST=AB	RTSTRUCT, nan	IDC,TCIA	2
+KNEE LEFT 3 VIEWS (ROUTINE)	CR	MIDRC	2
+BREAST 1^CE BREAST	MR, nan	IDC,TCIA	2
+Abdomen^JAMA_BRZUSZNA_WIELO_FAZ (Adult)	RTSTRUCT, nan	IDC,TCIA	2
+MRI ABDOMEN W&W/O CONT	MR, nan	IDC,TCIA	2
+MRI ABDOMEN W/O AND WITH CONTRAST	MR, nan	IDC,TCIA	2
+MRI ABDOMEN  WTHOUT CONTRAST	RTSTRUCT, nan	IDC,TCIA	2
+MRI ABDOMEN	MR, nan	IDC,TCIA	2
+CERVICAL	MR, nan	IDC,TCIA	2
+JHN CT CHEST WO OP	CT	MIDRC	2
+Abdomen^Jama_Brzuszna_3_Fazy (Adult)	RTSTRUCT, nan	IDC,TCIA	2
+MRI ABD WO/W CONTRAST	RTSTRUCT, nan	IDC,TCIA	2
+JOINY CT CHEST/PELVIS WITH	CT	MIDRC	2
+Abdomen^KIDNEY_STONE (Adult)	RTSTRUCT, nan	IDC,TCIA	2
+Abdomen^JBRZUSZNA_3FAZY_OPOZNIONE (Adult)	RTSTRUCT, nan	IDC,TCIA	2
+BRAIN IMAGING (PET)	SEG, nan	IDC,TCIA	2
+K-9 BRAIN	MR, nan	IDC,TCIA	2
+Abdomen^J_BRZUSZNA_3_FAZY (Adult)	RTSTRUCT, nan	IDC,TCIA	2
+Abdomen^KLP_JB_M (Adult)	RTSTRUCT, nan	IDC,TCIA	2
+CCT- ABD [LIVER]	SEG, nan	IDC,TCIA	2
+K9 SPINE	MR, nan	IDC,TCIA	2
+K9 SRS FULL BRAIN	MR, nan	IDC,TCIA	2
+KIDNEYS	MR, nan	IDC,TCIA	2
+MRI ABDOMEN AND PELVIS WITHOUT CONTRAST	MR	MIDRC	2
+KL.P BEZ I Z CE	CT, nan	IDC,TCIA	2
+MR ANGIOGRAPHY ABDOMEN WITH CONTRAST	MR, nan	IDC,TCIA	2
+CCT, AP LIVER	SEG, nan	IDC,TCIA	2
+MR BREAST BI W/WO	MR, nan	IDC,TCIA	2
+BREAST(s) ULTRA	US	ACRdart	2
+BRAIN POST OP	MR, nan	IDC,TCIA	2
+Abdomen^JB_3FAZY_BOLUS (Adult)	RTSTRUCT, nan	IDC,TCIA	2
+BONE MINERAL DENSITY DXA AXIAL SKELETON (ROUTINE)	CR	MIDRC	2
+Abdomen^J_BRZUSZNA_3FAZY_OPOZNIONA (Adult)	RTSTRUCT, nan	IDC,TCIA	2
+MRI ANKLE W/O CONTRAST - LEFT	MR	MIDRC	2
+MRBRUR	MR	IDC	2
+MR BREAST BIL SCREENING W CONTRAST	MR	ACRdart,IDC	2
+Abdomen^RENAL_PROTOCOL (Adult)	CT, nan	IDC,TCIA	2
+BODY^ABDOMEN PELVIS	MR, nan	IDC,TCIA	2
+Abdomen^RENAL_STONE (Adult)	CT, nan	IDC,TCIA	2
+Abdomen^ROUTINE_AP_LOW_DOSE_WO__Customized (Adult)	CT	MIDRC	2
+MR prostaat 3T + ERC_mc MCAPRO3T	MR, nan	IDC,TCIA	2
+JK^Brzuch	RTSTRUCT, nan	IDC,TCIA	2
+JOICC CT CHEST	CT	MIDRC	2
+BREAST ACRIN STUDY	MR, nan	IDC,TCIA	2
+BRAIN-STEROTATIC	MR, nan	IDC,TCIA	2
+BREAST/PRONE	SEG, nan	IDC,TCIA	2
+BRAIN W/WO CONTRAST (CT)-CS	CT	MIDRC	2
+CCHST+	CT, nan	IDC,TCIA	2
+MR jamy brzusznej: wielofazowo	RTSTRUCT, nan	IDC,TCIA	2
+KT KLP +C	CT, nan	IDC,TCIA	2
+MR prostaat stadiering PCMAPS_mc MCAPCMAPS	MR, nan	IDC,TCIA	2
+JHN STNECK CAP W OP	CT	MIDRC	2
+MR BREAST BILAT/SPECIAL BILLING	MR	IDC	2
+JOINY CT C/A/P COMBO	CT	MIDRC	2
+MRI ABDOMEN WO CONT	MR, nan	IDC,TCIA	2
+MR ABDOMEN +/- CONTRAST=AB	RTSTRUCT, nan	IDC,TCIA	2
+JOINE CT CHEST	CT	MIDRC	2
+MRA HEART LEFT ATRIAL MAPPING WITH AND WITHOUT CONTRAST	MR	MIDRC	2
+MR BREAST BIL DIAG WO W CONTRAST	MR	ACRdart,IDC	2
+Abdomen^KlpBrzuchMiednica (Adult)	CT, nan	IDC,TCIA	2
+MRI ABDOMEN WITHOUT CONTRAST	MR, nan	IDC,TCIA	2
+Abdomen^PEDS__ABD_PEL_WITH (Child)	CT	MIDRC	2
+MR ABDOMEN ENHANCED & NON-BODY	MR, nan	IDC,TCIA	2
+MRA RENAL	MR, nan	IDC,TCIA	2
+MR- Cholangiografia	RTSTRUCT, nan	IDC,TCIA	2
+MRI ABDOMENI WO CONT	MR, nan	IDC,TCIA	2
+X-RAY FOREARM 2 VIEWS - RIGHT	DX	MIDRC	1
+XR LEFT RIBS 2 VIEWS UNILATERAL	CR	MIDRC	1
+BODY/LEFT BREAST	SEG	IDC	1
+BODY/BREAST STUDY/LEFT	MR	IDC	1
+X-RAY FOREARM 2 VIEWS - LEFT	DX	MIDRC	1
+CT LUMBAR PUNCTURE DIAGNOSTIC	CT	MIDRC	1
+XR LUMBAR SPINE 2-3 VIEWS (AP/LAT/SPOT)	CR	MIDRC	1
+XR LUMBAR SPINE 3 VIEWS	DX	MIDRC	1
+BODY/BREAST RESEARCH	SEG	IDC	1
+BR-Breast US_LT	US	ACRdart	1
+BR-BxBreast LUS	US	ACRdart	1
+CT LT LOWER EXTREMITY W/O CONTRAST	CT	MIDRC	1
+3611 - 6657 RT BREAST/GAD	MR	IDC	1
+MRI THIGH WITHOUT CONTRAST - RIGHT	MR	MIDRC	1
+MR BREAST BILATERAL W/ OR W/O GAD	MR	ACRdart	1
+XR LUMBAR SPINE 1 VIEW	CR	MIDRC	1
+XR LEFT THUMB	CR	MIDRC	1
+XR LEFT WRIST 1-2 VIEWS	CR	MIDRC	1
+ANGIOS^GBO	MR	MIDRC	1
+MR BREAST-RIGHT	MR	IDC	1
+MRI UROGRAM WO/W CONTRAST	MR	MIDRC	1
+CT PULMONARY EMBOLI WITH IV CONTRAST	CT	MIDRC	1
+3D TOMO HD DX BI	MG	ACRdart	1
+ANKLE 3 VIEWS RIGHT	DX	MIDRC	1
+CT PULM VEIN OP	CT	MIDRC	1
+XR LUMBAR SPINE 1 VIEW INTRAOPERATIVE	DX	MIDRC	1
+BR-BxBreast RUS	US	ACRdart	1
+XR PORT ABDOMEN COMPLETE DECUB & O*	CR	MIDRC	1
+MR BRST BI BIRAD W/WO CNTRST	MR	ACRdart	1
+XR LUMBAR SPINE WITH OBLIQUES	DX	MIDRC	1
+X-RAY ENTIRE SPINE SCOLIOSIS 1 VIEW	DX	MIDRC	1
+MRI SPINE - LUMBAR W/O CONTRAST FOLLOWED BY W CONTRAST	nan	TCIA	1
+CT RFA LUMBAR/SACRAL NERVE/JOINT 1 LEVEL	CT	MIDRC	1
+CT RT LOWER EXTREMITY WO/W IV CONTRAST	CT	MIDRC	1
+X-RAY ELBOW 2 VIEWS - LEFT	DX	MIDRC	1
+MR_Brain	nan	TCIA	1
+XR RIGHT CLAVICLE	DX	MIDRC	1
+X-RAY CLAVICLE COMPLETE - LEFT	CR	MIDRC	1
+XR RIGHT ELBOW 1-2 VIEWS	CR	MIDRC	1
+CT HEART WO IV CONTRAST CALCIUM SCORING	CT	MIDRC	1
+CT RT UPPER EXTREMITY WO/W IV CONTRAST	CT	MIDRC	1
+CT SCREENING COLONOSCOPY	CT	MIDRC	1
+CT ABDOMEN PELVIS WWO	CT	MIDRC	1
+X-RAY CHEST 1 VIEW, FRONTAL, portable	DX	MIDRC	1
+X-RAY CHEST 1 VIEW, FRONTAL, PORTABLE	DX	MIDRC	1
+XR RIGHT FEMUR 1 VIEW	CR	MIDRC	1
+XR RIGHT FEMUR MIN 2 VIEWS	CR	MIDRC	1
+MR Breast Bilateral w?	SEG	IDC	1
+CT HEART PULMONARY VEINS STRUCTURE MORPHOLOGY WITH CONTRAST	CT	MIDRC	1
+MRI SHOULDER W/ + W/O CNTRST RIGHT	MR	MIDRC	1
+X-RAY CERVICAL SPINE COMPLT INCL OBL/FLX AND/OR EXT	DX	MIDRC	1
+CT HRCT THORAX	CT	AIMI	1
+MRI SPINE - THORACIC W/O CONTRAST FOLLOWED BY W CONTRAST	nan	TCIA	1
+MRI SPINE LUMBAR WO IV CONTRAST	MR	MIDRC	1
+MR Body Development Proc	MR	ACRdart	1
+CT LEVEL 1-2 FACE WO ED TRAUMA	CT	MIDRC	1
+XR P PORT ABDOMEN COMPLETE DECUB &*	CR	MIDRC	1
+MR BRST UNI E L	SEG	IDC	1
+XR PELVIS 1 VIEW ANTEROPOSTERIOR	DX	MIDRC	1
+BR-SV	US	ACRdart	1
+CT LEVEL 1-2 ANGIOGRAPHY NECK ED TRAUMA	CT	MIDRC	1
+XR PELVIS COMPLETE MINIMUM 3 VIEWS	DX	MIDRC	1
+XR PELVIS LIMITED 1 OR 2 VIEW	DX	MIDRC	1
+ABD_PELVIS 61_100LB(Child)	CT	MIDRC	1
+XR LEFT KNEE 4+ VIEWS	DX	MIDRC	1
+CT Initial/Annual Lung Screening	CT	MIDRC	1
+X-RAY FINGER(S) MINIMUM 2 VIEWS - RIGHT	DX	MIDRC	1
+BODY/ BREAST	MR	IDC	1
+ABD^RAPID MRCP	MR	MIDRC	1
+X-RAY FACIAL BONES COMPLT MINIMUM 3 VIEWS	DX	MIDRC	1
+BRAIN LAB ENT(Adult)	CT	MIDRC	1
+BRAIN MRA 2.21^NEW BRAIN W WO	MR	MIDRC	1
+CT L-SPINE W/O CONTRAST/BONE RECON	CT	MIDRC	1
+XR RIBS BILATERAL	CR	MIDRC	1
+CT ABDOMEN WWO CONTRAST (KIDNEYS)	CT	MIDRC	1
+CT LUMBAR SPINE FACET BLOCK MULTI LEVEL	CT	MIDRC	1
+X-RAY PELVIS COMPLETE MINIMUM 3 VIEWS	DX	MIDRC	1
+BR-BX BrstCoreB	US	ACRdart	1
+XR IVP W TOMOGRAMS	CR	MIDRC	1
+XR FEET BILATERAL	DX	MIDRC	1
+ADD VIEWS-UNILATERAL DIAGNOSTIC MAMMO-RT	MG	ACRdart	1
+CT P CHEST AND UPPER ABD W	CT	MIDRC	1
+3607 MR BREAST WO/W CONT & BOLD	SEG	IDC	1
+3607 6657 RT BREAST WO/W CONT	MR	IDC	1
+XR FOREARM (RADIUS/ULNA) LEFT	DX	MIDRC	1
+BIUSGCBXUS GUIDED CORE BX	US	ACRdart	1
+XR FOREARM (RADIUS/ULNA) RIGHT	DX	MIDRC	1
+X-RAY WRIST 2 VIEWS - RIGHT	DX	MIDRC	1
+X-RAY WRIST 2 VIEWS - LEFT	DX	MIDRC	1
+X-RAY TOE(S) MINIMUM 2 VIEWS - RIGHT	CR	MIDRC	1
+CT ABDOMEN W&W/O CONT	nan	TCIA	1
+XR HAND LEFT (LIMITED: AP,LAT)	CR	MIDRC	1
+XR HAND LEFT (ROUTINE: AP LAT OBL)	DX	MIDRC	1
+CT ABDOMEN W/O CONTRAST	CT	MIDRC	1
+X-RAY TIBIA & FIBULA 2 VIEWS - LEFT	DX	MIDRC	1
+ADULT CHEST - 2 VIEWS	CR	MIDRC	1
+X-RAY THORACOLUMBAR SPINE 2 VIEWS	DX	MIDRC	1
+XR HANDS BILATERAL (1-2 VIEWS)	DX	MIDRC	1
+ADULT CHEST 2 VIEW	CR	MIDRC	1
+CT OUTSIDE ABDOMEN PELVIS W INTERPRETATION OR CONSULT	CT	MIDRC	1
+X-RAY THORACIC SPINE 3 VIEWS	DX	MIDRC	1
+CT ORBITS OPTIC NERVES WWO CONTRAST	CT	MIDRC	1
+XR ELBOW RIGHT (LIMITED: AP LAT)	DX	MIDRC	1
+ACRIN6666 / SV	US	ACRdart	1
+3607 ACRIN 6657 LT BREAST/GAD	MR	IDC	1
+3607 MR BOLD BREAST WO/W CONT	SEG	IDC	1
+XR ABDOMEN SINGLE AP VIEW	CR	MIDRC	1
+XR ABDOMEN SITZ MARKER	DX	MIDRC	1
+XR ABDOMEN SUPINE AND ERECT	DX	MIDRC	1
+XR ABDOMEN TO CHECK TUBE PLCMT	DX	MIDRC	1
+XR ABDOMEN TUBE POSITION CHECK	DX	MIDRC	1
+XR ANKLE 3+ VIEWS	CR	MIDRC	1
+XR ANKLE LEFT (ROUTINE: AP,LAT,OBL)	DX	MIDRC	1
+MR BREAST UNILAT LEFT W&WO CONT	MR	IDC	1
+XR Abdomen AP	DX	MIDRC	1
+CT ABDOMEN W/DYE	nan	TCIA	1
+XR ABDOMEN ACUTE PORTABLE	CR	MIDRC	1
+3607 LT MR BREAST WO/W CONT 6657	MR	IDC	1
+3607 MR ACRIN 6657: RIGHT BREAST WO/W CONT	MR	IDC	1
+BODY/RT BREAST	MR	IDC	1
+3607 MR BREAST RIGHT	MR	IDC	1
+XR CERVICAL SPINE 2-3 VIEWS WITH FLEXION EXTENSION NEURO	CR	MIDRC	1
+CT ABDOMEN W/O & W/DYE	nan	TCIA	1
+XR CERVICAL SPINE 6+ VIEWS	CR	MIDRC	1
+3607 MR BREAST W/WO LEFT	MR	IDC	1
+CT PELVIS W CONTRAST GIGU	CT	MIDRC	1
+MR BREAST UNIL W OR WO SCCA	MR	IDC	1
+XR CLAVICLE LEFT	DX	MIDRC	1
+XR HUMERUS LEFT	CR	MIDRC	1
+3607 6657 BREAST LEFT MR RESEARCH	MR	IDC	1
+BR Screening DBT Mammogram RT	MG	ACRdart	1
+CT ORBITS OPTIC NERVES WO CONTRAST	CT	MIDRC	1
+3607 MR LT BREAST WO/W CONT (6657)	SEG	IDC	1
+XR LEFT FINGERS	DX	MIDRC	1
+3 SITES	CT	IDC	1
+X-RAY NASAL BONES MINIMUM 3 VIEWS	DX	MIDRC	1
+3607 MR RESEARCH 6657: LEFT BREAST WO/W	MR	IDC	1
+3607 MR RIGHT BREAST W/WO CONTRAST	SEG	IDC	1
+MR BREAST WO/W CONT#6657	MR	IDC	1
+X-RAY KNEES BILATERAL AP STANDING	DX	MIDRC	1
+CT ABDOMEN WWO CHEST PELVIS W (KIDNEYS)	CT	MIDRC	1
+ACRIN 6701 MRT Prostata Follow-up	MR	ACRdart	1
+CT ABDOMEN WWO CONTRAST	CT	MIDRC	1
+MR BREAST WO/W CONT-6657	SEG	IDC	1
+CT LUMBAR SPINE WITHOUT CONTRAST (S)	CT	MIDRC	1
+3607 MRI RT BREAST WO/W CONT 6657	SEG	IDC	1
+3607 RT BREAST WO/W CONT 6657	MR	IDC	1
+3607- MR BREAST WO OR W BILAT 6657	SEG	IDC	1
+3607-6657 LT BREAST	SEG	IDC	1
+CT LUMBAR SPINE WITH CONTRAST	CT	MIDRC	1
+BODY/LEFTBREAST	SEG	IDC	1
+3608 MR #6657 BOLD BREAST WO/W CONT	SEG	IDC	1
+CT LUMBAR SPINE NERVE BLOCK 1 LEVEL	CT	MIDRC	1
+X-RAY HUMERUS MINIMUM 2 VIEWS - RIGHT	DX	MIDRC	1
+X-RAY HUMERUS MINIMUM 2 VIEWS - LEFT	DX	MIDRC	1
+XR ABDOMEN FEEDING TUBE 1 VIEW	DX	MIDRC	1
+X-RAY RIBS BILATERAL 3 VIEWS	DX	MIDRC	1
+X-RAY SACROILIAC JOINTS 3 OR MORE VIEWS	DX	MIDRC	1
+3607 - 6657 MR RIGHT BREAST	SEG	IDC	1
+CT ORBIT WITH CONTRAST	CT	MIDRC	1
+MRI/MRA BRAIN WITHOUT AND WITH CONTRAST (INCLUDE VWI)	MR	MIDRC	1
+BODY/RESEARCH STUDY	SEG	IDC	1
+3607 MR BREAST WO/W CONT 6657	SEG	IDC	1
+XR KNEES BILATERAL	DX	MIDRC	1
+XR KNEES BILATERAL STANDING (3 VIEWS)	DX	MIDRC	1
+3607 -#6657 ACRIN BOLD  RIGHT BREAST WO/W CONT	MR	IDC	1
+MR BREAST WO OR W BILAT	MR	IDC	1
+3607 - MR BREAST WO/W CONT ACRIN 6657	MR	IDC	1
+3607 - 6657 RT BREAST WO/W CONT	SEG	IDC	1
+X-RAY SPINE SINGLE VIEW SPECIFY LEVEL	DX	MIDRC	1
+CT PELVIS WITHOUT CONTRAST (S)	CT	MIDRC	1
+XR LEFT CALCANEUS 2 VIEWS	CR	MIDRC	1
+3607 - 6657 LT BREAST/GAD	MR	IDC	1
+BODY/LT BREAST STUDY	SEG	IDC	1
+3607 MR BREAST WO/W CONT/BOLD	SEG	IDC	1
+3607 - 6657 LT BREAST WO/W CONT	SEG	IDC	1
+XR LEFT ELBOW 4+ VIEWS	DX	MIDRC	1
+XR LEFT FEMUR 1 VIEW	CR	MIDRC	1
+3607 MR BREAST/GAD-BOLD	SEG	IDC	1
+BR Screening DBT Mammogram Bilat	MG	ACRdart	1
+CT PELVIS WITHOUT CONTRAST	CT	MIDRC	1
+MR Breast Left wo+w co	SEG	IDC	1
+JHN CST/PEL W/	CT	MIDRC	1
+CT HEAD WITHOUT CONTRAST	CT	MIDRC	1
+XR RIGHT HIP 1 VIEW	DX	MIDRC	1
+Abdomen^RENAL_MASS (Adult)	CT	MIDRC	1
+Abdomen^ABDOMEN_PELVIS_W (Adult)	CT	MIDRC	1
+Abdomen^ABDOMEN_PELVIS_WO (Adult)	CT	MIDRC	1
+Abdomen^ABDOMEN_PELVIS_W_WO (Adult)	CT	MIDRC	1
+CT CHEST W W/O CONTRAST	CT	MIDRC	1
+Abdomen^MARKS_CAILLATT_PROTOCOL (Adult)	CT	MIDRC	1
+CT CHEST W CONTRAST PULMONARY EMBOLISM	CT	MIDRC	1
+CT CHEST W CONTRAST OP	CT	MIDRC	1
+CT CHEST W CONT PULMONARY ARTERIES FOR PE	CT	MIDRC	1
+CT CHEST W CON OP	CT	MIDRC	1
+CT CHEST W AND WO IV CONTRAST	CT	MIDRC	1
+CT CHEST W ABDOMEN PELVIS WWO	CT	MIDRC	1
+MRI BREAST BILATERAL WO W IV CONTRAST	MR	MIDRC	1
+breast^Breast Clinical Trial	MR	ACRdart	1
+breast^DENSE BREAST RESEARCH	MR	ACRdart	1
+CT CAP IP	CT	MIDRC	1
+CT CHEST SCREENING FOR LUNG CANCER	CT	MIDRC	1
+CT CHEST SCREENING	nan	TCIA	1
+Abdomen^ABD_WITHXXL_GR (Adult)	CT	MIDRC	1
+CT CHEST RADIATION ONCOLOGY	CT	AIMI	1
+MRI - BREAST BILATERAL WITHOUT AND WITH IV CONTRAST	MR	ACRdart	1
+Abdomen^ABD_WWO_renalmass_GR (Adult)	CT	MIDRC	1
+CT CHEST PULMONARY EMBOLISM (CTPE) (S)	CT	MIDRC	1
+Abdomen^AVERAGE_CTU_OVER_60 (Adult)	nan	TCIA	1
+Abdomen^AVERAGE_PELVIS_WITHOUT_IV_CONTRAST (Adult)	nan	TCIA	1
+MRI BREAST BILATERAL ABREV. NRMC	MR	ACRdart	1
+CT CHEST OUTSIDE WITH INTERPRETATION OR CONSULT	CT	MIDRC	1
+CT CAP W TRAUMA	CT	MIDRC	1
+MRI BREAST BILATERAL ABREV.	MR	IDC	1
+Abdomen^AB02A_AP_W (Adult)	CT	MIDRC	1
+MRI BREAST UNILATERAL	nan	TCIA	1
+CT CHEST W/O & W IV CON	CT	MIDRC	1
+MR SHOULDER LEFT WO CONTRAST	MR	MIDRC	1
+MR RT BREAST WO/W CONT/6657	SEG	IDC	1
+Abdomen^13_TRAUMA_CAP (Adult)	CT	MIDRC	1
+MRI Breast w Contrast bilat BIRADS	MR	ACRdart	1
+MR Research wo w 15 minutes	MR	ACRdart	1
+Abdomen^STONE_LOW_DOSE_1 (Adult)	CT	MIDRC	1
+MR Research wo w 45 minutes	MR	ACRdart	1
+MR Research wo w 60 minutes	MR	ACRdart	1
+MR SACROILIAC JOINTS WITHOUT CONTRAST (S)	MR	MIDRC	1
+Abdomen^STONE_FULL (Adult)	CT	MIDRC	1
+MRI Breast Bil - with and without Contrast	MR	ACRdart	1
+CT CHEST WITHOUT CONTRAST WITH OR WITHOUT 2D RECON	CT	MIDRC	1
+CT Angio Abdomen and Pelvis	CT	MIDRC	1
+CT Angio Chest W+/or WO + Recon	CT	MIDRC	1
+MRI BRST ABBR	MR	ACRdart	1
+MR WHOLE BODY PEDIATRIC WITHOUT CONTRAST	MR	MIDRC	1
+MR SPINE CERVICAL WO CONTRAST	MR	MIDRC	1
+CT CHEST WITH CONTRAST (O)	CT	MIDRC	1
+MR SPINE THORACIC WO CONTRAST	MR	MIDRC	1
+CT CHEST WITH CONTR	CT	MIDRC	1
+CT CHEST WITH CONT	CT	MIDRC	1
+MRI BREAST, UNILATERAL	MR	IDC	1
+MR THORACIC SPINE WITH CONTRAST	MR	MIDRC	1
+MR THORACIC SPINE WITHOUT CONTRAST	MR	MIDRC	1
+Abdomen^ROUTINE_AP_WITH_OVER_50_OVER_250 (Adult)	CT	MIDRC	1
+MRI BREAST WITH AND W/O CONTRAST-BILATERAL	MR	ACRdart	1
+MRI BREAST W/WO CONT 6657	SEG	IDC	1
+MR TOTAL SPINE WITH AND WITHOUT CONTRAST (S)	MR	MIDRC	1
+CT BRAIN WITH AND WITHOUT CONTRAST (S)	CT	MIDRC	1
+ct chest abdomen pelvi	CT	MIDRC	1
+CT CAP W/ DYE	nan	TCIA	1
+CT CHEST LUNG CANCER SCREENING LOW DOSE W/O CM	CT	MIDRC	1
+CT CHEST ABDOMEN AND PELVIS WITHOUT IV CONTRAST	CT	MIDRC	1
+CT CERVICAL SPINE NERVE BLOCK 1 LEVEL	CT	MIDRC	1
+CT CERVICAL SPINE WITHOUT IV CONTRAST	CT	MIDRC	1
+jhn ct chest wo op	CT	MIDRC	1
+Abdomen^CT_AP_WITH_L_SPINE_MPRS (Adult)	CT	MIDRC	1
+CT CHEST ABDOMEN PELVIS W WO CONTRAST (S)	CT	MIDRC	1
+MRI ABDOMEN W/O&W/DYE	nan	TCIA	1
+Abdomen^HEMATURIA_GREATERTHAN45 (Adult)	CT	MIDRC	1
+Abdomen^CT_MARKS_CAILLAT_AP_RENAL (Adult)	CT	MIDRC	1
+Abdomen^CT_UROGRAM_STONE (Adult)	CT	MIDRC	1
+CT CHEST ABDOMEN PELVIS ANGIOGRAM WITH IV CONTRAST	CT	MIDRC	1
+MRI BRAIN, MRA BRAIN, MRA NECK - WITHOUT CONTRAST FOCUSED STROKE	MR	MIDRC	1
+MRI BRAIN, MRA BRAIN, MRA NECK - WITHOUT AND WITH CONTRAST (S)	MR	MIDRC	1
+mammogram/ultrasiund exam	US	ACRdart	1
+CT CHEST ABDOMEN AND PELVIS WITH IV CONTRAST	CT	MIDRC	1
+CT CHEST ABDOMEN W CONTRAST (PANCREAS)	CT	MIDRC	1
+Abdomen^DE_CTA_AAA (Adult)	CT	MIDRC	1
+MRI BRACHIAL PLEXUS WO/W CONTRAST - LEFT SIDE	MR	MIDRC	1
+CT CHEST ABD PELVIS W O CONTRAST	CT	MIDRC	1
+Abdomen^DE_ROUTINE_AP_WITH_UNDER_50 (Adult)	CT	MIDRC	1
+CT CHEST (PULMONARY EMBOLISM) PELVIS LOWER EXTREMITY BILATERAL (	CT	MIDRC	1
+CT CHEST (HIGH RESOLUTION) WITHOUT CONTRAST	CT	MIDRC	1
+CT CHEST (CPT=71250)	CT	MIDRC	1
+Abdomen^DUAL_PHASE_ABDOMEN (Adult)	CT	MIDRC	1
+/BD/PRO Pelvis w	nan	TCIA	1
+MRI ANKLE W/O CONTRAST - RIGHT	MR	MIDRC	1
+Abdomen^HEMATURIA_45_and_UNDER (Adult)	CT	MIDRC	1
+CT CHEST  W/O 71250	CT	MIDRC	1
+Abdomen^GH_AbdomenRoutine (Adult)	CT	MIDRC	1
+Abdomen^CT_AP_GI_BLEED_ISCHEMIC_BOWEL_WWO (Adult)	CT	MIDRC	1
+Abdomen^CT_ABDOMEN_WITH (Adult)	CT	MIDRC	1
+CT CAP W/ WT lOSS OP	CT	MIDRC	1
+e+1 CT T SPINE RECON	CT	MIDRC	1
+CT CHEST IV IP	CT	MIDRC	1
+CT CHEST HRCT NO IVCON	CT	MIDRC	1
+CT CHEST HIGH RESOLUTION (S)	CT	MIDRC	1
+e+1 CT ANGIO CHEST W	CT	MIDRC	1
+e+1 CT CHEST ABDOMEN PELVIS WITHOUT CONTRAST	CT	MIDRC	1
+e+1 CT CHEST ABDOMEN PELVIS WO	CT	MIDRC	1
+e+1 CT CHEST W	CT	MIDRC	1
+e+1 CT CHEST WITHOUT CONTRAST	CT	MIDRC	1
+e+1 CT CHEST WO	CT	MIDRC	1
+CT CAP W/DYE	nan	TCIA	1
+CT CHEST HI-RESOLUTION W/O IV CONTRAST	CT	MIDRC	1
+CT CHEST FOR NODULE	CT	MIDRC	1
+e+1 CT SOFT TISSUE NECK W CONTRAST	CT	MIDRC	1
+e+1 CTA ANGIO NECK	CT	MIDRC	1
+e+2 PET LYMPHOMA HODGKINS	PT,CT	MIDRC	1
+e+1 CTA CHEST (PE STUDY) W CONTRAST	CT	MIDRC	1
+e+1 CTA CHEST WO/W	CT	MIDRC	1
+e+1 CTA dissection	CT	MIDRC	1
+MRI BREAST BILAT WO/W?	SEG	IDC	1
+Abdomen^CTA_ABD_PEL_RUNOFF_UNDER_250LB_Customized (Adult)	CT	MIDRC	1
+MRI BREAST BILAT WO/W CONTR	MR	IDC	1
+e+1 Head	CT	MIDRC	1
+CT CAP WITH CONTRAST	CT	MIDRC	1
+CT CHEST ANGIOGRAM IMAGE IMPORT	CT	MIDRC	1
+Abdomen^CTA_RUNOFF (Adult)	CT	MIDRC	1
+e+1 ct chest abdomen pelvi	CT	MIDRC	1
+e+1 ct chest abdomen pelvis with contrast	CT	MIDRC	1
+CT CHEST ABDOMEN WO CO	CT	MIDRC	1
+CT CHEST WWO CONT	CT	MIDRC	1
+CT CHEST W_ ABDOMEN PELVIS WWO	CT	MIDRC	1
+_t4of4_MR IAMs	nan	TCIA	1
+MR FACE, NASO, NECK WITH AND WITHOUT CONTRAST (S)	MR	MIDRC	1
+MR ELASTOGRAPHY OF THE ABDOMEN WITH AND WITHOUT CONTRAST	MR	MIDRC	1
+MR ELASTOGRAPHY OF THE ABDOMEN WITHOUT CONTRAST	MR	MIDRC	1
+XR SPINE LUMBAR (LATERAL ONLY FLEX/EX)	CR	MIDRC	1
+XR SPINE LUMBAR (LATERAL ONLY)	CR	MIDRC	1
+XR SPINE THORACIC (3 VIEWS - AP+LAT BENDING)	CR	MIDRC	1
+XR SPINE THORACIC (3 VIEWS)	CR	MIDRC	1
+CT EXAM SPLIT W/CON	nan	TCIA	1
+XR SPINE THORACIC (AP+LAT, SUP/UPRIGHT)	DX	MIDRC	1
+XR STERNUM 2+ VIEWS	DX	MIDRC	1
+MR FACE, NASO, NECK WITH AND WITHOUT CONTRAST	MR	MIDRC	1
+XR Spine Thoracic 2 Views	CR	MIDRC	1
+XR THIGH/FEMUR LEFT 2V	DX	MIDRC	1
+XR THIGH/FEMUR RIGHT 2V	DX	MIDRC	1
+XR THORACIC SPINE 3 VIEWS	CR	MIDRC	1
+CT FACE/SINUSES (BRAINLAB) W* CONTRAST	CT	MIDRC	1
+CT ENTEROGRAPHY DONE AT WAKE FOREST BAPTIST IMAGING	CT	MIDRC	1
+XR THORACOLUMBAR SPINE AP AND LATERAL	DX	MIDRC	1
+XR THORACOLUMBAR SPINE STANDING 2 OR 3 VIEWS	DX	MIDRC	1
+XR THUMB RIGHT	CR	MIDRC	1
+XR TOES RIGHT (SPECIFY DIGITS)	DX	MIDRC	1
+XR WRIST 3+ VIEWS	DX	MIDRC	1
+XR WRIST LEFT (LIMITED: AP,LAT)	DX	MIDRC	1
+MR FOOT (FOREFOOT) RIGHT WO CONTRAST	MR	MIDRC	1
+MR GUIDED BREAST BIOPSY	MR	ACRdart	1
+XR WRIST RIGHT (SCAPHOID VIEW)	DX	MIDRC	1
+BILAT BREAST US	US	ACRdart	1
+CT DIAGNOSTIC COLONOSCOPY	CT	MIDRC	1
+CT ANGIO ABDOMINAL ARTERIES	nan	TCIA	1
+CT ANG CHEST, ABD, PEL WWO	CT	MIDRC	1
+XR SPINE CERVICAL (LATERAL ONLY - FLEX/EX)	DX	MIDRC	1
+CT SOFT TISSUE NECK W/DYE	nan	TCIA	1
+CT ABDOMEN/PELVIS WITH CONTRAST (O)	CT	MIDRC	1
+XR RIGHT HIP 1 VIEW PORTABLE	CR	MIDRC	1
+BIOPSY BREAST-PERC NEEDLE AUTOMATED	US	ACRdart	1
+CT HEAD W/O CONT	nan	TCIA	1
+BILATERAL KNEE 3 VIEWS-CS	CR	MIDRC	1
+BILATERAL FOOT AP&LAT-CS	CR	MIDRC	1
+Abdomen GU,Abdomen	CR	MIDRC	1
+BILATERAL DIAGNOSTIC PLUS TOMO	MG	ACRdart	1
+XR RIGHT KNEE 4+ VIEWS	DX	MIDRC	1
+CT HEAD	CT	MIDRC	1
+XR RIGHT RIBS 2 VIEWS UNILATERAL	DX	MIDRC	1
+MR CERVICAL SPINE WITH AND WITHOUT CONTRAST (S)	MR	MIDRC	1
+MR CERVICAL SPINE WITH CONTRAST	MR	MIDRC	1
+XR RIGHT THUMB	CR	MIDRC	1
+CT ABDOMEN/PELVIS WITHOUT CONTRAST (O)	CT	MIDRC	1
+XR SPINE CERVICAL (AP+LAT+OBLS+SWIM+ODONTOID)	CR	MIDRC	1
+CT GUIDED CHEST LUNG B	CT	MIDRC	1
+XR SACROILIAC JOINTS 3+ VIEWS	DX	MIDRC	1
+XR SCAPULA RIGHT	CR	MIDRC	1
+XR SCOLIOSIS STUDY 2 OR 3 VIEWS (NEURO INTERPRETATION)	DX	MIDRC	1
+XR SCOLIOSIS STUDY 4 OR 5 VIEWS	DX	MIDRC	1
+XR SCOLIOSIS STUDY MINIMUM OF 6 VIEWS	DX	MIDRC	1
+CT GUIDED BIOPSY LUNG MEDIASTINUM	CT	MIDRC	1
+XR SHOULDER 2+ VIEWS	CR	MIDRC	1
+XR SHOULDER LEFT (COMPLETE: IR/ER/GRASHEY/Y/AXILLARY)	CR	MIDRC	1
+XR SHOULDER LT 2 OR MORE VIEWS	DX	MIDRC	1
+XR SHOULDER RIGHT (COMPLETE: IR/ER/GRASHEY/Y/AXILLARY)	CR	MIDRC	1
+MR CONGENITAL HEART DISORDER WITH AND WITHOUT CONTRAST	MR	MIDRC	1
+XR SPINE CERVICAL (4 VIEWS - AP+LAT+FLEX/EX)*	DX	MIDRC	1
+MRI PRE&POST INF BREASTMR	MR	IDC	1
+XR_WholeBody	nan	TCIA	1
+_t4of4_MR IAM's	MR	IDC	1
+MRI GUIDED BREAST BIOPSY AUT VAC ROT RIGHT	MR	ACRdart	1
+MRI LOWER EXTREMITY JOINT W/O CONTRAST - RIGHT	MR	MIDRC	1
+MRI LOWER EXTREMITY JOINT W/O CONTRAST - LEFT	MR	MIDRC	1
+MRI LIVER WO/W CONTRAST	MR	MIDRC	1
+MRI LIVER W/O CONTRAST WITH ELASTOGRAPHY	MR	MIDRC	1
+MRI LIVER METS WITH AND WITHOUT EOVIST	MR	MIDRC	1
+MR ORBIT WITH AND WITHOUT CONTRAST	MR	MIDRC	1
+CT CODE STROKE CTA	CT	MIDRC	1
+MRI L SPINE	MR	MIDRC	1
+CT CHST/ABD/PEL W/IV CONTRAST	CT	MIDRC	1
+CT CHEST/ABDOMEN/PELVIS W/CONTRAST	CT	MIDRC	1
+MRI JNT OF LWR EXTRE W/O DYE - LEFT	nan	TCIA	1
+Adult Chest - 2 Views	DX	MIDRC	1
+MRI HAND WITHOUT CONTRAST-RIGHT	MR	MIDRC	1
+Acute Abd child	DX	MIDRC	1
+CT ANGIOGRAPHY CHEST WITH CONTRAST PULMEMB	CT	MIDRC	1
+MRI FOOT (FOREFOOT) WITHOUT CONTRAST -RIGHT	MR	MIDRC	1
+MR PROSTATE W ENDORECTAL COIL	SEG	IDC	1
+MRI ENTEROGRAPHY WO/W CONTRAST	MR	MIDRC	1
+MRI ELASTOGRAPHY	MR	MIDRC	1
+_t3of4_MR IAM's	MR	IDC	1
+_t3of4_MR IAMs	nan	TCIA	1
+CT CHEST-ABD-PELV W/O CM	CT	MIDRC	1
+CT CHEST-ABD-PELV W/ CM	CT	MIDRC	1
+Abdomen^10_STONE_STUDY (Adult)	CT	MIDRC	1
+CT CHEST, ABDOMEN, PEL	CT	MIDRC	1
+CT CHEST, ABDOMEN & PELVIS WO CONTRAST	CT	MIDRC	1
+CT CHEST, ABDOMEN & PELVIS W/ 74177,71260,Q9967	CT	MIDRC	1
+Abdomen^STONE_XXL (Adult)	CT	MIDRC	1
+MRI LOWER EXTREMITY NON JOINT WO/W IV CONTRAST - LEFT	MR	MIDRC	1
+_t1of9_MR IAMs	nan	TCIA	1
+CT ANGIO CHEST PE	CT	MIDRC	1
+_t1of4_MR IAMs	nan	TCIA	1
+CT ANGIO CHEST WITH ECG GATING	CT	MIDRC	1
+CT ANGIO CHEST/ABD/PELVIS	CT	MIDRC	1
+CT ANGIO CHST/ABD/PEL W/WO CONTRAST	CT	MIDRC	1
+CT ANGIO HEAD W OR WO CONTRAST	CT	MIDRC	1
+_t1of2_MR IAM's	MR	IDC	1
+_t1of2_MR IAMs	nan	TCIA	1
+MRI PELVIS SOFT TISSUE W/O CONTRAST	MR	MIDRC	1
+MRI OF THE ABDOMEN WITH AND WITHOUT CONTRAST	nan	TCIA	1
+CT ANGIO NECK	CT	MIDRC	1
+MRI OF LUMBAR SPINE WITHOUT CONTRAST	nan	TCIA	1
+CT Chest WO	CT	MIDRC	1
+CT ANGIOGRAM CHEST W CONTRAST	CT	MIDRC	1
+_t1of4_MR IAM's	MR	IDC	1
+MRI NECK SPINE W/O DYE	nan	TCIA	1
+_t1of9_MR IAM's	MR	IDC	1
+CT ANGIOGRAM CHEST W W	CT	MIDRC	1
+_t1of5_MR IAM's	MR	IDC	1
+_t1of5_MR IAMs	nan	TCIA	1
+CT ANGIOGRAM CHEST [CH]	CT	MIDRC	1
+CT Chest W	CT	MIDRC	1
+MRI MSK CHEST WALL WO/W CONTRAST	MR	MIDRC	1
+_t1of6_MR IAM's	MR	IDC	1
+_t1of6_MR IAMs	nan	TCIA	1
+CT ANGIOGRAM LOWER EXTREMITY RIGHT W WO CONTRAST	CT	MIDRC	1
+MRI LUMBAR SPINE W/O DYE	nan	TCIA	1
+MR LUMBAR SPINE WITH AND WITHOUT CONTRAST (S)	MR	MIDRC	1
+MR LUMBAR SPINE WITH CONTRAST	MR	MIDRC	1
+CT CT-Abdomen/Pelvis W/Contrast	CT	MIDRC	1
+CT ANGIO AORTA RUNOFF	CT	MIDRC	1
+NM TC-HIDA SCAN	NM	MIDRC	1
+CT SPINE LUMBAR WOUT CON	CT	MIDRC	1
+LT Foot	CR	MIDRC	1
+Skull, Sinus & Facial,Nasal & Orbits	CR	MIDRC	1
+CARDIAC MICS OP	CT	MIDRC	1
+LEFT US BREAST LIMITED	US	ACRdart	1
+CARDIAC IP	CT	MIDRC	1
+LEFT WRIST-ROUTINE STUDY-CS	CR	MIDRC	1
+Specials^BX_PROCEDURE (Adult)	CT	MIDRC	1
+Specials^OVER_220_LBS_CHEST_LOW_DOSE (Adult)	nan	TCIA	1
+Specials^Perfusion (Adult)	CT	MIDRC	1
+Spine^CT_LUMBAR_SPINE_WO (Adult)	CT	MIDRC	1
+Spine^C_Spine_Tin_Filter (Adult)	CT	MIDRC	1
+LOW DOSE LUNG CA SCRN 71271-CS	CT	MIDRC	1
+LOWER EXTREMITY^KNEE	MR	MIDRC	1
+LT APEX	CT	IDC	1
+Sup MSK	US	ACRdart	1
+LT LUNG/MEDIASTINUM	RTSTRUCT	IDC	1
+Siemens AP	nan	TCIA	1
+GASTROGRAFIN SINGLE CONTRAST ENEMA	RF	MIDRC	1
+T0 - US	US	ACRdart	1
+GASTROGRAFIN CHALLENGE, ABDOMEN 1V, INITIAL	DX	MIDRC	1
+T0 6 MO F/U	US	ACRdart	1
+T0 ultrasound	US	ACRdart	1
+T1 -  F/U 1	US	ACRdart	1
+T1 - 1 YR F/U	US	ACRdart	1
+T1 - F/U 1 ultrasound	US	ACRdart	1
+T1 - F/U1- ULTRASOUND	US	ACRdart	1
+T1 - F/U1-additional images	US	ACRdart	1
+CHEST X-RAY	DX	MIDRC	1
+T1 1 YR F/U	US	ACRdart	1
+T1 ultrasound	US	ACRdart	1
+Foot RT	DX	MIDRC	1
+Siemens PVP	nan	TCIA	1
+Shoulder L	CR	MIDRC	1
+Femur / Joints L	CR	MIDRC	1
+CHEST VENOGRAM IP	CT	MIDRC	1
+CHEST PLAIN OP	CT	MIDRC	1
+CHEST PORT LINE TUBE PLCT 1 EXAM	CR	MIDRC	1
+CHEST PORTABLE SINGLE VIEW	CR	MIDRC	1
+Knee - 3 Views	DX	MIDRC	1
+Knee Lt.	CR	MIDRC	1
+HUP5 PROTOCOLS^NECK	MR	IDC	1
+CHEST PULMONARY WITH	CT	MIDRC	1
+HIP RIGHT 1 VIEW	CR	MIDRC	1
+HIP LEFT MIN 2 VIEWS ORTHO (LATERAL AND AP HIP)	CR	MIDRC	1
+L MRI PRE&POST INF BREAMR	MR	IDC	1
+CARDIAC TRIPLE OP	CT	MIDRC	1
+CHEST SINGLE VIEW	DX	MIDRC	1
+CHEST SINGLE VIEW ADULT PORTABLE	DX	MIDRC	1
+L-SPINE(Adult)	CT	MIDRC	1
+L-SPINE^L-SP optimized	MR	MIDRC	1
+PETCT GENERIC (RESEARCH ONLY)	PT	MIDRC	1
+CHEST W/ OP	CT	MIDRC	1
+CHEST W/O IP	CT	MIDRC	1
+L-SpineLAT WALL	DX	MIDRC	1
+L/S SP W/OBL FLEX & EXTEN-CS	CR	MIDRC	1
+HAND RIGHT 3 VIEWS MIN	DX	MIDRC	1
+HAND 2 VIEWS LEFT	CR	MIDRC	1
+CHEST WC	CT	MIDRC	1
+CARDIAC PV OP	CT	MIDRC	1
+GD CHEST ONE VIEW	DX	MIDRC	1
+LCMC XR ABDOMEN 1 VW	CR	MIDRC	1
+CARDIAC PUL VEIN OP	CT	MIDRC	1
+Screening Breast Tomosynthesis Bil	MG	ACRdart	1
+LEFT FOOT - ROUTINE STUDY(RAD)-CS	CR	MIDRC	1
+LEFT HILUM	RTSTRUCT	IDC	1
+Foot - 2 Views	DX	MIDRC	1
+LTLUNG UP DIBH	CT	IDC	1
+Digital Diagnostic Mammogram Bilateral	nan	TCIA	1
+MRI Abdomen w/ + w/o Contrast	MR	MIDRC	1
+Lumbar spine	CR	MIDRC	1
+CHEST/PELVIS OP	CT	MIDRC	1
+TOMOSYNTHESIS MAMMO DIGITAL DIAGNOSTIC BILATERAL	MG	ACRdart	1
+TOMOSYNTHESIS MAMMO DIGITAL DIAGNOSTIC LEFT	MG	IDC	1
+TOMOSYNTHESIS MAMMO DIGITAL DIAGNOSTIC RIGHT	MG	IDC	1
+TOSHIBA MEC	nan	TCIA	1
+PET,HEAD&NECK CA INIT'	SEG	IDC	1
+PET,HEAD&NECK CA INIT	nan	TCIA	1
+CHEST; 1V	CR	MIDRC	1
+FDA  LCIT	nan	TCIA	1
+CHESTWALL	RTSTRUCT	IDC	1
+Thoracic spine	CR	MIDRC	1
+PET TUMOR IMAGING WITH GA-68 DOTATATE	PT,CT	MIDRC	1
+MA MAMMOGRAM DIAGNOSTIC BILATERAL W/TOMO	MG	ACRdart	1
+ELBOW COMPLETE LEFT MIN 3 VIEWS	DX	MIDRC	1
+TO - INITIAL  ULTRASOUND	US	ACRdart	1
+ELBOW	MR	MIDRC	1
+CAP IV ER	CT	MIDRC	1
+MAGNETIC IMAGE,LOWER EXTREMITY	nan	TCIA	1
+Thorax^01_CHEST_ROUTINE_WO (Adult)	CT	MIDRC	1
+Thorax^01_CHEST_W_HR (Adult)	CT	MIDRC	1
+PET THYROID CANCER (W/	PT,CT	MIDRC	1
+Thorax^01_LG_CHEST_lowdose_WO_screenin (Adult)	CT	MIDRC	1
+MAM BILAT DIGITAL SCREENING W/CAD	MG	ACRdart	1
+EC BILATERAL DIAGNOSTIC MAMMOGRAM WITH CAD	MG	ACRdart	1
+Duke University Medical Center	nan	TCIA	1
+PET SARCOMA (W/LOW DOSE CT)	PT,CT	MIDRC	1
+PET SARCOIDOSIS WITH N	PT,CT	MIDRC	1
+Digital Screening Mammogram Bilateral TOMO NRMC	MG	ACRdart	1
+Digital Screening Mammogram	MG	ACRdart	1
+TO INITIAL	US	ACRdart	1
+TO - INITIAL	US	ACRdart	1
+THORACIC SPINE 2 VIEWS	CR	MIDRC	1
+CAP W/WO OP	CT	MIDRC	1
+LUMBAR SACRAL SPINE MIN 4 VIEWS	CR	MIDRC	1
+THORACIC SPINE 3 VIEWS-CS	DX	MIDRC	1
+CHEST, LAT DECUB LT	CR	MIDRC	1
+LUMBOSACRAL SP W/OBL ROUTINE-CS	DX	MIDRC	1
+LUMBOSACRAL SPINE AP/LAT ONLY-CS	CR	MIDRC	1
+LUNG 4DCT	CT	IDC	1
+CAP WO IP	CT	MIDRC	1
+FOREARM LEFT 2 VIEWS	CR	MIDRC	1
+THORAX/ZXL	CT	IDC	1
+THORAX^CHEST_WO (ADULT)	CT	MIDRC	1
+TIBIA AND FIBULA LEFT 2 VIEWS	DX	MIDRC	1
+TIBIA AND FIBULA RIGHT 2 VIEWS	DX	MIDRC	1
+TIBIA AND FIBULA RT, 4 VWS OR MORE	CR	MIDRC	1
+FOOT LEFT MIN 3 VIEWS (ROUTINE)	CR	MIDRC	1
+FOOT 3+ VIEWS, LEFT	DX	MIDRC	1
+TO  - INITIAL ULTRASOUND	US	ACRdart	1
+FOOT 2 VIEWS RIGHT	DX	MIDRC	1
+FNA, WITH IMAGING GUIDANCE - CT	nan	TCIA	1
+FLUOROSCOPY CHEST W/SNIFF	RF	MIDRC	1
+CHEST/ABD-PEL 3PHASE IP	CT	MIDRC	1
+FL PYELOGRAM RETROGRADE INTRAOPERATIVE	CR	MIDRC	1
+FL KIDNEY RETROGRAD	RF	MIDRC	1
+FL HYSTEROSALPINGOGRAM	RF	MIDRC	1
+CAP W/O IP	CT	MIDRC	1
+FL ERCP CHOLANGIOGRAM PANCREATOGRAPHY	XA	MIDRC	1
+FINGER(S) LEFT 2 VIEWS MIN	DX	MIDRC	1
+FEMUR RIGHT 2 VIEWS MIN	DX	MIDRC	1
+FEMUR LEFT 2 VIEWS MIN	CR	MIDRC	1
+PET/CT (SKULL-MIDTHIGH)	nan	TCIA	1
+TO	US	ACRdart	1
+CHEST PE STUDY	CT	MIDRC	1
+Head^CT_HEAD_WO_CHEST_WO (Adult)	CT	MIDRC	1
+SV BR	US	ACRdart	1
+JCCI CAP TRIPLE	CT	MIDRC	1
+JCCI CT CHEST AND PELVIS ENHANCED	CT	MIDRC	1
+QA scan^MQA_DAILY_QA	MR	MIDRC	1
+CHEST - PA AND LAT	CR	MIDRC	1
+JCCI CT CAP WITHOUT	CT	MIDRC	1
+R MRI PRE&POST INF BREAST,UNILAT	MR	IDC	1
+CHEST /A/ P IV IP	CT	MIDRC	1
+RA Chest 1 View Frontal	CR	MIDRC	1
+CHEST 1 VIEW AP/PA	CR	MIDRC	1
+JCCI CHEST/PEL	CT	MIDRC	1
+JCCI CHEST WO	CT	MIDRC	1
+JCCI CHEST WITHOUT	CT	MIDRC	1
+JCCI CHEST WITH PE	CT	MIDRC	1
+JCCI CHEST	CT	MIDRC	1
+RENAL BIOPSY PERQ	nan	TCIA	1
+JCCI CAP ENHANCED	CT	MIDRC	1
+Private^1_CHEST_ABD_PELVIS_PET (Adult)	nan	TCIA	1
+JOICC CT CHEST W/	CT	MIDRC	1
+JOIEN C/P	CT	MIDRC	1
+JOIEN CT ABD/PEL	CT	MIDRC	1
+CHEST 1 VIEW PA	CR	MIDRC	1
+JOIEN CT CHEST - PE	CT	MIDRC	1
+RH CTA CHEST WITH CONTRAST	CT	MIDRC	1
+JOIEN CT CHEST W/O	CT	MIDRC	1
+RIBS UNILATERAL LEFT 2 VIEWS	CR	MIDRC	1
+RIBS UNILATERAL LEFT 2 VWS WITH PA CHEST	CR	MIDRC	1
+RIBS UNILATERAL RIGHT 2 VWS WITH PA CHEST	CR	MIDRC	1
+RIGHT - Unilateral Diagnostic Mammogram	MG	ACRdart	1
+IWC MAMMO+3D SCREEN	MG	ACRdart	1
+RIGHT FOOT-ROUTINE STUDY(RAD)-CS	CR	MIDRC	1
+RIGHT KNEE-ROUTINE STUDY (RAD)-CS	CR	MIDRC	1
+JCCI CT CHEST FOR PE	CT	MIDRC	1
+JHN PE CHEST IP	CT	MIDRC	1
+CHEST OP CARDIAC/PVEIN	CT	MIDRC	1
+JHN CAP IP	CT	MIDRC	1
+JHN CHEST WO IP	CT	MIDRC	1
+PV-Ven	US	ACRdart	1
+JHN CHEST WITH OP	CT	MIDRC	1
+JHN CHEST W OP	CT	MIDRC	1
+JHN CTA CHEST WITH ONLY IP	CT	MIDRC	1
+JHN IP CAP W	CT	MIDRC	1
+JHN CHEST IP	CT	MIDRC	1
+JHN CAP WITH IP	CT	MIDRC	1
+JHN IP PE W/	CT	MIDRC	1
+JHN CAP W/ OP	CT	MIDRC	1
+PelvisAP TABLE	DX	MIDRC	1
+JHN CAP W/ IP	CT	MIDRC	1
+JHN CAP W OP	CT	MIDRC	1
+JHN OP CAP COMBO	CT	MIDRC	1
+JHN CAP COMBO IV	CT	MIDRC	1
+JHN OP CTA CHEST W/W/O	CT	MIDRC	1
+JHN CAP COMBO IP	CT	MIDRC	1
+Pelvis^PELVIS_W__GR (Adult)	CT	MIDRC	1
+Pelvis^Pelvis (Adult)	CT	MIDRC	1
+Pelvis^ROUTINE_PELVIS (Adult)	CT	MIDRC	1
+JHN CAP 3D PANC AP OP	CT	MIDRC	1
+JHN A/P IP	CT	MIDRC	1
+JCCI CTA CHEST	CT	MIDRC	1
+JCCI CT TRIPLE CAP	CT	MIDRC	1
+JCCI CT PE CHEST	CT	MIDRC	1
+JHN OP CHEST W/O	CT	MIDRC	1
+JCCI CT LUNG CANCER SCREENING	CT	MIDRC	1
+JCCI CT LOW DOSE CHEST	CT	MIDRC	1
+JCCI CT CHESTW	CT	MIDRC	1
+JCCI CT CHEST W/O	CT	MIDRC	1
+IWC DIG MAM SCRN> BIL DX SAME DAY	MG	ACRdart	1
+CHEST ABD PELVIS	CT	MIDRC	1
+JOINY CT C/A/P TRIPLE	CT	MIDRC	1
+SINUSES COMPLETE MIN 3 VIEWS	CR	MIDRC	1
+CHEST CT WITHOUT CONTRAST	CT	MIDRC	1
+PET^1PETCT_150to200LBS (Adult)	nan	TCIA	1
+CCHWO	CT	MIDRC	1
+KNEE COMPLETE LEFT 4 OR MORE VIEWS	DX	MIDRC	1
+PET^1HP_PETCT_DOTATATE (Adult)	PT,CT	MIDRC	1
+SCREENING MAMMOGRAPHY	MG	ACRdart	1
+SCREENING PROGRAM MAMMO/TOMO BIL	MG	ACRdart	1
+SCREENING WITH SAME DAY DX WORK UP	MG	ACRdart	1
+Head^HEAD_C_SPINE (Adult)	CT	MIDRC	1
+SHOULDER 3 VIEWS RIGHT	CR	MIDRC	1
+SHOULDER LEFT 1 VIEW	CR	MIDRC	1
+SHOULDER RIGHT 2 VIEWS	CR	MIDRC	1
+SHOULDER RIGHT 4 VIEWS	CR	MIDRC	1
+SINUS(Adult)	CT	MIDRC	1
+Head^HEAD_CERV_COMB (Adult)	CT	MIDRC	1
+RIGHT foot	MR	MIDRC	1
+CHEST ER	CT	MIDRC	1
+SMALL BOWEL	DX	MIDRC	1
+Head^FAST_HEAD_Customized (Adult)	CT	MIDRC	1
+Head^FACIAL_BONES_WO (Adult)	CT	MIDRC	1
+CHEST FOUR VIEWS	CR	MIDRC	1
+SPINE L-SPINE	MR	MIDRC	1
+CHEST IP IV	CT	MIDRC	1
+SPINE^C SPINE	nan	TCIA	1
+Head^FACE_ORBITS_GR (Adult)	CT	MIDRC	1
+Head^DE_HEAD_WITH_Customized (Adult)	CT	MIDRC	1
+CHEST LAT	CR	MIDRC	1
+SPLIT DISSECTION GATED CTA	CT	MIDRC	1
+CHEST OP CARDIAC	CT	MIDRC	1
+KNEE^LEFT	MR	MIDRC	1
+SCRAPBOOK	US	ACRdart	1
+KNEE 2 VIEWS RIGHT	DX	MIDRC	1
+SBRT LUNG	CT	IDC	1
+SACRUM AND COCCYX MIN 2 VIEWS	CR	MIDRC	1
+CERVICAL SPINE 2-3 VIEWS	CR	MIDRC	1
+JOINY CT C/A/P WO	CT	MIDRC	1
+RM CHEST PA OR AP	DX	MIDRC	1
+RM CTA CHEST WITH CONT	CT	MIDRC	1
+JOINY CT CHES WITH	CT	MIDRC	1
+IRM FÉMUR/CUISSE GAUCHE C- C+ -MUSQ	MR	IDC	1
+RP ABDOMEN DRAINAGE	CT	MIDRC	1
+RP ABSCESS DRAINAGE	CT	MIDRC	1
+RP IR CONSULT	CT	MIDRC	1
+RP RIGHT CHEST TUBE PLACEMENT	CT	MIDRC	1
+IRM FEMUR/CUISSE GAUCHE C- C+ -MUSQ	nan	TCIA	1
+JOINY CT CHEST PE STUDY	CT	MIDRC	1
+RT BREAST ACCRIN	MR	IDC	1
+PORTABLE ABDOMEN	CR	MIDRC	1
+PORT CHEST	DX	MIDRC	1
+RT BREAST US	US	ACRdart	1
+JOINY CT CHEST W/O	CT	MIDRC	1
+77057 Screening Mamm Bilat	MG	ACRdart	1
+JOINY CT CHEST WITH	CT	MIDRC	1
+RT LOW LUNG	RTSTRUCT	IDC	1
+IR ESI SPINE CERVICAL THORACIC	CT	MIDRC	1
+PET^PETCT_DailyQC (Adult)	PT,CT	MIDRC	1
+IR CHEST TUBE PLACEMENT (ORERABLE BY	CT	MIDRC	1
+RT^RCCT_THORAX_8F_High_CONTRAST (Adult)	CT	IDC	1
+RT^RCCT_THORAX_8F_Low (Adult)	RTSTRUCT	IDC	1
+INFANT BONE SURVEY UP TO 12 MONTHS OLD	CR	MIDRC	1
+Ribs bilat	CR	MIDRC	1
+Head^TEMP_BONES_GR (Adult)	CT	MIDRC	1
+Head^TEMPORAL_BONE (Adult)	CT	MIDRC	1
+MAM DIAG LT/TOMO	MG	ACRdart	1
+MAM Digital Breast Diag Tomosynthesis	MG	ACRdart	1
+CT ABDOMEN PELVIS WO CONTRAST	CT	MIDRC	1
+US BREAST UNILATERAL	US	ACRdart	1
+ULTRASOUND T0 TARGETED IMAGES	US	ACRdart	1
+CT ABD/PEL W/ CON	nan	TCIA	1
+ULTRASOUNDS T0 INITIAL	US	ACRdart	1
+ULTRASOUNDS T0 INITIAL/6 MO. F/U	US	ACRdart	1
+ULTRSOUND	US	ACRdart	1
+ULTZ RESEARCH	US	ACRdart	1
+MM US LT BREAST BIOPSY	US	ACRdart	1
+MR 3607 RT BREAST WO/W CONT	MR	IDC	1
+ABDOMEN 2018^ABD GENERIC ABDOMEN DOT 2019	MR	MIDRC	1
+MR 6657 RT BREAST WO/W #92	SEG	IDC	1
+US ABDOMEN COMPLETE	US	MIDRC	1
+CT ABD/PEL W/CON	nan	TCIA	1
+BREAST^	MR	ACRdart	1
+Needle Biopsy Guidance (US)	US	ACRdart	1
+Neck^DE_CT_NECK (Adult)	CT	MIDRC	1
+UCLA	nan	TCIA	1
+ABDOMEN COMPLETE MIN 2 VWS	DX	MIDRC	1
+CT ABD/PEL WITH	nan	TCIA	1
+Neck^CTA_HEAD_NECK (Adult)	CT	MIDRC	1
+CT ABD/PEL WITH IV CONTRAST	CT	MIDRC	1
+NUC MED RENAL SCAN WITH PHARM INTERVENTION	NM	MIDRC	1
+US DUPLEX EXTRCRAN CAROTID ART CMPLT	US	MIDRC	1
+NUC MED MYOCARD PERF SPECT STRESS AND REST	NM,CT	MIDRC	1
+NUC MED LYMPHOSCINTIGRAPHY	NM	MIDRC	1
+NUC MED GASTRIC EMPTYING STUDY	NM	MIDRC	1
+US L-VAC BX W CLIP	US	ACRdart	1
+US LOWER EXTREMITY VENOUS DUPLEX BILATERAL	US	MIDRC	1
+CT WHOLE BODY LOW DOSE WITHOUT CONTRAST (ABDOMEN FOCUS)	CT	MIDRC	1
+MR ABD OUTSIDE IMAGING	SEG	IDC	1
+BREAST-RIGHT	MR	IDC	1
+CT-CHEST WO	CT	MIDRC	1
+BREAST^SENTINELLE FOV  PINK COIL	MR	ACRdart	1
+CT VIRTUAL COLON	CT	IDC	1
+CT ABD/PEL W IVCON	CT	MIDRC	1
+4D 3MM	nan	TCIA	1
+Thorax^ROUTINE_CONTRAST_CHEST_175lbs_andUnder (Adult)	CT	MIDRC	1
+BRST UNI LT SCREENING MAMMO W/ TOMO	MG	ACRdart	1
+MG DIAGNOSTIC MAMMO DIGITAL LEFT WCAD	MG	ACRdart	1
+MG DIGITAL DX LT	MG	ACRdart	1
+Thorax^ThoraxRoutine (Adult)	CT	MIDRC	1
+Thorax^ThoraxRoutine (Child)	CT	MIDRC	1
+Thorax^VERAN_LARGE (Adult)	CT	MIDRC	1
+MG Diagnostic Left	MG	ACRdart	1
+MG Diagnostic Mammo Digital Right w/CAD	MG	ACRdart	1
+CTA CARDIAC OP	CT	MIDRC	1
+Thorax^XL_CAP_WO_Customized (Adult)	CT	MIDRC	1
+Thorax^XL_CHEST_WITH_Customized (Adult)	CT	MIDRC	1
+Obstruction Series	DX	MIDRC	1
+Thorax^XL_CTA_CAP (Adult)	CT	MIDRC	1
+CT ABD/PEL W/	nan	TCIA	1
+CTA ABDOMEN AND PELVIS-CS	CT	MIDRC	1
+Thorax^XL_PE_ABD_PELVIS (Adult)	CT	MIDRC	1
+MG Tomosynthesis Breast Diagnostic Bilateral	MG	ACRdart	1
+CTA ABD AORTA W/BILAT LE ARTERIES	CT	MIDRC	1
+OUTSIDE FILM REVIEW_ABDOMINAL MRI	SEG	IDC	1
+CT: Chest without Cont	nan	TCIA	1
+OUTSIDE FILM REVIEW-ABDOMINAL MRI	nan	TCIA	1
+CT: CTA Chest for PE	CT	MIDRC	1
+OUT X-RAY CHEST 1 VIEW 71045	CR	MIDRC	1
+OUT X-RAY CHEST 1 VIEW	CR	MIDRC	1
+CT/CH/ABD/PEL(PANC)	nan	TCIA	1
+OUT CTA CHEST WWO CONTRAST	CT	MIDRC	1
+OUT CT CHEST WO	CT	MIDRC	1
+Tomosynthesis Breast Screening Bilateral	MG	ACRdart	1
+US SCROTUM AND CONTENTS	US	MIDRC	1
+MR ABDOMEN MRCP WITHOUT CONTRAST	MR	MIDRC	1
+MAM Digital Diagnostic Lt	MG	ACRdart	1
+Vascular^_DISSECTION_CHEST_only (Adult)	CT	MIDRC	1
+MR BRAIN WITHOUT CONTRAST RAPID (S)	MR	MIDRC	1
+Vascular^HEAD_NECK_CTA (Adult)	CT	MIDRC	1
+ABDOMEN^GSO ABDOMEN	MR	MIDRC	1
+ABDOMEN^GSO MRCP	MR	MIDRC	1
+Vascular^PE_2023 (Adult)	CT	MIDRC	1
+Mammogram Diagnostic Bilat	MG	ACRdart	1
+Vascular^POST_THORACIC_STENT (Adult)	CT	MIDRC	1
+MR BRAIN WWO CONTRAST (EPILEPSY PROTOCOL)	MR	MIDRC	1
+MR BRAIN/MR ANGIOGRAM WITH AND WITHOUT CONTRAST	MR	MIDRC	1
+Vascular^RENAL_CTA (Adult)	CT	MIDRC	1
+Mammo-Digital Diagnostic BILAT w/ Tomosynthesis	MG	ACRdart	1
+CT ABDOMEN PELVIS W CONTRAST (CIRRHOSIS)	CT	MIDRC	1
+Vascular^VASC02_CTA_AAA_W_DELAY (Adult)	CT	MIDRC	1
+Vascular^VENOUS_AbdPel_Less45 (Adult)	CT	MIDRC	1
+BREAST - LT	MR	IDC	1
+ABDOMEN^ENTEROGRAPHY 2013	MR	MIDRC	1
+Mamm Digital Addl Views Right	MG	ACRdart	1
+MSK US NONVASCULAR EXTREMITY LTD - RIGHT	US	MIDRC	1
+CT ABDOMEN PELVIS W/IVCON	CT	MIDRC	1
+ABDOMINAL^GENERIC ABD_PEL	MR	MIDRC	1
+MR_Spine	nan	TCIA	1
+CT THORACIC SPINE WITHOUT IV CONTRAST	CT	MIDRC	1
+WRIST^ROUTINE	MR	MIDRC	1
+CT THORACIC SPINE REFORMAT IMAG	CT	MIDRC	1
+Wrist 4 View	CR	MIDRC	1
+X-RAY ABDOMEN 2 VIEWS	DX	MIDRC	1
+X-RAY ABDOMEN COMPLETE W/CHEST 1 VIEW	DX	MIDRC	1
+MR_Pelvis	nan	TCIA	1
+CT T-SPINE W/O CONTRAST/BONE RECON	CT	MIDRC	1
+ABDOMINAL^LIVER	MR	MIDRC	1
+Vascular^Dissection_CHEST_CTA (Adult)	CT	MIDRC	1
+CT ABDOMEN AND PELVIS WO INFUSION - UROLOGY TX	CT	MIDRC	1
+CT ABD/PELVIS WITH CON	nan	TCIA	1
+VP SHUNT - CHEST 2V, ABD COMPLETE, SKULL < 4VWS	CR	MIDRC	1
+BREAST US	US	ACRdart	1
+ABDOMEN PELVIS MRI^MRCP	MR	MIDRC	1
+Ultrasound-Additional images	US	ACRdart	1
+University of MD	nan	TCIA	1
+CT UROGRAM W POST PROCESSING	CT	MIDRC	1
+Unknown RIS Code	CR	MIDRC	1
+MR ABDOMEN WITH AND WITHOUT CONTRAST (S)	MR	MIDRC	1
+MR ANGIOGRAM ABDOMEN WITH AND WITHOUT CONTRAST (S)	MR	MIDRC	1
+Unspecified Merge Only CR	CR	MIDRC	1
+NM REST MYOCARDIAL PERFUSION (S)	NM	MIDRC	1
+MR ANGIOGRAM BRAIN WITHOUT CONTRAST	MR	MIDRC	1
+MR ANGIOGRAM CHEST WITH AND WITHOUT CONTRAST	MR	MIDRC	1
+ABDOMEN SERIES-NO CHEST-CS	CR	MIDRC	1
+MR ARM W/O CONTRAST	nan	TCIA	1
+CT Thorax High Resolution	CT	MIDRC	1
+CT ABDOMEN AND PELVIS WO CONTRAST	CT	MIDRC	1
+MR BRAIN (BRAIN TUMOR PROTOCOL) WWO CONTRAST*	MR	MIDRC	1
+NM LUNG VENTILATION/PERFUSION SCAN (S)	NM	MIDRC	1
+BREAST BX RT PERC W/IMAGES	US	ACRdart	1
+Vascular^CODE_STROKE_CTA_WITH_PERFUSION_WS (Adult)	CT	MIDRC	1
+Vascular^CTA_ABD_PEL_GI_BLEED (Adult)	CT	MIDRC	1
+Vascular^CTA_CAP_GR (Adult)	CT	MIDRC	1
+Vascular^CTA_CHEST (Adult)	CT	MIDRC	1
+CT TRAUMA CHEST ABDOMEN PELVIS W CONTRAST	CT	MIDRC	1
+BREAST BIOPSY	US	ACRdart	1
+Vascular^CTA_HEADNECK_GR (Adult)	CT	MIDRC	1
+MR BRAIN WITHOUT CONTRAST - FOCUSED BRAIN	MR	MIDRC	1
+CT THORAX w/o	nan	TCIA	1
+CT ABDOMEN AND PELVIS RENAL STONE LOW DOSE	CT	MIDRC	1
+NIST	nan	TCIA	1
+CTA CHEST AORTA ANGIOGRAPHY W WO CONTRAST	CT	MIDRC	1
+MAMMOGram/ultrasound exam	US	ACRdart	1
+Thorax^ROUTINE_CHEST_W (Adult)	CT	MIDRC	1
+Chest PA + Lat	CR	MIDRC	1
+MAMMO 3D TOMO DIAGNOSTIC BILATERAL	MG	ACRdart	1
+Thorax^CAP_WO_W_IRIS (Adult)	CT	MIDRC	1
+Thorax^CAP_W_IRIS (Adult)	CT	MIDRC	1
+Thorax^CH2_CHEST_WITH (Adult)	CT	MIDRC	1
+CADAVER	MR	IDC	1
+ChestPA WALL	DX	MIDRC	1
+CR_WholeBody	nan	TCIA	1
+CSPINE^ROUTINE 2013	MR	MIDRC	1
+MAMMO ADD VIEWS UNI DIAGNOSTIC LT	MG	ACRdart	1
+MAMMO ADD VIEWS UNI DIAGNOSTIC RT	MG	ACRdart	1
+C/AP WO OP	CT	MIDRC	1
+Chest PE AVERAGE	CT	MIDRC	1
+Thorax^CHEST_ANGIO_PE_W (Adult)	CT	MIDRC	1
+Thorax^CHEST_BMI_30_TO_34 (Adult)	CT	MIDRC	1
+Thorax^CHEST_ILD (Adult)	CT	MIDRC	1
+CRANE 4D 3MM	CT	IDC	1
+Thorax^CHEST_LOW_DOSE_WO (Adult)	CT	MIDRC	1
+Thorax^CHEST_W (Adult)	CT	MIDRC	1
+PET ESOPHAGEAL OR GASTRIC CANCER (W/LOW DOSE CT)	PT,CT	MIDRC	1
+PET ESOPHAGEAL OR GAST	PT,CT	MIDRC	1
+PET ENDOMETRIAL OR CERVICAL CANCER (W/LOW DOSE CT)	PT,CT	MIDRC	1
+Thorax^CHEST_WITHOUT_WITH (Adult)	CT	MIDRC	1
+MAMMO DIGITAL DIAGNOSTIC BILAT WITH TOMOSYNTHESIS	MG	ACRdart	1
+MAMMO DIGITAL DIAGNOSTIC BILAT WITH TOMOSYNTHESIS_CAD	MG	IDC	1
+Chest 2 View	DX	MIDRC	1
+MAMMO DIGITAL DIAGNOSTIC LEFT	MG	ACRdart	1
+C/A/P OP TAVAR	CT	MIDRC	1
+Thorax^CHEST_W_AP_WWO (Adult)	CT	MIDRC	1
+C/A/P IP ADRENAL	CT	MIDRC	1
+C/A/P IP 3D PANC	CT	MIDRC	1
+ComboHD Unilateral Right	MG	ACRdart	1
+DCH2	CR	MIDRC	1
+MAMMOGRSM/ULTRASOUND EXAM	US	ACRdart	1
+DIGITAL DIAG MAMM RIGHT UNIL W/ TOMO	MG	ACRdart	1
+PET PANCREATIC CANCER (W/LOW DOSE CT)	PT,CT	MIDRC	1
+PET PANCREATIC CANCER	PT,CT	MIDRC	1
+DX ADULT VP SHUNT SERIES	DX	MIDRC	1
+DX ABDOMEN PORTABLE ANTERIOR POSTERIOR 1 VIEW	DX	MIDRC	1
+CAP ER TRAUMA	CT	MIDRC	1
+Thorax^1CAP_W_IRIS (Adult)	CT	MIDRC	1
+Thorax^1CHEST_W_IRIS (Adult)	CT	MIDRC	1
+DIGITAL SCREENING MAMMOGRAM BILATERAL TOMO	MG	IDC	1
+DIGITAL SCR MAMMO BILAT	MG	ACRdart	1
+CAP COMBO OP	CT	MIDRC	1
+MAM MAMMOGRAPHY UNILAT DIAG	MG	ACRdart	1
+DIGITAL MAMMOGRAM BILATERAL	nan	TCIA	1
+Thorax^1ThoraxRoutine (Adult)	CT	MIDRC	1
+CAP COMBO	CT	MIDRC	1
+DIGITAL CALL BACK DX MAMMO UNI NO CAD	MG	ACRdart	1
+CAMRIS^PELVIC RESEARCH	MR	ACRdart	1
+MAM SCREEN BILAT/TOMO	MG	ACRdart	1
+CAP 3D PANC	CT	MIDRC	1
+CAP 3D LIVER	CT	MIDRC	1
+DIG MAM SCRN> BIL DX SAME DAY	MG	IDC	1
+PET MELANOMA OR OTHER SKIN CANCER (W/LOW DOSE CT)	PT,CT	MIDRC	1
+Thorax^1_THORAX_XXL (Adult)	nan	TCIA	1
+DIG CB DX TOMO MAM UNI NC	MG	ACRdart	1
+DIG CB DX TOMO MAM UNI	MG	ACRdart	1
+DG RIBS W/ CHEST 3+V*L*	CR	MIDRC	1
+Thorax^AVERAGE_CHEST_WITHOUT_IV_CONTRAST (Adult)	nan	TCIA	1
+Thorax^AVERAGE_CTPA (Adult)	nan	TCIA	1
+Thorax^C2_CHEST_ENHANCED (Adult)	CT	MIDRC	1
+Thorax^C4A_FLASH_CTA_PE_ROUTINE (Adult)	CT	MIDRC	1
+Thorax^C4_CTA_PE (Adult)	CT	MIDRC	1
+MAMMO LEFT ADDITIONAL VW	MG	ACRdart	1
+C/A/P 3 PHASE IP	CT	MIDRC	1
+Cardiac^COR_RETRO_HR_MORE_THAN_85 (Adult)	CT	MIDRC	1
+PE/ACUTE GI IP ECMO	CT	MIDRC	1
+MAMMOGRAM DIAGNOSTIC BILATERAL W / TOMO	MG	IDC	1
+CTSTNECK CHEST ABDOMEN PELVIS W WO CONTRAST	CT	MIDRC	1
+Thorax^LARGE_CTPA (Adult)	nan	TCIA	1
+MAMMOGRAM DIAGNOSTIC LEFT W/TOMOSYNTHESIS	MG	ACRdart	1
+Thorax^LOW_DOSE_CHEST_LG (Adult)	CT	MIDRC	1
+MAMMOGRAM DIGITAL DIAGNOSTIC BILATERAL W/TOMO	MG	ACRdart	1
+MAMMOGRAM DIGITAL DIAGNOSTIC UNILATERAL W/TOMO	MG	ACRdart	1
+BX_US	US	ACRdart	1
+MAMMOGRAM/ ULTRASOUND EXAM	US	ACRdart	1
+MAMMOGRAM/@ BIOPSY	US	ACRdart	1
+CTA P PE CHEST W	CT	MIDRC	1
+Thorax^MCV_CH_AB_PL_ROUTINE (Adult)	CT	MIDRC	1
+CTA MICS IP	CT	MIDRC	1
+MAMMOGRAM/ULTRASOOUND EXAM	US	ACRdart	1
+PE/ABDPEL IV ER	CT	MIDRC	1
+Thorax^CTA_CHEST_ABD_PELVIS (Adult)	CT	MIDRC	1
+CTA CHEST(ENTIRE AORTA)	CT	MIDRC	1
+PE IP	CT	MIDRC	1
+PE CHEST(Adult)	CT	MIDRC	1
+Thorax^PEDS__PE_CHEST (Child)	CT	MIDRC	1
+BX BRST. MAMMOTOME, W /GUID	US	ACRdart	1
+Thorax^PE_CHEST_DSXXL (Adult)	CT	MIDRC	1
+Thorax^PE_DE_UNDER_200 (Adult)	CT	MIDRC	1
+PE CHEST OP	CT	MIDRC	1
+CTA CHEST W IV CONT	CT	MIDRC	1
+Thorax^Pulmonary_Angiogram (Adult)	CT	MIDRC	1
+Thorax^Pulmonary_Embolism_Study (Adult)	CT	MIDRC	1
+PE CHEST IP	CT	MIDRC	1
+MAMMOGRAM/US/BIOPSY	US	ACRdart	1
+MAMMOGRAPHY-DIAGNOSTIC-TOMO-UNILAT-RT	MG	ACRdart	1
+CT_AP_WO	CT	MIDRC	1
+CT ABD AND PELVIS W WO CONTRAS-CS	CT	MIDRC	1
+CT ABD & PELVIS W/O IV CONTRAST	nan	TCIA	1
+Thorax^ILD_BMI_Greater_than_40 (Adult)	CT	MIDRC	1
+Cardiac^COR_HR_75to85 (Adult)	CT	MIDRC	1
+Cardiac^CA_SCORING_2021 (Adult)	CT	MIDRC	1
+Cardiac^CA_SCORING_2018 (Adult)	CT	MIDRC	1
+Cardiac^CALCIUM_SCORE_ROUTINE (Adult)	CT	MIDRC	1
+Thorax^CT_CAP_WITH_T_AND_L_SPINE_MPRS (Adult)	CT	MIDRC	1
+Cardiac^ALIVE (Adult)	CT	MIDRC	1
+Thorax^CT_CA_WO (Adult)	CT	MIDRC	1
+Thorax^CT_CHEST_ANGIO_PE_W (Adult)	CT	MIDRC	1
+CXR 2 VIEW	DX	MIDRC	1
+Thorax^CT_CHEST_WO (Adult)	CT	MIDRC	1
+C-ARM FLUOROSCOPY UP TO 4 HOURS	RF	MIDRC	1
+MAMMO SCREENING DIGITAL-BILATERAL	MG	ACRdart	1
+Thorax^C_A_P_WO (Adult)	CT	MIDRC	1
+PET CT IMG ANY SITE NO	PT,CT	MIDRC	1
+Thorax^Chest_Routine_Without (Adult)	CT	MIDRC	1
+PET CT FOR SARCOIDOSIS	PT,CT	MIDRC	1
+Thorax^DE_PE_ABD_PELVIS (Adult)	CT	MIDRC	1
+MAMMO TOMOGRAPHY DIAGNOSTIC LEFT	MG	ACRdart	1
+Thorax^DE_TRAUMA_CAP_WITH_FEET_FIRST___ (Adult)	CT	MIDRC	1
+Thorax^DE_TRAUMA_CAP_WITH__INFUSION_AUTO_Customized (Adult)	CT	MIDRC	1
+Breast-Rifht	MR	IDC	1
+Thorax^FLASH_CAP_WITHOUT (Adult)	CT	MIDRC	1
+Thorax^FLASH_CAP_WITH_Customized (Adult)	CT	MIDRC	1
+Thorax^FLASH_CTA_CAP (Adult)	CT	MIDRC	1
+Breast  Right	SEG	IDC	1
+PEREZ	US	ACRdart	1
+MAMMOGRAM / @ BIOPSY	US	ACRdart	1
+MAMMOGRAM ADD'T VIEW LEFT W/TOMOSYNTHESIS	MG	ACRdart	1
+PELVIS^ROUTINE	MR	MIDRC	1
+ELBOW RIGHT MIN 3 VIEWS (ROUTINE)	CR	MIDRC	1


### PR DESCRIPTION
Per the recent request by TDP3b, this input dataframe has 1 row per unique StudyDescription, with modalities per StudyDescription listed. Also listed per StudyDescription are project_id and platform for reference.
This is different from previous input file(s) which had 1 row per unique combination of StudyDescription / Modality. 